### PR TITLE
feat: Add NixOS support with flake.nix

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ Voice Mode includes a flake.nix with all required dependencies. You can either:
 
 1. **Use the development shell** (temporary):
 ```bash
-nix develop github:licht1stein/voicemode/nixos-flake-wrapper
+nix develop github:mbailey/voicemode
 ```
 
 2. **Install system-wide** (see Installation section below)
@@ -155,6 +155,9 @@ nix develop github:licht1stein/voicemode/nixos-flake-wrapper
 # Using Claude Code (recommended)
 claude mcp add --scope user voice-mode uvx voice-mode
 
+# Using Claude Code with Nix (NixOS)
+claude mcp add voice-mode nix run github:mbailey/voicemode
+
 # Using UV
 uvx voice-mode
 
@@ -162,7 +165,7 @@ uvx voice-mode
 pip install voice-mode
 
 # Using Nix (NixOS)
-nix run github:licht1stein/voicemode/nixos-flake-wrapper
+nix run github:mbailey/voicemode
 ```
 
 ### Configuration for AI Coding Assistants
@@ -404,14 +407,14 @@ pip install -e .
 
 **1. Install with nix profile (user-wide):**
 ```bash
-nix profile install github:licht1stein/voicemode/nixos-flake-wrapper
+nix profile install github:mbailey/voicemode
 ```
 
 **2. Add to NixOS configuration (system-wide):**
 ```nix
 # In /etc/nixos/configuration.nix
 environment.systemPackages = [
-  (builtins.getFlake "github:licht1stein/voicemode/nixos-flake-wrapper").packages.${pkgs.system}.default
+  (builtins.getFlake "github:mbailey/voicemode").packages.${pkgs.system}.default
 ];
 ```
 
@@ -419,13 +422,13 @@ environment.systemPackages = [
 ```nix
 # In home-manager configuration
 home.packages = [
-  (builtins.getFlake "github:licht1stein/voicemode/nixos-flake-wrapper").packages.${pkgs.system}.default
+  (builtins.getFlake "github:mbailey/voicemode").packages.${pkgs.system}.default
 ];
 ```
 
 **4. Run without installing:**
 ```bash
-nix run github:licht1stein/voicemode/nixos-flake-wrapper
+nix run github:mbailey/voicemode
 ```
 </details>
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Natural voice conversations for AI assistants. Voice Mode brings human-like voic
 
 ## 🖥️ Compatibility
 
-**Runs on:** Linux • macOS • Windows (WSL) | **Python:** 3.10+
+**Runs on:** Linux • macOS • Windows (WSL) • NixOS | **Python:** 3.10+
 
 ## ✨ Features
 
@@ -136,6 +136,19 @@ brew install portaudio ffmpeg
 Follow the Ubuntu/Debian instructions above within WSL.
 </details>
 
+<details>
+<summary><strong>NixOS</strong></summary>
+
+Voice Mode includes a flake.nix with all required dependencies. You can either:
+
+1. **Use the development shell** (temporary):
+```bash
+nix develop github:licht1stein/voicemode/nixos-flake-wrapper
+```
+
+2. **Install system-wide** (see Installation section below)
+</details>
+
 ### Quick Install
 
 ```bash
@@ -147,6 +160,9 @@ uvx voice-mode
 
 # Using pip
 pip install voice-mode
+
+# Using Nix (NixOS)
+nix run github:licht1stein/voicemode/nixos-flake-wrapper
 ```
 
 ### Configuration for AI Coding Assistants
@@ -380,6 +396,36 @@ pipx install voice-mode
 git clone https://github.com/mbailey/voicemode.git
 cd voicemode
 pip install -e .
+```
+</details>
+
+<details>
+<summary><strong>NixOS Installation Options</strong></summary>
+
+**1. Install with nix profile (user-wide):**
+```bash
+nix profile install github:licht1stein/voicemode/nixos-flake-wrapper
+```
+
+**2. Add to NixOS configuration (system-wide):**
+```nix
+# In /etc/nixos/configuration.nix
+environment.systemPackages = [
+  (builtins.getFlake "github:licht1stein/voicemode/nixos-flake-wrapper").packages.${pkgs.system}.default
+];
+```
+
+**3. Add to home-manager:**
+```nix
+# In home-manager configuration
+home.packages = [
+  (builtins.getFlake "github:licht1stein/voicemode/nixos-flake-wrapper").packages.${pkgs.system}.default
+];
+```
+
+**4. Run without installing:**
+```bash
+nix run github:licht1stein/voicemode/nixos-flake-wrapper
 ```
 </details>
 

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,61 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1751984180,
+        "narHash": "sha256-LwWRsENAZJKUdD3SpLluwDmdXY9F45ZEgCb0X+xgOL0=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "9807714d6944a957c2e036f84b0ff8caf9930bc0",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,87 @@
+{
+  description = "Voice Mode - Natural voice conversations for AI assistants";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    flake-utils.url = "github:numtide/flake-utils";
+  };
+
+  outputs = { self, nixpkgs, flake-utils }:
+    flake-utils.lib.eachDefaultSystem (system:
+      let
+        pkgs = nixpkgs.legacyPackages.${system};
+        
+        pythonEnv = pkgs.python312.withPackages (ps: with ps; [
+          pip
+          setuptools
+          wheel
+          virtualenv
+        ]);
+        
+        # Wrapper script that uses uvx with proper LD_LIBRARY_PATH
+        voice-mode = pkgs.writeShellScriptBin "voice-mode" ''
+          export LD_LIBRARY_PATH="${pkgs.lib.makeLibraryPath [
+            pkgs.portaudio
+            pkgs.libpulseaudio
+            pkgs.alsa-lib
+            pkgs.stdenv.cc.cc.lib
+          ]}:$LD_LIBRARY_PATH"
+          
+          exec ${pkgs.uv}/bin/uvx voice-mode "$@"
+        '';
+      in
+      {
+        packages.default = voice-mode;
+        
+        devShells.default = pkgs.mkShell {
+          buildInputs = with pkgs; [
+            # Python
+            pythonEnv
+            uv
+            
+            # Audio libraries
+            portaudio
+            libpulseaudio
+            alsa-lib
+            ffmpeg
+            
+            # Development headers and tools
+            pkg-config
+            
+            # Audio tools
+            pulseaudio
+            alsa-utils
+            
+            # Additional tools
+            git
+          ];
+          
+          shellHook = ''
+            echo "Voice Mode NixOS development environment"
+            echo "Python ${pkgs.python312.version} with uv and audio dependencies"
+            
+            # Set up library paths
+            export LD_LIBRARY_PATH="${pkgs.lib.makeLibraryPath [
+              pkgs.portaudio
+              pkgs.libpulseaudio
+              pkgs.alsa-lib
+              pkgs.stdenv.cc.cc.lib
+            ]}:$LD_LIBRARY_PATH"
+            
+            # Set up pkg-config
+            export PKG_CONFIG_PATH="${pkgs.portaudio}/lib/pkgconfig:${pkgs.libpulseaudio}/lib/pkgconfig:$PKG_CONFIG_PATH"
+            
+            # Create venv if it doesn't exist
+            if [ ! -d .venv ]; then
+              echo "Creating virtual environment..."
+              uv venv
+            fi
+            
+            echo ""
+            echo "To activate the virtual environment, run: source .venv/bin/activate"
+            echo "Then install voice-mode with: uv pip install -e ."
+            echo "Or run directly with: uvx voice-mode"
+          '';
+        };
+      });
+}


### PR DESCRIPTION
## Summary

This PR adds NixOS support to Voice Mode by providing a flake.nix configuration that handles all audio dependencies and creates a system-wide installable wrapper.

## Problem

NixOS users currently encounter a "PortAudio library not found" error when trying to run Voice Mode because the required audio libraries aren't available in the Python environment.

## Solution

- Added `flake.nix` with all required audio dependencies (PortAudio, PulseAudio, ALSA, FFmpeg)
- Created a wrapper script that sets proper `LD_LIBRARY_PATH` and uses `uvx` to run voice-mode
- Updated README with comprehensive NixOS installation instructions

## Installation Options for NixOS Users

After this PR is merged, NixOS users will have multiple ways to use Voice Mode:

1. **Quick run**: `nix run github:mbailey/voicemode`
2. **With Claude Code**: `claude mcp add voice-mode nix run github:mbailey/voicemode`
3. **System-wide**: via NixOS configuration or home-manager
4. **User-wide**: `nix profile install github:mbailey/voicemode`

## Testing

Tested on NixOS 24.05 with:
- Direct execution via `nix run`
- System-wide installation
- Development shell

All methods successfully resolve the PortAudio dependency issue.

## Changes

- Added `flake.nix` with proper audio library setup
- Added `flake.lock` (generated by Nix)
- Updated README with NixOS compatibility and installation instructions