### PR TITLE
feat: add shell completions command with static scripts

### DIFF
--- a/tests/test_service_commands.bats
+++ b/tests/test_service_commands.bats
@@ -186,3 +186,108 @@ setup() {
     
     return 0
 }
+
+@test "version command runs without error" {
+    # Test that version command works
+    run $VOICE_MODE version
+    
+    # Check that it didn't crash
+    if [[ "$output" == *"Traceback"* ]]; then
+        echo "Command crashed with Python error:"
+        echo "$output"
+        return 1
+    fi
+    
+    # Should contain "Voice Mode version"
+    if [[ "$output" != *"Voice Mode version"* ]]; then
+        echo "Version command didn't output expected text:"
+        echo "$output"
+        return 1
+    fi
+    
+    return 0
+}
+
+@test "update command runs without error" {
+    # Test that update command works (may fail if no updates available)
+    run $VOICE_MODE update --help
+    
+    # Check that help works at least
+    if [[ "$output" == *"Traceback"* ]]; then
+        echo "Command crashed with Python error:"
+        echo "$output"
+        return 1
+    fi
+    
+    # Should contain "Update Voice Mode"
+    if [[ "$output" != *"Update Voice Mode"* ]]; then
+        echo "Update command help didn't output expected text:"
+        echo "$output"
+        return 1
+    fi
+    
+    return 0
+}
+
+@test "completions command generates bash completions" {
+    # Test that completions command generates bash completion script
+    run $VOICE_MODE completions bash
+    
+    # Check that it didn't crash
+    if [[ "$output" == *"Traceback"* ]]; then
+        echo "Command crashed with Python error:"
+        echo "$output"
+        return 1
+    fi
+    
+    # Should contain bash completion function
+    if [[ "$output" != *"_voicemode_completion"* ]]; then
+        echo "Completions didn't generate bash function:"
+        echo "$output"
+        return 1
+    fi
+    
+    return 0
+}
+
+@test "completions command generates zsh completions" {
+    # Test that completions command generates zsh completion script
+    run $VOICE_MODE completions zsh
+    
+    # Check that it didn't crash
+    if [[ "$output" == *"Traceback"* ]]; then
+        echo "Command crashed with Python error:"
+        echo "$output"
+        return 1
+    fi
+    
+    # Should contain zsh completion function
+    if [[ "$output" != *"#compdef voicemode"* ]]; then
+        echo "Completions didn't generate zsh function:"
+        echo "$output"
+        return 1
+    fi
+    
+    return 0
+}
+
+@test "completions command generates fish completions" {
+    # Test that completions command generates fish completion script
+    run $VOICE_MODE completions fish
+    
+    # Check that it didn't crash
+    if [[ "$output" == *"Traceback"* ]]; then
+        echo "Command crashed with Python error:"
+        echo "$output"
+        return 1
+    fi
+    
+    # Should contain fish completion function
+    if [[ "$output" != *"__fish_voicemode_complete"* ]]; then
+        echo "Completions didn't generate fish function:"
+        echo "$output"
+        return 1
+    fi
+    
+    return 0
+}


### PR DESCRIPTION
## Summary
- Add `voicemode completions` command to generate shell completion scripts
- Support bash, zsh, and fish shells with static completion scripts
- Add `--install` flag to automatically install completions to appropriate locations

## Motivation
Shell completions don't work reliably with uvx, and Click's dynamic completion generation was causing startup errors. This PR implements static completion scripts that work reliably across all supported shells.

## Implementation
- Static completion scripts for bash, zsh, and fish
- Each script uses the appropriate shell-specific completion mechanism
- Installation paths follow standard conventions for each shell
- Comprehensive bats tests for all three shells

## Usage
```bash
# Output completion script to stdout
voicemode completions bash
voicemode completions zsh
voicemode completions fish

# Install to appropriate location
voicemode completions bash --install   # → ~/.bash_completion.d/voicemode
voicemode completions zsh --install    # → ~/.zfunc/_voicemode
voicemode completions fish --install   # → ~/.config/fish/completions/voicemode.fish
```

## Testing
✅ All bats tests pass for bash, zsh, and fish completions
✅ Tested generation of all three completion script types
✅ No Python errors or crashes

## Related
This is a separate PR from #42 (version/update commands) to avoid holding up that work.

🤖 Generated with [Claude Code](https://claude.ai/code)