### PR TITLE
feat(VM-404): Conch wait mode for multi-agent coordination

### DIFF
--- a/tests/test_conch.py
+++ b/tests/test_conch.py
@@ -131,3 +131,59 @@ class TestConch:
         Conch.LOCK_FILE.write_text("not valid json {{{")
 
         assert Conch.is_active() is False
+
+
+class TestConchConfig:
+    """Tests for conch configuration options."""
+
+    def test_conch_enabled_default(self):
+        """CONCH_ENABLED defaults to True."""
+        from voice_mode.config import CONCH_ENABLED
+        # Default should be True (unless env var overrides)
+        assert isinstance(CONCH_ENABLED, bool)
+
+    def test_conch_timeout_default(self):
+        """CONCH_TIMEOUT defaults to 60 seconds."""
+        from voice_mode.config import CONCH_TIMEOUT
+        assert isinstance(CONCH_TIMEOUT, float)
+        assert CONCH_TIMEOUT == 60.0
+
+    def test_conch_check_interval_default(self):
+        """CONCH_CHECK_INTERVAL defaults to 0.5 seconds."""
+        from voice_mode.config import CONCH_CHECK_INTERVAL
+        assert isinstance(CONCH_CHECK_INTERVAL, float)
+        assert CONCH_CHECK_INTERVAL == 0.5
+
+    def test_conch_enabled_env_var(self):
+        """CONCH_ENABLED can be set via environment variable."""
+        import os
+        import importlib
+        import voice_mode.config
+
+        # Test with false
+        os.environ["VOICEMODE_CONCH_ENABLED"] = "false"
+        importlib.reload(voice_mode.config)
+        assert voice_mode.config.CONCH_ENABLED is False
+
+        # Test with true
+        os.environ["VOICEMODE_CONCH_ENABLED"] = "true"
+        importlib.reload(voice_mode.config)
+        assert voice_mode.config.CONCH_ENABLED is True
+
+        # Clean up
+        del os.environ["VOICEMODE_CONCH_ENABLED"]
+        importlib.reload(voice_mode.config)
+
+    def test_conch_timeout_env_var(self):
+        """CONCH_TIMEOUT can be set via environment variable."""
+        import os
+        import importlib
+        import voice_mode.config
+
+        os.environ["VOICEMODE_CONCH_TIMEOUT"] = "120"
+        importlib.reload(voice_mode.config)
+        assert voice_mode.config.CONCH_TIMEOUT == 120.0
+
+        # Clean up
+        del os.environ["VOICEMODE_CONCH_TIMEOUT"]
+        importlib.reload(voice_mode.config)

--- a/voice_mode/config.py
+++ b/voice_mode/config.py
@@ -475,6 +475,19 @@ ALWAYS_TRY_LOCAL = os.getenv("VOICEMODE_ALWAYS_TRY_LOCAL", "true").lower() in ("
 # Auto-start configuration
 AUTO_START_KOKORO = os.getenv("VOICEMODE_AUTO_START_KOKORO", "").lower() in ("true", "1", "yes", "on")
 
+# ==================== CONCH CONFIGURATION ====================
+# The conch is a coordination mechanism for multi-agent voice conversations
+# Only the agent holding the conch may speak
+
+# Enable/disable the conch system entirely
+CONCH_ENABLED = os.getenv("VOICEMODE_CONCH_ENABLED", "true").lower() in ("true", "1", "yes", "on")
+
+# Maximum time (seconds) to wait for conch when wait_for_conch=true
+CONCH_TIMEOUT = float(os.getenv("VOICEMODE_CONCH_TIMEOUT", "60"))
+
+# How often (seconds) to check if conch is free when waiting
+CONCH_CHECK_INTERVAL = float(os.getenv("VOICEMODE_CONCH_CHECK_INTERVAL", "0.5"))
+
 # ==================== SERVICE CONFIGURATION ====================
 
 # OpenAI configuration


### PR DESCRIPTION
## Summary
- Add `wait_for_conch` parameter to converse tool for multi-agent coordination
- Agents can now politely wait their turn when another agent is speaking
- Configurable timeout and polling interval via environment variables

## Changes
- **Default behavior** (`wait_for_conch=false`): If conch is busy, return status info immediately ("User is currently speaking with X...")
- **Wait mode** (`wait_for_conch=true`): Poll until conch is free, then speak
- **Config options**: CONCH_ENABLED, CONCH_TIMEOUT (60s), CONCH_CHECK_INTERVAL (0.5s)

## Test plan
- [x] Unit tests for config options pass
- [x] All 16 conch tests pass
- [ ] Manual test: two agents, one waits for the other

Related to VM-326 (The Conch epic), builds on VM-399 (conch lock file).

🤖 Generated with [Claude Code](https://claude.com/claude-code)