### PR TITLE
fix(VM-411): Create venv during kokoro install for fresh systems

### DIFF
--- a/voice_mode/tools/kokoro/install.py
+++ b/voice_mode/tools/kokoro/install.py
@@ -303,7 +303,14 @@ async def kokoro_install(
                     "success": False,
                     "error": f"Failed to checkout version {version}"
                 }
-        
+
+        # Create virtual environment if it doesn't exist (GH-145)
+        # The kokoro-fastapi start scripts use `uv pip install` which requires a venv
+        venv_path = os.path.join(install_dir, ".venv")
+        if not os.path.exists(venv_path):
+            logger.info("Creating virtual environment for kokoro...")
+            subprocess.run(["uv", "venv"], cwd=install_dir, check=True)
+
         # Determine system and select appropriate start script
         system = platform.system()
         if system == "Darwin":


### PR DESCRIPTION
## Summary
- Creates virtual environment during kokoro install if one doesn't exist
- Fixes installation failure on fresh Linux systems (PopOS/Ubuntu 24)

## Problem
The kokoro-fastapi start scripts use `uv pip install` which requires an existing virtual environment. On fresh Linux installations, there's no pre-existing venv, causing the error:
```
error: No virtual environment found; run `uv venv` to create an environment
```

## Solution
After cloning and checking out the version, check if `.venv` exists in the install directory. If not, create it with `uv venv`. This is idempotent - existing installations are unaffected.

## Test plan
- [ ] Test fresh install on Ubuntu/PopOS VM
- [ ] Verify existing macOS installs still work
- [ ] Verify re-install doesn't recreate venv unnecessarily

Fixes #145

🤖 Generated with [Claude Code](https://claude.com/claude-code)