### PR TITLE
Fix macOS service auto-enable issue

### DIFF
--- a/voice_mode/tools/services/kokoro/install.py
+++ b/voice_mode/tools/services/kokoro/install.py
@@ -251,13 +251,14 @@ async def kokoro_install(
             with open(plist_path, 'w') as f:
                 f.write(plist_content)
             
-            # Load the launchagent
+            # Unload if already loaded (ignore errors)
             try:
                 subprocess.run(["launchctl", "unload", plist_path], capture_output=True)
             except:
                 pass  # Ignore if not loaded
             
-            subprocess.run(["launchctl", "load", plist_path], check=True)
+            # Don't load here - let enable_service handle it with the -w flag
+            # This prevents the "already loaded" error when enable_service runs
             result["launchagent"] = plist_path
             result["message"] += f"\nLaunchAgent installed: {plist_name}"
             

--- a/voice_mode/tools/services/whisper/install.py
+++ b/voice_mode/tools/services/whisper/install.py
@@ -369,13 +369,14 @@ exec "$SERVER_BIN" \\
             with open(plist_path, 'w') as f:
                 f.write(plist_content)
             
-            # Load the launchagent
+            # Unload if already loaded (ignore errors)
             try:
                 subprocess.run(["launchctl", "unload", plist_path], capture_output=True)
             except:
                 pass  # Ignore if not loaded
             
-            subprocess.run(["launchctl", "load", plist_path], check=True)
+            # Don't load here - let enable_service handle it with the -w flag
+            # This prevents the "already loaded" error when enable_service runs
             
             # Handle auto_enable
             enable_message = ""


### PR DESCRIPTION
## Summary
- Fixes services not auto-enabling on boot on macOS despite `--auto-enable` flag
- Removes duplicate `launchctl load` calls that were causing conflicts

## Problem
The whisper and kokoro install scripts were doing `launchctl load` without the `-w` flag (which doesn't persist), then later calling `enable_service` which tries `launchctl load -w` (which persists). This caused a conflict because the service was already loaded, preventing the persistent loading from working.

## Solution
- Removed the duplicate `launchctl load` from both `whisper/install.py` (line 378) and `kokoro/install.py` (line 260)
- Now the install scripts only unload any existing service (to clean up)
- Let `enable_service` handle the actual loading with the `-w` flag for persistence

## Test Plan
- [ ] Install whisper with `--auto-enable` on macOS
- [ ] Install kokoro with `--auto-enable` on macOS
- [ ] Verify services start automatically after reboot
- [ ] Verify no "already loaded" errors in logs

This fixes the issue reported where both Cora instances were working but services weren't auto-enabling on boot on Mac.