### PR TITLE
perf: add converse command for direct voice interactions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -108,3 +108,6 @@ docs/README_PROCESSED.md
 # Test files
 test_preferences.py
 testdir/
+
+# Profiling output
+*.prof

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **CLI converse command** - Direct voice conversations from the command line
+  - New `voice-mode converse` command for testing voice interactions
+  - Supports all MCP tool options (voice, speed, audio format, etc.)
+  - Continuous conversation mode with `--continuous` flag
+  - Useful for testing TTS/STT services without MCP client
+  - Full control over voice parameters and silence detection
+  
+### Changed
+- **Gitignore update** - Added `*.prof` files to gitignore for profiling output
+
 ## [2.25.1] - 2025-08-18
 
 ### Fixed


### PR DESCRIPTION
## Summary
- Added `voice-mode converse` command for direct voice interactions
- Bypasses MCP server and tool protocol for performance testing
- Enables profiling of voice conversation performance

## Changes
- New CLI command: `voice-mode converse` with message and optional flags
- Direct integration with voice conversation functions
- Support for all voice conversation parameters (TTS provider, voice, listen duration, etc.)
- Added `.prof` files to gitignore

## Purpose
This PR adds a direct CLI interface to voice conversations, bypassing the MCP protocol layer. This allows for:
- Performance profiling and optimization
- Direct testing of voice functionality
- Reduced latency for voice interactions

## Test Plan
- [x] Command executes successfully
- [x] Voice conversations work correctly
- [x] All parameters are properly passed through
- [x] Profiling data can be collected

🤖 Generated with [Claude Code](https://claude.ai/code)