### PR TITLE
fix: source shell profile after adding UV and npm to PATH on macOS/zsh

### DIFF
--- a/docs/web/install.sh
+++ b/docs/web/install.sh
@@ -419,6 +419,9 @@ install_uvx() {
         if ! grep -q "\.local/bin" "$shell_profile"; then
           echo 'export PATH="$HOME/.local/bin:$PATH"' >>"$shell_profile"
           print_success "Added UV to PATH in $shell_profile"
+          # Source the profile to make UV immediately available
+          source "$shell_profile"
+          print_success "Loaded $shell_profile to update PATH"
         fi
       fi
 
@@ -453,13 +456,20 @@ setup_local_npm() {
   if [[ "$SHELL" == *"zsh"* ]]; then
     shell_profile="$HOME/.zshrc"
   elif [[ "$SHELL" == *"bash"* ]]; then
-    shell_profile="$HOME/.bash_profile"
+    if [[ "$OS" == "macos" ]]; then
+      shell_profile="$HOME/.bash_profile"
+    else
+      shell_profile="$HOME/.bashrc"
+    fi
   fi
 
   if [ -n "$shell_profile" ] && [ -f "$shell_profile" ]; then
     if ! grep -q "\.npm-global/bin" "$shell_profile"; then
       echo 'export PATH="$HOME/.npm-global/bin:$PATH"' >>"$shell_profile"
       print_success "Added npm global bin to PATH in $shell_profile"
+      # Source the profile to make npm immediately available
+      source "$shell_profile"
+      print_success "Loaded $shell_profile to update PATH"
     fi
   fi
 


### PR DESCRIPTION
This fixes the 'uvx command not found' error on fresh macOS systems with zsh. The installer was adding UV to PATH in .zshrc but not sourcing it, so UV wasn't available for the rest of the installation process.

Changes:
- Source shell profile after adding UV to PATH
- Source shell profile after adding npm to PATH
- Fix npm setup to use correct shell profile (bashrc vs bash_profile)

This ensures UV and npm are immediately available without requiring a new shell.