### PR TITLE
Add version and update commands

### DIFF
--- a/tests/test_service_commands.bats
+++ b/tests/test_service_commands.bats
@@ -186,3 +186,59 @@ setup() {
     
     return 0
 }
+
+@test "version command runs without error" {
+    run $VOICE_MODE version
+    
+    # Check that it didn't crash
+    if [[ "$output" == *"Traceback"* ]]; then
+        echo "Command crashed with Python error:"
+        echo "$output"
+        return 1
+    fi
+    
+    if [[ "$output" == *"NameError"* ]]; then
+        echo "Command has NameError (missing import?):"
+        echo "$output"
+        return 1
+    fi
+    
+    # Check that it shows version information
+    if [[ "$output" != *"Voice Mode version:"* ]]; then
+        echo "Version command didn't show version info:"
+        echo "$output"
+        return 1
+    fi
+    
+    # Success - command ran and showed version
+    return 0
+}
+
+@test "update command runs without error" {
+    # Test update command (it should check for updates without actually updating)
+    run $VOICE_MODE update
+    
+    # Check that it didn't crash
+    if [[ "$output" == *"Traceback"* ]]; then
+        echo "Command crashed with Python error:"
+        echo "$output"
+        return 1
+    fi
+    
+    if [[ "$output" == *"NameError"* ]]; then
+        echo "Command has NameError (missing import?):"
+        echo "$output"
+        return 1
+    fi
+    
+    # Check that it shows appropriate message
+    # Should either say "Already running the latest version" or "Updating Voice Mode"
+    if [[ "$output" != *"Already running"* ]] && [[ "$output" != *"Updating Voice Mode"* ]]; then
+        echo "Update command didn't show expected output:"
+        echo "$output"
+        return 1
+    fi
+    
+    # Success - command ran without errors
+    return 0
+}

--- a/voice_mode/cli.py
+++ b/voice_mode/cli.py
@@ -1539,3 +1539,120 @@ def converse(message, wait, duration, min_duration, transport, room_name, voice,
     asyncio.run(run_conversation())
 
 
+# Version command
+@voice_mode_main_cli.command()
+def version():
+    """Show Voice Mode version and check for updates."""
+    import requests
+    from importlib.metadata import version as get_version, PackageNotFoundError
+    
+    try:
+        current_version = get_version("voice-mode")
+    except PackageNotFoundError:
+        # Fallback for development installations
+        current_version = "development"
+    
+    click.echo(f"Voice Mode version: {current_version}")
+    
+    # Check for updates if not in development mode
+    if current_version != "development":
+        try:
+            response = requests.get(
+                "https://pypi.org/pypi/voice-mode/json",
+                timeout=2
+            )
+            if response.status_code == 200:
+                latest_version = response.json()["info"]["version"]
+                
+                # Simple version comparison (works for semantic versioning)
+                if latest_version != current_version:
+                    click.echo(f"Latest version: {latest_version} available")
+                    click.echo("Run 'voicemode update' to update")
+                else:
+                    click.echo("You are running the latest version")
+        except (requests.RequestException, KeyError, ValueError):
+            # Fail silently if we can't check for updates
+            pass
+
+
+# Update command
+@voice_mode_main_cli.command()
+@click.option('--force', is_flag=True, help='Force reinstall even if already up to date')
+def update(force):
+    """Update Voice Mode to the latest version."""
+    import subprocess
+    import requests
+    from importlib.metadata import version as get_version, PackageNotFoundError
+    
+    try:
+        current_version = get_version("voice-mode")
+    except PackageNotFoundError:
+        current_version = "development"
+    
+    if not force and current_version != "development":
+        # Check if update is needed
+        try:
+            response = requests.get(
+                "https://pypi.org/pypi/voice-mode/json",
+                timeout=2
+            )
+            if response.status_code == 200:
+                latest_version = response.json()["info"]["version"]
+                if latest_version == current_version:
+                    click.echo(f"Already running the latest version ({current_version})")
+                    return
+        except (requests.RequestException, KeyError, ValueError):
+            # Continue with update if we can't check
+            pass
+    
+    click.echo("Updating Voice Mode to the latest version...")
+    
+    # Try UV first, fall back to pip
+    try:
+        # Check if UV is available
+        result = subprocess.run(
+            ["uv", "--version"],
+            capture_output=True,
+            text=True,
+            check=False
+        )
+        
+        if result.returncode == 0:
+            # Use UV for update
+            result = subprocess.run(
+                ["uv", "pip", "install", "--upgrade", "voice-mode"],
+                capture_output=True,
+                text=True
+            )
+            if result.returncode == 0:
+                # Get new version
+                try:
+                    new_version = get_version("voice-mode")
+                    click.echo(f"✅ Successfully updated to version {new_version}")
+                except PackageNotFoundError:
+                    click.echo("✅ Successfully updated Voice Mode")
+            else:
+                click.echo(f"❌ Update failed: {result.stderr}")
+                click.echo("Try running: uv pip install --upgrade voice-mode")
+        else:
+            # Fall back to pip
+            result = subprocess.run(
+                [sys.executable, "-m", "pip", "install", "--upgrade", "voice-mode"],
+                capture_output=True,
+                text=True
+            )
+            if result.returncode == 0:
+                try:
+                    new_version = get_version("voice-mode")
+                    click.echo(f"✅ Successfully updated to version {new_version}")
+                except PackageNotFoundError:
+                    click.echo("✅ Successfully updated Voice Mode")
+            else:
+                click.echo(f"❌ Update failed: {result.stderr}")
+                click.echo("Try running: pip install --upgrade voice-mode")
+    
+    except FileNotFoundError as e:
+        click.echo(f"❌ Update failed: {e}")
+        click.echo("Please install UV or pip and try again")
+
+


### PR DESCRIPTION
## Summary
Adds two new commands to Voice Mode for version management:
- `voicemode version` - Show current version and check for updates
- `voicemode update` - Self-update to the latest version

## Features

### Version Command
- Shows current Voice Mode version
- Checks PyPI for the latest available version
- Informs user if an update is available
- Handles development installations gracefully

### Update Command
- Updates Voice Mode to the latest version from PyPI
- Prefers UV for updates, falls back to pip if UV not available
- Supports `--force` flag to reinstall even if already up to date
- Shows clear success/failure messages

## Testing
- Added comprehensive bats tests for both commands
- Tests verify commands run without Python errors
- Tests check for expected output messages
- All tests passing ✅

## Example Usage

```bash
$ voicemode version
Voice Mode version: 2.26.0
Latest version: 2.27.0 available
Run 'voicemode update' to update

$ voicemode update
Updating Voice Mode to the latest version...
✅ Successfully updated to version 2.27.0

$ voicemode update --force
# Forces reinstall even if already on latest
```

## Next Steps
A follow-up PR will add the `completions` command for shell completion support.

Addresses part of the requirements for making Voice Mode a mature, properly installed CLI tool.