### PR TITLE
docs: add mpv-dj location note to DJ Mode section

### DIFF
--- a/skills/voicemode/SKILL.md
+++ b/skills/voicemode/SKILL.md
@@ -118,6 +118,8 @@ See [Configuration Guide](../../docs/guides/configuration.md) for all options.
 
 Background music during VoiceMode sessions with track-level control.
 
+**Location:** The `mpv-dj` script lives in `bin/mpv-dj` within this skill directory.
+
 ```bash
 mpv-dj mfp 49           # Play Music For Programming episode
 mpv-dj status           # What's playing


### PR DESCRIPTION
## Summary
- Adds a note to the DJ Mode section clarifying that mpv-dj lives in `bin/mpv-dj` within the skill directory

This helps users find the script when it's not on their PATH.

🤖 Generated with [Claude Code](https://claude.com/claude-code)