### PR TITLE
feat(installer): add telemetry opt-in prompt to Python installer (VM-256)

### DIFF
--- a/voice_mode/config.py
+++ b/voice_mode/config.py
@@ -329,6 +329,18 @@ TTS \\bAPI\\b A P I # API as individual letters
 # VOICEMODE_SERVICE_AUTO_ENABLE=true
 
 #############
+# Telemetry (opt-in analytics to improve VoiceMode)
+#############
+
+# Enable telemetry: true, false (default: false - opt-in only)
+# - true: Send anonymous usage statistics
+# - false: Disable telemetry completely
+# VOICEMODE_TELEMETRY=false
+
+# Note: Setting DO_NOT_TRACK=1 in your environment also disables telemetry
+# Learn more: https://voicemode.dev/docs/privacy
+
+#############
 # Advanced Configuration
 #############
 


### PR DESCRIPTION
## Summary
- Add telemetry consent flow to the Python-based installer (`voice-mode-install`)
- VM-249/PR-142 incorrectly targeted the deprecated bash installer - this implements it properly
- Prompt appears after VoiceMode installation, before local services section

## Changes
- `installer/voicemode_install/cli.py`: Add `configure_telemetry_consent()` and `set_telemetry_preference()` functions
- `voice_mode/config.py`: Update voicemode.env template with telemetry section

## Features
- Respects `DO_NOT_TRACK` environment variable (universal opt-out standard)
- Respects existing `VOICEMODE_TELEMETRY` setting
- Defaults to disabled in non-interactive/`--yes` mode
- Saves preference to `~/.voicemode/voicemode.env`
- Clear privacy messaging with link to docs

## Test plan
- [x] Tested dry run mode - shows placeholder message
- [x] Tested non-interactive mode - defaults to disabled
- [x] Tested DO_NOT_TRACK - respects universal opt-out
- [x] Tested existing setting - skips prompt when already configured
- [x] Existing tests pass

## Related
- Supersedes VM-249/PR-142 (which targeted deprecated bash installer)
- Related to VM-152 (telemetry system)

🤖 Generated with [Claude Code](https://claude.com/claude-code)