### PR TITLE
feat: skip audio compression for local STT endpoints (VM-245)

### DIFF
--- a/tests/test_stt_local_compression_skip.py
+++ b/tests/test_stt_local_compression_skip.py
@@ -1,0 +1,225 @@
+"""Test that STT compression is skipped for local endpoints."""
+
+import tempfile
+import asyncio
+from pathlib import Path
+import numpy as np
+import pytest
+from unittest.mock import patch, MagicMock, AsyncMock
+
+from voice_mode.tools.converse import speech_to_text
+from voice_mode import config
+
+
+@pytest.mark.asyncio
+async def test_stt_skips_compression_for_local_endpoint():
+    """Test that STT skips compression when primary endpoint is local (auto mode)."""
+
+    # Create test audio data (1 second of silence at 24kHz to match SAMPLE_RATE)
+    sample_rate = 24000
+    audio_data = np.zeros(sample_rate, dtype=np.int16)
+
+    # Track what format was used
+    format_used = None
+
+    def capture_format(audio_data, output_format):
+        nonlocal format_used
+        format_used = output_format
+        # Return minimal valid audio bytes
+        import io
+        from pydub import AudioSegment
+        audio = AudioSegment(
+            audio_data.tobytes(),
+            frame_rate=sample_rate,
+            sample_width=2,
+            channels=1
+        )
+        buffer = io.BytesIO()
+        if output_format == "wav":
+            audio.export(buffer, format="wav")
+        else:
+            audio.export(buffer, format="mp3", bitrate="32k")
+        return buffer.getvalue()
+
+    # Mock local endpoint as primary with auto mode (default)
+    with patch('voice_mode.config.STT_BASE_URLS', ['http://127.0.0.1:2022/v1']), \
+         patch('voice_mode.config.STT_COMPRESS', 'auto'), \
+         patch('voice_mode.tools.converse.prepare_audio_for_stt', side_effect=capture_format), \
+         patch('voice_mode.simple_failover.simple_stt_failover', new_callable=AsyncMock) as mock_stt:
+
+        mock_stt.return_value = {"text": "Test", "provider": "whisper", "endpoint": "http://127.0.0.1:2022/v1"}
+
+        await speech_to_text(
+            audio_data=audio_data,
+            save_audio=False,
+            audio_dir=None,
+            transport="local"
+        )
+
+        # Verify WAV format was used (no compression)
+        assert format_used == "wav", f"Expected 'wav' for local endpoint in auto mode, got '{format_used}'"
+
+
+@pytest.mark.asyncio
+async def test_stt_compresses_for_remote_endpoint():
+    """Test that STT compresses when primary endpoint is remote (auto mode)."""
+
+    sample_rate = 24000
+    audio_data = np.zeros(sample_rate, dtype=np.int16)
+
+    format_used = None
+
+    def capture_format(audio_data, output_format):
+        nonlocal format_used
+        format_used = output_format
+        import io
+        from pydub import AudioSegment
+        audio = AudioSegment(
+            audio_data.tobytes(),
+            frame_rate=sample_rate,
+            sample_width=2,
+            channels=1
+        )
+        buffer = io.BytesIO()
+        if output_format == "wav":
+            audio.export(buffer, format="wav")
+        else:
+            audio.export(buffer, format="mp3", bitrate="32k")
+        return buffer.getvalue()
+
+    # Mock remote endpoint as primary with auto mode
+    with patch('voice_mode.config.STT_BASE_URLS', ['https://api.openai.com/v1']), \
+         patch('voice_mode.config.STT_COMPRESS', 'auto'), \
+         patch('voice_mode.tools.converse.STT_AUDIO_FORMAT', 'mp3'), \
+         patch('voice_mode.tools.converse.prepare_audio_for_stt', side_effect=capture_format), \
+         patch('voice_mode.simple_failover.simple_stt_failover', new_callable=AsyncMock) as mock_stt:
+
+        mock_stt.return_value = {"text": "Test", "provider": "openai", "endpoint": "https://api.openai.com/v1"}
+
+        await speech_to_text(
+            audio_data=audio_data,
+            save_audio=False,
+            audio_dir=None,
+            transport="local"
+        )
+
+        # Verify MP3 format was used (compression enabled)
+        assert format_used == "mp3", f"Expected 'mp3' for remote endpoint in auto mode, got '{format_used}'"
+
+
+@pytest.mark.asyncio
+async def test_stt_always_mode_compresses_local():
+    """Test that STT_COMPRESS=always compresses even for local endpoints."""
+
+    sample_rate = 24000
+    audio_data = np.zeros(sample_rate, dtype=np.int16)
+
+    format_used = None
+
+    def capture_format(audio_data, output_format):
+        nonlocal format_used
+        format_used = output_format
+        import io
+        from pydub import AudioSegment
+        audio = AudioSegment(
+            audio_data.tobytes(),
+            frame_rate=sample_rate,
+            sample_width=2,
+            channels=1
+        )
+        buffer = io.BytesIO()
+        if output_format == "wav":
+            audio.export(buffer, format="wav")
+        else:
+            audio.export(buffer, format="mp3", bitrate="32k")
+        return buffer.getvalue()
+
+    # Mock local endpoint BUT with always mode
+    with patch('voice_mode.config.STT_BASE_URLS', ['http://127.0.0.1:2022/v1']), \
+         patch('voice_mode.config.STT_COMPRESS', 'always'), \
+         patch('voice_mode.tools.converse.STT_AUDIO_FORMAT', 'mp3'), \
+         patch('voice_mode.tools.converse.prepare_audio_for_stt', side_effect=capture_format), \
+         patch('voice_mode.simple_failover.simple_stt_failover', new_callable=AsyncMock) as mock_stt:
+
+        mock_stt.return_value = {"text": "Test", "provider": "whisper", "endpoint": "http://127.0.0.1:2022/v1"}
+
+        await speech_to_text(
+            audio_data=audio_data,
+            save_audio=False,
+            audio_dir=None,
+            transport="local"
+        )
+
+        # Verify MP3 format was used despite local endpoint (always mode)
+        assert format_used == "mp3", f"Expected 'mp3' with always mode, got '{format_used}'"
+
+
+@pytest.mark.asyncio
+async def test_stt_never_mode_skips_compression_for_remote():
+    """Test that STT_COMPRESS=never skips compression even for remote endpoints."""
+
+    sample_rate = 24000
+    audio_data = np.zeros(sample_rate, dtype=np.int16)
+
+    format_used = None
+
+    def capture_format(audio_data, output_format):
+        nonlocal format_used
+        format_used = output_format
+        import io
+        from pydub import AudioSegment
+        audio = AudioSegment(
+            audio_data.tobytes(),
+            frame_rate=sample_rate,
+            sample_width=2,
+            channels=1
+        )
+        buffer = io.BytesIO()
+        if output_format == "wav":
+            audio.export(buffer, format="wav")
+        else:
+            audio.export(buffer, format="mp3", bitrate="32k")
+        return buffer.getvalue()
+
+    # Mock remote endpoint BUT with never mode
+    with patch('voice_mode.config.STT_BASE_URLS', ['https://api.openai.com/v1']), \
+         patch('voice_mode.config.STT_COMPRESS', 'never'), \
+         patch('voice_mode.tools.converse.prepare_audio_for_stt', side_effect=capture_format), \
+         patch('voice_mode.simple_failover.simple_stt_failover', new_callable=AsyncMock) as mock_stt:
+
+        mock_stt.return_value = {"text": "Test", "provider": "openai", "endpoint": "https://api.openai.com/v1"}
+
+        await speech_to_text(
+            audio_data=audio_data,
+            save_audio=False,
+            audio_dir=None,
+            transport="local"
+        )
+
+        # Verify WAV format was used despite remote endpoint (never mode)
+        assert format_used == "wav", f"Expected 'wav' with never mode, got '{format_used}'"
+
+
+@pytest.mark.asyncio
+async def test_is_local_provider_detection():
+    """Test that is_local_provider correctly identifies local endpoints."""
+    from voice_mode.provider_discovery import is_local_provider
+
+    # Local endpoints
+    assert is_local_provider("http://127.0.0.1:2022/v1") == True
+    assert is_local_provider("http://localhost:2022/v1") == True
+    assert is_local_provider("http://127.0.0.1:8880/v1") == True  # Kokoro
+    assert is_local_provider("http://localhost:8880/v1") == True
+
+    # Remote endpoints
+    assert is_local_provider("https://api.openai.com/v1") == False
+    assert is_local_provider("https://custom.cloud.service/v1") == False
+
+
+if __name__ == "__main__":
+    asyncio.run(test_stt_skips_compression_for_local_endpoint())
+    asyncio.run(test_stt_compresses_for_remote_endpoint())
+    asyncio.run(test_stt_always_mode_compresses_local())
+    asyncio.run(test_stt_never_mode_skips_compression_for_remote())
+    asyncio.run(test_is_local_provider_detection())
+    print("All tests passed!")

--- a/voice_mode/config.py
+++ b/voice_mode/config.py
@@ -647,6 +647,20 @@ STT_AUDIO_FORMAT = os.getenv("VOICEMODE_STT_AUDIO_FORMAT", "mp3" if AUDIO_FORMAT
 # Default: wav (uncompressed, full quality)
 STT_SAVE_FORMAT = os.getenv("VOICEMODE_STT_SAVE_FORMAT", "wav").lower()
 
+# STT compression mode - controls when audio is compressed before upload
+# Options:
+#   auto   - Compress for remote endpoints, skip for local (default)
+#            Saves ~200-800ms transcode time for local endpoints where
+#            bandwidth isn't a bottleneck. Remote uploads benefit from
+#            smaller file sizes (MP3 is ~90% smaller than WAV).
+#   always - Always compress regardless of endpoint type
+#   never  - Never compress, always send WAV (highest quality, larger files)
+STT_COMPRESS = os.getenv("VOICEMODE_STT_COMPRESS", "auto").lower()
+
+# Validate STT_COMPRESS value
+if STT_COMPRESS not in ("auto", "always", "never"):
+    STT_COMPRESS = "auto"
+
 # Supported audio formats
 SUPPORTED_AUDIO_FORMATS = ["pcm", "opus", "mp3", "wav", "flac", "aac"]
 SUPPORTED_SAVE_FORMATS = ["wav", "mp3", "flac"]  # Formats suitable for saving recordings


### PR DESCRIPTION
## Summary

- Automatically skip MP3 compression for local STT endpoints (localhost, 127.0.0.1, LAN)
- Saves ~200-800ms transcode time when local bandwidth isn't a bottleneck
- Add configurable `VOICEMODE_STT_COMPRESS` option with three modes:
  - `auto` (default): compress for remote, skip for local
  - `always`: always compress regardless of endpoint type
  - `never`: never compress, always send WAV

## Context

From VM-243 evaluation testing:
- Remote (OpenAI): MP3 60% faster due to upload time savings
- Local (Whisper): All formats had same speed, transcode overhead was wasted

## Test plan

- [x] Unit tests for all three STT_COMPRESS modes (auto/always/never)
- [x] Test is_local_provider detection for localhost, 127.0.0.1, and remote URLs
- [x] Full test suite passes (679 tests)
- [ ] Manual test with local Whisper endpoint
- [ ] Manual test with remote OpenAI endpoint

🤖 Generated with [Claude Code](https://claude.com/claude-code)