### PR TITLE
fix(installer): Show warning when model download fails

### DIFF
--- a/voice_mode/cli.py
+++ b/voice_mode/cli.py
@@ -415,6 +415,14 @@ def whisper_service_install(install_dir, model, use_gpu, force, version, auto_en
             click.echo("\nNext steps:")
             for step in result['next_steps']:
                 click.echo(f"   - {step}")
+
+        # Show warning if model download failed (GH-174)
+        if result.get('model_error'):
+            click.echo()
+            click.secho("⚠️  Model download failed:", fg='yellow', bold=True)
+            click.secho(f"   {result['model_error']}", fg='yellow')
+            click.echo("   Whisper won't work without a model.")
+            click.echo("   Try: voicemode whisper model install")
     else:
         click.echo(f"❌ Installation failed: {result.get('error', 'Unknown error')}")
         if result.get('details'):

--- a/voice_mode/tools/whisper/install.py
+++ b/voice_mode/tools/whisper/install.py
@@ -639,13 +639,16 @@ async def whisper_install(
                 logger.warning(f"Failed to download model: {download_result.get('error', 'Unknown error')}")
                 logger.info("You can download models later using 'voicemode whisper model install'")
                 model_path = None
+                model_error = download_result.get('error', 'Unknown error')
             else:
                 model_path = download_result["path"]
+                model_error = None
                 if download_result.get("core_ml_status", {}).get("success"):
                     logger.info(f"✅ Core ML model downloaded for 2-3x faster performance!")
         else:
             logger.info("Skipping model download (--no-model specified)")
             model_path = None
+            model_error = None
         
         # Test whisper with sample if available (only if we have a model)
         # With CMake build, binaries are in build/bin/
@@ -693,6 +696,7 @@ async def whisper_install(
                 "success": True,
                 "install_path": install_dir,
                 "model_path": model_path,
+                "model_error": model_error,
                 "gpu_enabled": use_gpu,
                 "gpu_type": gpu_type,
                 "version": current_version,
@@ -718,6 +722,7 @@ async def whisper_install(
                 "success": True,
                 "install_path": install_dir,
                 "model_path": model_path,
+                "model_error": model_error,
                 "gpu_enabled": use_gpu,
                 "gpu_type": gpu_type,
                 "version": current_version,
@@ -741,6 +746,7 @@ async def whisper_install(
                 "success": True,
                 "install_path": install_dir,
                 "model_path": model_path,
+                "model_error": model_error,
                 "gpu_enabled": use_gpu,
                 "gpu_type": gpu_type,
                 "version": current_version,


### PR DESCRIPTION
## Summary
- Show clear warning when whisper model download fails but install succeeds
- Add `model_error` field to install result dicts
- CLI displays yellow warning box with error message and recovery suggestion

Closes #174

## Problem
When running `voicemode whisper install`, if the model download fails (e.g., SSL certificate error), the installer incorrectly reports success. Users then find whisper doesn't work because no model is present.

## Solution
Track model download errors separately from overall install success. The CLI now shows:
```
✅ Whisper installed successfully!
   Install path: /path/to/whisper

⚠️  Model download failed:
   [SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed
   Whisper won't work without a model.
   Try: voicemode whisper model install
```

## Test plan
- [x] All 592 existing tests pass
- [x] Code review of changes
- [ ] Manual test on machine with SSL certificate issues (optional)

🤖 Generated with [Claude Code](https://claude.com/claude-code)