### PR TITLE
fix: enable CoreML fallback for whisper.cpp on Apple Silicon

### DIFF
--- a/voice_mode/tools/services/whisper/install.py
+++ b/voice_mode/tools/services/whisper/install.py
@@ -217,7 +217,8 @@ async def whisper_install(
             # On Apple Silicon, also enable Core ML for better performance
             if platform.machine() == "arm64":
                 cmake_flags.append("-DWHISPER_COREML=ON")
-                logger.info("Enabling Core ML support for Apple Silicon")
+                cmake_flags.append("-DWHISPER_COREML_ALLOW_FALLBACK=ON")
+                logger.info("Enabling Core ML support with fallback for Apple Silicon")
         elif is_linux and use_gpu:
             cmake_flags.append("-DGGML_CUDA=ON")
         


### PR DESCRIPTION
Adds WHISPER_COREML_ALLOW_FALLBACK=ON cmake flag when building whisper.cpp on ARM64 Macs. This prevents initialization failures when CoreML models are missing or incompatible, allowing graceful fallback to Metal GPU or CPU.

Fixes issues with large-v1, large-v2, and other models that lack CoreML support, ensuring all Whisper models work reliably on Apple Silicon.