### PR TITLE
fix: update tests for pronunciation CLI removal and service version bump

### DIFF
--- a/tests/test_help_comprehensive.py
+++ b/tests/test_help_comprehensive.py
@@ -111,11 +111,8 @@ def discover_all_commands() -> List[List[str]]:
         if sub in config_with_options:
             commands.append(base_cmd + ['config', sub, '-h'])
 
-    # Config pronounce subgroup
-    commands.append(base_cmd + ['config', 'pronounce', '--help'])
-    pronounce_cmds = ['add', 'disable', 'edit', 'enable', 'list', 'reload', 'remove', 'test']
-    for cmd in pronounce_cmds:
-        commands.append(base_cmd + ['config', 'pronounce', cmd, '--help'])
+    # Note: config pronounce subgroup was removed in v7.0.0
+    # Pronunciation now uses environment variables (VOICEMODE_PRONOUNCE)
 
     # === EXCHANGES COMMANDS ===
     exchanges_subcommands = ['export', 'search', 'stats', 'tail', 'view']

--- a/tests/test_service_file_updates.py
+++ b/tests/test_service_file_updates.py
@@ -20,8 +20,8 @@ def test_load_service_file_version():
     """Test loading service file versions from versions.json."""
     # Test for kokoro on macOS
     version = load_service_file_version("kokoro", "plist")
-    assert version == "1.1.0"
-    
+    assert version == "1.2.0"  # Updated in v7.0.0 for uv curl installer PATH fix
+
     # Test for whisper on Linux
     version = load_service_file_version("whisper", "service")
     assert version == "1.1.0"


### PR DESCRIPTION
## Summary
- Remove references to `config pronounce` commands from help tests
- Update service file version test to expect 1.2.0 for Kokoro plist

## Context
Tests were failing in CI because:
1. The `config pronounce` CLI commands were removed (pronunciation now uses env vars)
2. Kokoro plist version was bumped to 1.2.0 for the uv curl installer PATH fix

## Test Results
All 343 help tests pass locally after this fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)