### PR TITLE
feat: standardize project name as VoiceMode MCP

### DIFF
--- a/docs/web/index.html
+++ b/docs/web/index.html
@@ -3,8 +3,8 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Voice Mode MCP Server - Natural voice conversations with AI</title>
-    <meta name="description" content="Voice Mode enables natural voice conversations with Claude, ChatGPT, and other AI assistants. Simple setup, powerful features.">
+    <title>VoiceMode MCP - Voice Mode for Claude Code</title>
+    <meta name="description" content="VoiceMode MCP enables natural voice conversations with Claude Code and other AI coding assistants. Simple setup, powerful features.">
     <style>
         :root {
             /* Enhanced color palette */
@@ -541,8 +541,8 @@
 <body>
     <div class="container">
         <header>
-            <h1>Voice Mode</h1>
-            <p class="tagline">"Natural voice conversations with AI"</p>
+            <h1>VoiceMode MCP</h1>
+            <p class="tagline">"Voice Mode for Claude Code (and other AI Coding Assistants)"</p>
             <a href="https://github.com/mbailey/voicemode" class="github-cta">
                 <svg width="20" height="20" viewBox="0 0 16 16" fill="currentColor">
                     <path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0016 8c0-4.42-3.58-8-8-8z"/>
@@ -558,7 +558,7 @@
         <section>
             <h2>Overview</h2>
             <p>
-                Voice Mode brings natural voice conversations to AI assistants like Claude and ChatGPT. 
+                VoiceMode MCP brings natural voice conversations Claude Code and other AI coding assistants. 
                 Built on the Model Context Protocol (MCP), it provides a clean, reliable interface for adding voice capabilities 
                 to your AI workflows.
             </p>
@@ -569,7 +569,7 @@
             <div class="video-container">
                 <iframe 
                     src="https://www.youtube.com/embed/cYdwOD_-dQc" 
-                    title="Voice Mode Demo" 
+                    title="VoiceMode MCP Demo" 
                     frameborder="0" 
                     allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" 
                     allowfullscreen>
@@ -581,11 +581,11 @@
             <h2>AI Conversations: Claude Meets Gemini</h2>
             <p>
                 Experience a groundbreaking series of conversations between Claude and Gemini, speaking to each other through 
-                their respective CLI tools (Claude Code and Gemini CLI) via Voice Mode MCP. In this episode, they discuss 
+                their respective CLI tools (Claude Code and Gemini CLI) via VoiceMode MCP. In this episode, they discuss 
                 whether Gemini CLI represents innovation or imitation in the AI coding assistant space.
             </p>
             <p style="margin-top: 1rem; font-size: 0.9em; color: var(--text-secondary);">
-                This is part of an ongoing series exploring AI-to-AI communication, demonstrating how Voice Mode enables 
+                This is part of an ongoing series exploring AI-to-AI communication, demonstrating how VoiceMode MCP enables 
                 natural conversations between different AI systems.
             </p>
             <div class="video-container">


### PR DESCRIPTION
Updates website content to consistently use 'VoiceMode MCP' as the project name, emphasizing its role as a voice mode solution for Claude Code and other AI coding assistants.