### PR TITLE
chore: update release script to set plugin version with p0 suffix

### DIFF
--- a/scripts/release.py
+++ b/scripts/release.py
@@ -101,6 +101,15 @@ def update_version(new_version, packages=None):
         ):
             files_updated.append("installer/pyproject.toml")
 
+    # Update plugin.json with version + p0 suffix
+    plugin_version = f"{new_version}p0"
+    if update_version_in_file(
+        ".claude-plugin/plugin.json",
+        r'"version": "[^"]*"',
+        f'"version": "{plugin_version}"'
+    ):
+        files_updated.append(".claude-plugin/plugin.json")
+
     # Update CHANGELOG for all package updates
     if update_changelog(new_version):
         files_updated.append("CHANGELOG.md")
@@ -129,7 +138,7 @@ def commit_and_tag(version, packages=None):
         package_desc = "voice-mode"
 
     # Stage all changed files
-    files_to_add = ["CHANGELOG.md"]
+    files_to_add = ["CHANGELOG.md", ".claude-plugin/plugin.json"]
     if packages is None or "package" in packages:
         files_to_add.extend(["voice_mode/__version__.py", "server.json"])
     if packages is None or "installer" in packages:


### PR DESCRIPTION
## Summary

- Release script now automatically updates `.claude-plugin/plugin.json`
- Sets plugin version to `{package_version}p0` (e.g., 7.3.0 -> 7.3.0p0)
- Allows plugin-only updates to bump p1, p2, etc. without full package release

## Test plan

- [x] Tested with `--no-commit` dry run - plugin.json updated correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)