### PR TITLE
feat: read VOICEMODE_TTS_SPEED from environment as default speed

### DIFF
--- a/voice_mode/tools/converse.py
+++ b/voice_mode/tools/converse.py
@@ -1030,6 +1030,17 @@ consult the MCP resources listed above.
         # Use global setting
         should_skip_tts = SKIP_TTS
     
+    # Read default speed from environment variable if speed is not provided
+    if speed is None:
+        tts_speed_env = os.getenv("VOICEMODE_TTS_SPEED")
+        if tts_speed_env is not None:
+            try:
+                speed = float(tts_speed_env)
+                logger.info(f"Using speed from VOICEMODE_TTS_SPEED environment variable: {speed}")
+            except ValueError:
+                logger.warning(f"Invalid VOICEMODE_TTS_SPEED value '{tts_speed_env}', ignoring")
+                speed = None
+    
     # Convert string speed to float
     if speed is not None and isinstance(speed, str):
         try:


### PR DESCRIPTION
## Summary

This PR adds support for reading the `VOICEMODE_TTS_SPEED` environment variable as the default speed value when the `speed` parameter is not explicitly provided to the `converse` function.

## Changes

- Modified `voice_mode/tools/converse.py` to read `VOICEMODE_TTS_SPEED` from the environment when `speed=None`
- The environment variable is parsed as a float and validated to be within the range 0.25-4.0
- Invalid values are logged as warnings and ignored
- Explicitly passed `speed` values still take precedence over the environment variable

## Motivation

Currently, users can set `VOICEMODE_TTS_SPEED` in their MCP configuration, but it's not actually used by the `converse` function. This makes it impossible to set a default TTS speed via environment variables, requiring users to always pass the `speed` parameter explicitly.

This change allows users to configure a default TTS speed in their MCP configuration (e.g., `VOICEMODE_TTS_SPEED=1.3`) and have it automatically applied to all conversations.

## Testing

- Tested with `VOICEMODE_TTS_SPEED=1.3` in MCP configuration
- Verified that explicitly passed `speed` values override the environment variable
- Verified that invalid environment variable values are handled gracefully