### PR TITLE
refactor: standardize logger names to "voicemode" without hyphen

### DIFF
--- a/voice_mode/cli.py
+++ b/voice_mode/cli.py
@@ -32,7 +32,7 @@ if not os.environ.get('VOICEMODE_DEBUG', '').lower() in ('true', '1', 'yes'):
     
     # Also suppress INFO logging for CLI commands (but not for MCP server)
     import logging
-    logging.getLogger("voice-mode").setLevel(logging.WARNING)
+    logging.getLogger("voicemode").setLevel(logging.WARNING)
     logging.getLogger("httpx").setLevel(logging.WARNING)
 
 
@@ -56,7 +56,7 @@ def voice_mode_main_cli(ctx, debug, tools_enabled, tools_disabled):
         os.environ['VOICEMODE_DEBUG'] = 'true'
         # Re-enable INFO logging
         import logging
-        logging.getLogger("voice-mode").setLevel(logging.INFO)
+        logging.getLogger("voicemode").setLevel(logging.INFO)
 
     # Set environment variables from CLI args
     if tools_enabled:

--- a/voice_mode/config.py
+++ b/voice_mode/config.py
@@ -673,7 +673,7 @@ def setup_logging() -> logging.Logger:
         
         # Legacy trace file support
         trace_file = Path.home() / "voicemode_trace.log"
-        trace_logger = logging.getLogger("voicemode-trace")
+        trace_logger = logging.getLogger("voicemode.trace")
         trace_handler = logging.FileHandler(trace_file, mode='a')
         trace_handler.setFormatter(logging.Formatter('%(asctime)s - %(message)s'))
         trace_logger.addHandler(trace_handler)

--- a/voice_mode/provider_discovery.py
+++ b/voice_mode/provider_discovery.py
@@ -21,7 +21,7 @@ from openai import AsyncOpenAI
 from . import config
 from .config import TTS_BASE_URLS, STT_BASE_URLS, OPENAI_API_KEY
 
-logger = logging.getLogger("voice-mode")
+logger = logging.getLogger("voicemode")
 
 
 def detect_provider_type(base_url: str) -> str:

--- a/voice_mode/providers.py
+++ b/voice_mode/providers.py
@@ -12,7 +12,7 @@ from openai import AsyncOpenAI
 from .config import TTS_VOICES, TTS_MODELS, TTS_BASE_URLS, OPENAI_API_KEY, get_voice_preferences
 from .provider_discovery import provider_registry, EndpointInfo, is_local_provider
 
-logger = logging.getLogger("voice-mode")
+logger = logging.getLogger("voicemode")
 
 
 async def get_tts_client_and_voice(

--- a/voice_mode/statistics.py
+++ b/voice_mode/statistics.py
@@ -16,7 +16,7 @@ from pathlib import Path
 
 import logging
 
-logger = logging.getLogger("voice-mode")
+logger = logging.getLogger("voicemode")
 
 
 @dataclass

--- a/voice_mode/tools/__init__.py
+++ b/voice_mode/tools/__init__.py
@@ -4,7 +4,7 @@ import importlib
 from pathlib import Path
 import logging
 
-logger = logging.getLogger("voice-mode")
+logger = logging.getLogger("voicemode")
 
 # Get the directory containing this file
 tools_dir = Path(__file__).parent

--- a/voice_mode/tools/configuration_management.py
+++ b/voice_mode/tools/configuration_management.py
@@ -8,7 +8,7 @@ from voice_mode.server import mcp
 from voice_mode.config import BASE_DIR, reload_configuration, find_voicemode_env_files
 import logging
 
-logger = logging.getLogger("voice-mode")
+logger = logging.getLogger("voicemode")
 
 # Configuration file path (user-level only for security)
 USER_CONFIG_PATH = Path.home() / ".voicemode" / "voicemode.env"

--- a/voice_mode/tools/converse.py
+++ b/voice_mode/tools/converse.py
@@ -80,7 +80,7 @@ from voice_mode.utils import (
 )
 from voice_mode.pronounce import get_manager as get_pronounce_manager, is_enabled as pronounce_enabled
 
-logger = logging.getLogger("voice-mode")
+logger = logging.getLogger("voicemode")
 
 # Log silence detection config at module load time
 logger.info(f"Module loaded with DISABLE_SILENCE_DETECTION={DISABLE_SILENCE_DETECTION}")

--- a/voice_mode/tools/dependencies.py
+++ b/voice_mode/tools/dependencies.py
@@ -10,7 +10,7 @@ from voice_mode.utils.audio_diagnostics import (
     diagnose_audio_setup
 )
 
-logger = logging.getLogger("voice-mode")
+logger = logging.getLogger("voicemode")
 
 
 @mcp.tool()

--- a/voice_mode/tools/devices.py
+++ b/voice_mode/tools/devices.py
@@ -7,7 +7,7 @@ import sounddevice as sd
 from voice_mode.server import mcp
 from voice_mode.shared import startup_initialization
 
-logger = logging.getLogger("voice-mode")
+logger = logging.getLogger("voicemode")
 
 
 @mcp.tool()

--- a/voice_mode/tools/diagnostics.py
+++ b/voice_mode/tools/diagnostics.py
@@ -7,7 +7,7 @@ from voice_mode.config import TTS_VOICES, TTS_BASE_URLS, TTS_MODELS
 from voice_mode.provider_discovery import provider_registry
 import logging
 
-logger = logging.getLogger("voice-mode")
+logger = logging.getLogger("voicemode")
 
 
 @mcp.tool()

--- a/voice_mode/tools/kokoro/install.py
+++ b/voice_mode/tools/kokoro/install.py
@@ -19,7 +19,7 @@ from voice_mode.utils.version_helpers import (
 )
 from voice_mode.utils.migration_helpers import auto_migrate_if_needed
 
-logger = logging.getLogger("voice-mode")
+logger = logging.getLogger("voicemode")
 
 
 async def update_kokoro_service_files(

--- a/voice_mode/tools/kokoro/uninstall.py
+++ b/voice_mode/tools/kokoro/uninstall.py
@@ -12,7 +12,7 @@ from voice_mode.server import mcp
 from voice_mode.config import BASE_DIR
 from voice_mode.utils.services.common import find_process_by_port
 
-logger = logging.getLogger("voice-mode")
+logger = logging.getLogger("voicemode")
 
 
 @mcp.tool()

--- a/voice_mode/tools/livekit/frontend.py
+++ b/voice_mode/tools/livekit/frontend.py
@@ -11,7 +11,7 @@ from typing import Dict, Any, Optional
 
 from voice_mode.server import mcp
 
-logger = logging.getLogger("voice-mode")
+logger = logging.getLogger("voicemode")
 
 # Global production server instance
 _production_server = None

--- a/voice_mode/tools/livekit/install.py
+++ b/voice_mode/tools/livekit/install.py
@@ -21,7 +21,7 @@ from voice_mode.utils.version_helpers import (
 )
 from voice_mode.utils.migration_helpers import auto_migrate_if_needed
 
-logger = logging.getLogger("voice-mode")
+logger = logging.getLogger("voicemode")
 
 
 async def download_livekit_binary(version: str, install_dir: Path) -> bool:

--- a/voice_mode/tools/livekit/production_server.py
+++ b/voice_mode/tools/livekit/production_server.py
@@ -12,7 +12,7 @@ from threading import Thread
 from typing import Optional, Dict, Any
 from urllib.parse import urlparse, parse_qs
 
-logger = logging.getLogger("voice-mode")
+logger = logging.getLogger("voicemode")
 
 
 class ProductionFrontendHandler(SimpleHTTPRequestHandler):

--- a/voice_mode/tools/livekit/uninstall.py
+++ b/voice_mode/tools/livekit/uninstall.py
@@ -13,7 +13,7 @@ import asyncio
 from voice_mode.server import mcp
 from voice_mode.tools.service import stop_service, disable_service, uninstall_service
 
-logger = logging.getLogger("voice-mode")
+logger = logging.getLogger("voicemode")
 
 
 @mcp.tool()

--- a/voice_mode/tools/providers.py
+++ b/voice_mode/tools/providers.py
@@ -7,7 +7,7 @@ from voice_mode.server import mcp
 from voice_mode.provider_discovery import provider_registry, detect_provider_type
 from voice_mode.config import TTS_BASE_URLS, STT_BASE_URLS
 
-logger = logging.getLogger("voice-mode")
+logger = logging.getLogger("voicemode")
 
 
 @mcp.tool()

--- a/voice_mode/tools/service.py
+++ b/voice_mode/tools/service.py
@@ -18,7 +18,7 @@ from voice_mode.utils.services.common import find_process_by_port, check_service
 from voice_mode.utils.services.whisper_helpers import find_whisper_server, find_whisper_model
 from voice_mode.utils.services.kokoro_helpers import find_kokoro_fastapi, has_gpu_support
 
-logger = logging.getLogger("voice-mode")
+logger = logging.getLogger("voicemode")
 
 
 def load_service_file_version(service_name: str, file_type: str) -> Optional[str]:

--- a/voice_mode/tools/whisper/install.py
+++ b/voice_mode/tools/whisper/install.py
@@ -27,7 +27,7 @@ from voice_mode.utils.version_helpers import (
 from voice_mode.utils.migration_helpers import auto_migrate_if_needed
 from voice_mode.utils.gpu_detection import detect_gpu
 
-logger = logging.getLogger("voice-mode")
+logger = logging.getLogger("voicemode")
 
 
 async def update_whisper_service_files(

--- a/voice_mode/tools/whisper/model_install.py
+++ b/voice_mode/tools/whisper/model_install.py
@@ -13,7 +13,7 @@ from voice_mode.server import mcp
 from voice_mode.config import logger, MODELS_DIR, DEFAULT_WHISPER_MODEL
 from voice_mode.utils.services.whisper_helpers import download_whisper_model, get_available_models
 
-logger = logging.getLogger("voice-mode")
+logger = logging.getLogger("voicemode")
 
 
 @mcp.tool()

--- a/voice_mode/tools/whisper/uninstall.py
+++ b/voice_mode/tools/whisper/uninstall.py
@@ -12,7 +12,7 @@ from voice_mode.server import mcp
 from voice_mode.config import BASE_DIR
 from voice_mode.utils.services.common import find_process_by_port
 
-logger = logging.getLogger("voice-mode")
+logger = logging.getLogger("voicemode")
 
 
 @mcp.tool()

--- a/voice_mode/utils/audio_diagnostics.py
+++ b/voice_mode/utils/audio_diagnostics.py
@@ -6,7 +6,7 @@ import os
 import logging
 from typing import Dict, List, Tuple, Optional
 
-logger = logging.getLogger("voice-mode")
+logger = logging.getLogger("voicemode")
 
 
 def check_system_audio_packages() -> Dict[str, bool]:

--- a/voice_mode/utils/event_logger.py
+++ b/voice_mode/utils/event_logger.py
@@ -16,7 +16,7 @@ from dataclasses import dataclass, asdict, field
 import logging
 import atexit
 
-logger = logging.getLogger("voice-mode.event-logger")
+logger = logging.getLogger("voicemode.event-logger")
 
 
 @dataclass

--- a/voice_mode/utils/format_migration.py
+++ b/voice_mode/utils/format_migration.py
@@ -10,7 +10,7 @@ from pathlib import Path
 from typing import Optional
 import logging
 
-logger = logging.getLogger("voice-mode")
+logger = logging.getLogger("voicemode")
 
 
 def detect_existing_format_preference() -> Optional[str]:

--- a/voice_mode/utils/gpu_detection.py
+++ b/voice_mode/utils/gpu_detection.py
@@ -5,7 +5,7 @@ import subprocess
 from typing import Tuple, Optional
 import logging
 
-logger = logging.getLogger("voice-mode")
+logger = logging.getLogger("voicemode")
 
 
 def detect_gpu() -> Tuple[bool, Optional[str]]:

--- a/voice_mode/utils/migration_helpers.py
+++ b/voice_mode/utils/migration_helpers.py
@@ -6,7 +6,7 @@ import logging
 from pathlib import Path
 from typing import List, Optional
 
-logger = logging.getLogger("voice-mode")
+logger = logging.getLogger("voicemode")
 
 
 def check_old_whisper_installations() -> List[Path]:

--- a/voice_mode/utils/services/common.py
+++ b/voice_mode/utils/services/common.py
@@ -5,7 +5,7 @@ import socket
 from typing import Optional, Tuple
 import logging
 
-logger = logging.getLogger("voice-mode")
+logger = logging.getLogger("voicemode")
 
 
 def find_process_by_port(port: int) -> Optional[psutil.Process]:

--- a/voice_mode/utils/services/coreml_setup.py
+++ b/voice_mode/utils/services/coreml_setup.py
@@ -6,7 +6,7 @@ import logging
 from pathlib import Path
 from typing import Optional, Dict, Any
 
-logger = logging.getLogger("voice-mode")
+logger = logging.getLogger("voicemode")
 
 
 def setup_coreml_venv(whisper_dir: Path, force: bool = False) -> Dict[str, Any]:

--- a/voice_mode/utils/services/livekit_helpers.py
+++ b/voice_mode/utils/services/livekit_helpers.py
@@ -7,7 +7,7 @@ import logging
 from pathlib import Path
 from typing import Optional
 
-logger = logging.getLogger("voice-mode")
+logger = logging.getLogger("voicemode")
 
 
 def find_livekit_server() -> Optional[Path]:

--- a/voice_mode/utils/services/version_info.py
+++ b/voice_mode/utils/services/version_info.py
@@ -15,7 +15,7 @@ from voice_mode.utils.services.kokoro_helpers import find_kokoro_fastapi
 from voice_mode.utils.services.common import find_process_by_port
 from voice_mode.utils.version_helpers import get_current_version
 
-logger = logging.getLogger("voice-mode")
+logger = logging.getLogger("voicemode")
 
 
 def get_whisper_version() -> Dict[str, Any]:

--- a/voice_mode/utils/services/whisper_helpers.py
+++ b/voice_mode/utils/services/whisper_helpers.py
@@ -14,7 +14,7 @@ from typing import Optional, List, Dict, Union
 
 from voice_mode.utils.download import download_with_progress_async
 
-logger = logging.getLogger("voice-mode")
+logger = logging.getLogger("voicemode")
 
 def find_whisper_server() -> Optional[str]:
     """Find the whisper-server binary."""

--- a/voice_mode/utils/version_helpers.py
+++ b/voice_mode/utils/version_helpers.py
@@ -6,7 +6,7 @@ from typing import List, Optional, Tuple
 from pathlib import Path
 import re
 
-logger = logging.getLogger("voice-mode")
+logger = logging.getLogger("voicemode")
 
 
 def get_git_tags(repo_url: str) -> List[str]:


### PR DESCRIPTION
Standardizes all logging.getLogger() calls to use "voicemode" instead of "voice-mode" for consistent logger naming across the codebase.

Changes:
- Replace getLogger("voice-mode") with getLogger("voicemode") in 32 files
- Replace getLogger("voice-mode.event-logger") with getLogger("voicemode.event-logger")
- Replace getLogger("voicemode-trace") with getLogger("voicemode.trace") for consistency

This improves log filtering and searching by using a single consistent logger name throughout the application.

Fixes #76

🤖 Generated with [Claude Code](https://claude.com/claude-code)