### PR TITLE
Fix macOS timeout command dependency

### DIFF
--- a/docs/web/install.sh
+++ b/docs/web/install.sh
@@ -207,7 +207,7 @@ check_system_dependencies() {
   print_step "Checking system dependencies..."
 
   if [[ "$OS" == "macos" ]]; then
-    local packages=("node" "portaudio" "ffmpeg" "cmake")
+    local packages=("node" "portaudio" "ffmpeg" "cmake" "coreutils")
     local missing_packages=()
 
     for package in "${packages[@]}"; do
@@ -283,7 +283,7 @@ install_system_dependencies() {
         brew update
 
         # Install required packages
-        local packages=("node" "portaudio" "ffmpeg" "cmake")
+        local packages=("node" "portaudio" "ffmpeg" "cmake" "coreutils")
 
         for package in "${packages[@]}"; do
           if brew list "$package" >/dev/null 2>&1; then


### PR DESCRIPTION
## Summary
- Adds `coreutils` to macOS dependencies to provide the `timeout` command
- Fixes installation failure on fresh macOS systems

## Problem
The install script uses the `timeout` command which is not available by default on macOS. This causes the script to fail with "Failed to download Voice Mode" error on fresh macOS installations.

## Solution
- Added `coreutils` package to the Homebrew dependencies list for macOS
- This provides GNU coreutils including the `timeout` command
- Maintains compatibility with the existing timeout usage in the script

## Test Plan
- [ ] Run install script on fresh macOS system
- [ ] Verify coreutils gets installed via Homebrew
- [ ] Verify Voice Mode download completes successfully with timeout
- [ ] Confirm no regression on systems with coreutils already installed

This fix ensures the install script works on fresh macOS installations without requiring manual intervention.