### PR TITLE
feat: add support for multiple MCP transport types for codex

### DIFF
--- a/voice_mode/cli.py
+++ b/voice_mode/cli.py
@@ -47,8 +47,10 @@ if not os.environ.get('VOICEMODE_DEBUG', '').lower() in ('true', '1', 'yes'):
 @click.option('--debug', is_flag=True, help='Enable debug mode and show all warnings')
 @click.option('--tools-enabled', help='Comma-separated list of tools to enable (whitelist)')
 @click.option('--tools-disabled', help='Comma-separated list of tools to disable (blacklist)')
+@click.option('--transport', type=click.Choice(['stdio', 'sse', 'streamable-http']), default='stdio', help='MCP transport type (default: stdio)')
+@click.option('--port', type=int, default=8000, help='Port for HTTP transports (default: 8000)')
 @click.pass_context
-def voice_mode_main_cli(ctx, debug, tools_enabled, tools_disabled):
+def voice_mode_main_cli(ctx, debug, tools_enabled, tools_disabled, transport, port):
     """Voice Mode - MCP server and service management.
 
     Without arguments, starts the MCP server.
@@ -72,7 +74,7 @@ def voice_mode_main_cli(ctx, debug, tools_enabled, tools_disabled):
         # No subcommand - run MCP server
         # Note: warnings are already suppressed at module level unless debug is enabled
         from .server import main as voice_mode_main
-        voice_mode_main()
+        voice_mode_main(transport=transport, port=port)
 
 
 def voice_mode() -> None:

--- a/voice_mode/server.py
+++ b/voice_mode/server.py
@@ -16,8 +16,13 @@ from . import prompts
 from . import resources
 
 # Main entry point
-def main():
-    """Run the VoiceMode MCP server."""
+def main(transport="stdio", port=8000):
+    """Run the VoiceMode MCP server.
+
+    Args:
+        transport: Transport type - 'stdio', 'sse', or 'streamable-http' (default: 'stdio')
+        port: Port number for HTTP transports (default: 8000)
+    """
     import os
     import sys
     import warnings
@@ -79,8 +84,13 @@ def main():
     else:
         logger.info("Event logging disabled")
     
-    # Run the server
-    mcp.run(transport="stdio")
+    # Run the server with specified transport
+    logger.info(f"Starting MCP server with transport: {transport}")
+    if transport in ['sse', 'streamable-http']:
+        logger.info(f"Using port {port} for HTTP transport")
+        mcp.run(transport=transport, port=port)
+    else:
+        mcp.run(transport=transport)
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
## Summary
Adds transport and port configuration options to VoiceMode MCP server, enabling support for stdio, SSE, and streamable-HTTP transports with configurable ports.

## Changes
### Transport Configuration
* **`--transport` option**: Choose between `stdio` (default), `sse`, or `streamable-http` transports
* **`--port` option**: Configure port for HTTP-based transports (default: 8000)
* **Smart port handling**: Port option only applies to HTTP transports, ignored for stdio
* **FastMCP integration**: Leverages FastMCP 2.0's built-in multi-transport support

### Implementation
* **CLI layer**: Added options to `voice_mode_main_cli` in `cli.py`
* **Server layer**: Updated `main()` function to accept transport and port parameters
* **Conditional logic**: Port parameter passed only for HTTP transports

## Benefits
* Enables Codex and other AI coding assistants that require HTTP transports to work with VoiceMode
* Run multiple VoiceMode instances on different ports without conflicts
* Compatible with various MCP clients that require specific transports
* Enables cloud deployment with HTTP-based transports
* Facilitates integration testing with multiple server instances
* Supports browser-based debugging with HTTP transports

## Testing
Tested with:

* Default stdio transport (backward compatibility)
* SSE transport on custom ports (9001, 9002)
* Streamable-HTTP transport on custom ports
* Port conflict handling
* Help text verification

## Usage Examples
```bash
# Default stdio transport
voicemode

# SSE with custom port
voicemode --transport sse --port 9001

# Streamable-HTTP with custom port
voicemode --transport streamable-http --port 9002
```
