### PR TITLE
docs: remove deprecated bash installer from SKILL.md

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -228,10 +228,7 @@ voicemode config set VOICEMODE_TTS_VOICE nova
 
 ### Quick Install
 ```bash
-# Install VoiceMode package
-curl -sL https://voicemode.ai/install.sh | bash
-
-# Or with UV
+# Install VoiceMode using the Python installer
 uv tool install voice-mode-install
 voice-mode-install
 


### PR DESCRIPTION
## Summary
- Update Quick Install section to only show the Python installer method (`uv tool install voice-mode-install`)
- Remove deprecated `curl -sL https://voicemode.ai/install.sh | bash` reference
- Created VM-255 to track archiving the deprecated installer files

## Test plan
- [x] Verify SKILL.md renders correctly
- [x] Confirm Python installer instructions are clear

🤖 Generated with [Claude Code](https://claude.com/claude-code)