### PR TITLE
fix: increase STT timeout from 30s to 60s

### DIFF
--- a/voice_mode/simple_failover.py
+++ b/voice_mode/simple_failover.py
@@ -220,7 +220,7 @@ async def simple_stt_failover(
             client = AsyncOpenAI(
                 api_key=api_key,
                 base_url=base_url,
-                timeout=30.0,
+                timeout=60.0,  # Allow time for slower transcriptions
                 max_retries=max_retries
             )
 


### PR DESCRIPTION
## Summary

- Increases STT timeout from 30s to 60s in `simple_failover.py`
- Whisper sometimes takes longer than 30s for complex/longer audio, causing transcription failures

## Test plan

- [x] All existing tests pass (678 passed)
- [ ] Manual verification with longer audio transcriptions

Refs: VM-325

🤖 Generated with [Claude Code](https://claude.com/claude-code)