### PR TITLE
feat(stt): add detailed timing metrics to STT requests (VM-244)

### DIFF
--- a/voice_mode/config.py
+++ b/voice_mode/config.py
@@ -107,6 +107,12 @@ def load_voicemode_env():
 # Skip TTS for faster text-only responses (true/false)
 # VOICEMODE_SKIP_TTS=false
 
+# Metrics output level in converse results (minimal/summary/verbose)
+# - minimal: Just the response text, no timing (saves tokens)
+# - summary: Response + compact timing string (default)
+# - verbose: Response + detailed metrics breakdown
+# VOICEMODE_METRICS_LEVEL=summary
+
 # Enable audio feedback chimes (true/false)
 # VOICEMODE_AUDIO_FEEDBACK=true
 
@@ -446,6 +452,13 @@ SKIP_TTS = os.getenv("VOICEMODE_SKIP_TTS", "false").lower() in ("true", "1", "ye
 
 # TTS speed configuration (0.25-4.0, default None uses provider default)
 TTS_SPEED = float(os.getenv("VOICEMODE_TTS_SPEED")) if os.getenv("VOICEMODE_TTS_SPEED") else None
+
+# Metrics output level configuration (minimal/summary/verbose)
+# - minimal: Just the response text, no timing
+# - summary: Response + compact timing string (default)
+# - verbose: Response + detailed metrics breakdown
+_metrics_level = os.getenv("VOICEMODE_METRICS_LEVEL", "summary").lower()
+METRICS_LEVEL = _metrics_level if _metrics_level in ("minimal", "summary", "verbose") else "summary"
 
 # Local provider preference configuration
 PREFER_LOCAL = os.getenv("VOICEMODE_PREFER_LOCAL", "true").lower() in ("true", "1", "yes", "on")

--- a/voice_mode/simple_failover.py
+++ b/voice_mode/simple_failover.py
@@ -165,17 +165,41 @@ async def simple_stt_failover(
 
     Returns:
         Dict with transcription result or error information:
-        - Success: {"text": "...", "provider": "...", "endpoint": "..."}
-        - No speech: {"error_type": "no_speech", "provider": "..."}
+        - Success: {"text": "...", "provider": "...", "endpoint": "...", "metrics": {...}}
+        - No speech: {"error_type": "no_speech", "provider": "...", "metrics": {...}}
         - All failed: {"error_type": "connection_failed", "attempted_endpoints": [...]}
+
+        The metrics dict (when present) contains:
+        - file_size_bytes: Size of audio file sent
+        - request_time_ms: Total time for the API request
+        - is_local: Whether the endpoint is local (localhost/LAN)
     """
+    import time
+
     connection_errors = []
     successful_but_empty = False
     successful_provider = None
 
+    # Get file size for metrics
+    file_size_bytes = 0
+    try:
+        # Save current position, seek to end to get size, restore position
+        start_pos = audio_file.tell()
+        audio_file.seek(0, 2)  # Seek to end
+        file_size_bytes = audio_file.tell()
+        audio_file.seek(start_pos)  # Restore position
+        # Ensure we got an integer
+        if not isinstance(file_size_bytes, int):
+            file_size_bytes = 0
+    except Exception as e:
+        logger.debug(f"Could not get file size: {e}")
+        file_size_bytes = 0
+
     # Log STT request details
     logger.info("STT: Starting speech-to-text conversion")
     logger.info(f"  Available endpoints: {STT_BASE_URLS}")
+    if file_size_bytes > 0:
+        logger.info(f"  Audio file size: {file_size_bytes / 1024:.1f}KB")
 
     # Try each STT endpoint in order
     for i, base_url in enumerate(STT_BASE_URLS):
@@ -200,25 +224,38 @@ async def simple_stt_failover(
                 max_retries=max_retries
             )
 
-            # Try STT with this endpoint
+            # Try STT with this endpoint - track timing
+            request_start = time.perf_counter()
             transcription = await client.audio.transcriptions.create(
                 model=model,
                 file=audio_file,
                 response_format="text"
             )
+            request_time_ms = (time.perf_counter() - request_start) * 1000
 
             text = transcription.strip() if isinstance(transcription, str) else transcription.text.strip()
+
+            # Build metrics dict
+            is_local = is_local_provider(base_url)
+            metrics = {
+                "file_size_bytes": file_size_bytes,
+                "request_time_ms": round(request_time_ms, 1),
+                "is_local": is_local,
+            }
 
             if text:
                 logger.info(f"✓ STT succeeded with {provider_type} at {base_url}")
                 logger.info(f"  Transcribed: {text[:100]}{'...' if len(text) > 100 else ''}")
-                # Return both text and provider info for display
-                return {"text": text, "provider": provider_type, "endpoint": base_url}
+                logger.info(f"  Request time: {request_time_ms:.0f}ms, File size: {file_size_bytes/1024:.1f}KB")
+                # Return both text and provider info for display, plus metrics
+                return {"text": text, "provider": provider_type, "endpoint": base_url, "metrics": metrics}
             else:
                 # Successful connection but no speech detected
                 logger.warning(f"STT returned empty result from {base_url} ({provider_type})")
                 successful_but_empty = True
                 successful_provider = provider_type
+                # Store metrics for potential no_speech return
+                successful_metrics = metrics
 
         except Exception as e:
             error_str = str(e)
@@ -258,7 +295,11 @@ async def simple_stt_failover(
     if successful_but_empty:
         # At least one endpoint connected successfully but returned no speech
         logger.info("STT: No speech detected (successful connection)")
-        return {"error_type": "no_speech", "provider": successful_provider}
+        result = {"error_type": "no_speech", "provider": successful_provider}
+        # Include metrics if we captured them
+        if 'successful_metrics' in locals():
+            result["metrics"] = successful_metrics
+        return result
     elif connection_errors:
         # All endpoints failed with connection/auth errors
         logger.error(f"✗ All STT endpoints failed after {len(STT_BASE_URLS)} attempts")

--- a/voice_mode/streaming.py
+++ b/voice_mode/streaming.py
@@ -313,11 +313,21 @@ async def stream_pcm_audio(
         # Wait for playback to finish
         stream.stop()
         
-        # Log TTS playback end
-        if event_logger:
-            event_logger.log_event(event_logger.TTS_PLAYBACK_END)
-        
         end_time = time.perf_counter()
+
+        # Log TTS playback end with metrics
+        if event_logger:
+            tts_event_data = {
+                "metrics": {
+                    "ttfa_ms": round((first_chunk_time - start_time) * 1000, 1) if first_chunk_time else 0,
+                    "total_time_ms": round((end_time - start_time) * 1000, 1),
+                    "bytes_received": bytes_received,
+                    "chunks": chunk_count,
+                    "format": "pcm",
+                    "sample_rate_hz": SAMPLE_RATE
+                }
+            }
+            event_logger.log_event(event_logger.TTS_PLAYBACK_END, tts_event_data)
         metrics.generation_time = first_chunk_time - start_time if first_chunk_time else 0
         metrics.playback_time = end_time - start_time
         


### PR DESCRIPTION
## Summary

Adds detailed timing metrics to STT (speech-to-text) and TTS (text-to-speech) operations for performance analysis and debugging.

## Before/After

### Before
```
Voice response: Hello | Timing: ttfa 0.5s, gen 0.5s, play 3.2s, record 5.3s, stt 1.0s, total 9.0s
```
- No visibility into audio file size sent to STT
- No way to correlate STT time with file size
- Couldn't distinguish local vs cloud STT endpoints
- Event log only captured text, no performance data

### After
```
Voice response: Hello | Timing: ttfa 0.5s, gen 0.5s, play 3.2s, record 5.3s, stt 1.0s, audio 217KB, total 9.0s
```
- Shows audio file size in timing output (e.g., "audio 217KB")
- Logs audio format, sample rate, bitrate when saving (e.g., "WAV, 24000Hz, 384kbps")
- STT result includes metrics dict with:
  - `file_size_bytes`: Size of audio sent
  - `request_time_ms`: API request time
  - `is_local`: Whether endpoint is local (localhost/LAN)
- Event logger captures full metrics in STT_COMPLETE events

### Example Event Log Entries

**STT_COMPLETE:**
```json
{
  "event_type": "STT_COMPLETE",
  "data": {
    "text": "Hello there",
    "metrics": {
      "file_size_bytes": 221804,
      "request_time_ms": 1040.1,
      "is_local": true,
      "format": "wav",
      "sample_rate_hz": 24000,
      "bitrate_kbps": 384
    }
  }
}
```

**TTS_PLAYBACK_END:**
```json
{
  "event_type": "TTS_PLAYBACK_END",
  "data": {
    "metrics": {
      "ttfa_ms": 450.2,
      "total_time_ms": 1523.5,
      "bytes_received": 48000,
      "chunks": 12,
      "format": "pcm",
      "sample_rate_hz": 24000
    }
  }
}
```

## Why This Matters

During voice mode evaluation work, we identified that understanding where time is spent is crucial for optimization. This helps users identify if their bottleneck is:

1. **Large audio files** → adjust recording length or compression settings
2. **Network latency** → switch to local Whisper instance
3. **Server processing** → try a smaller Whisper model

For example, if you see `audio 2631KB` with high STT time, you might want to enable compressed audio upload (VM-240) to reduce transfer time.

## Changes

- **simple_failover.py**: Added file size measurement, request timing, and metrics dict to STT result
- **converse.py**:
  - Extracts and displays STT metrics in timing output
  - Logs audio format, sample rate, bitrate when saving
  - Includes full metrics in STT_COMPLETE event log
  - Added `metrics_level` parameter (minimal/summary/verbose)
- **streaming.py**: Added TTS metrics to TTS_PLAYBACK_END event (streaming path)
- **core.py**: Added TTS metrics to TTS_PLAYBACK_END event (buffered path)
- **config.py**: Added VOICEMODE_METRICS_LEVEL configuration

### Metrics Level Options

| Level | Output | Use Case |
|-------|--------|----------|
| minimal | Just response text | Token-constrained contexts |
| summary | Response + compact timing (default) | Normal operation |
| verbose | Response + detailed breakdown | Debugging/analysis |

## Test plan

- [x] Verify metrics appear in STT success logs
- [x] Confirm audio size shows in converse timing output
- [x] Confirm format/sample rate/bitrate logged when audio saved
- [ ] Confirm metrics appear in event log (requires MCP restart)
- [x] Check no performance regression from instrumentation
- [x] Verify metrics_level parameter works

🤖 Generated with [Claude Code](https://claude.com/claude-code)