### PR TITLE
feat(VM-462): Add --transport option to serve command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,21 +9,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- **Support for All Claude Products** (VM-434, VM-458)
+- **Support for All Claude Products** (VM-434, VM-458, VM-462)
   - VoiceMode now works with Claude.ai, Claude Desktop, Claude Cowork, and Claude Mobile
-  - New `voicemode serve` command exposes VoiceMode as HTTP/SSE MCP server
+  - New `voicemode serve` command exposes VoiceMode as HTTP MCP server
+  - **Transport options:**
+    - `--transport` / `-t` to select protocol: `streamable-http` (default) or `sse`
+    - `streamable-http` uses `/mcp` endpoint (recommended)
+    - `sse` uses `/sse` endpoint (deprecated, shows warning)
   - **Security options:**
     - `--allow-anthropic` to allow Anthropic's outbound IP ranges (160.79.104.0/21)
     - `--allow-tailscale` to allow Tailscale network ranges (100.64.0.0/10)
     - `--allow-ip` to add custom CIDR ranges to allowlist (repeatable)
     - `--allow-local/--no-allow-local` to control localhost access (default: true)
-    - `--secret` for URL path authentication (endpoint becomes `/sse/{secret}`)
+    - `--secret` for URL path authentication (endpoint becomes `/{base}/{secret}`)
     - `--token` for Bearer token authentication
     - Defense in depth: IP allowlist and token auth can be combined
   - **Operational features:**
     - Access logging with X-Forwarded-For header support for proxy deployments
     - Environment variable configuration via `voicemode.env`
-    - `VOICEMODE_ALLOW_TAILSCALE` and `VOICEMODE_TRANSPORT` env vars
+    - `VOICEMODE_SERVE_TRANSPORT`, `VOICEMODE_ALLOW_TAILSCALE` env vars
 
 - **Multi-Agent Voice Coordination** (VM-399, VM-404, VM-405)
   - Conch lock file at `~/.voicemode/conch` signals when voice conversation is active

--- a/tests/test_serve.py
+++ b/tests/test_serve.py
@@ -1,0 +1,295 @@
+"""Unit tests for the VoiceMode serve command.
+
+Tests for:
+- Default transport is streamable-http
+- --transport sse selects SSE
+- Deprecation warning appears for SSE
+- Environment variable VOICEMODE_SERVE_TRANSPORT is respected
+- CLI --transport overrides environment variable
+"""
+
+import os
+import pytest
+from unittest.mock import patch, MagicMock
+from click.testing import CliRunner
+
+
+class TestServeTransportOption:
+    """Tests for the serve command --transport option."""
+
+    def test_serve_help_shows_transport_option(self):
+        """Test that serve --help shows the transport option."""
+        from voice_mode.cli import voice_mode_main_cli
+
+        runner = CliRunner()
+        result = runner.invoke(voice_mode_main_cli, ['serve', '--help'])
+
+        assert result.exit_code == 0
+        assert '--transport' in result.output or '-t' in result.output
+        assert 'streamable-http' in result.output
+        assert 'sse' in result.output
+        assert 'deprecated' in result.output.lower()
+
+    def test_default_transport_is_streamable_http(self):
+        """Test that default transport is streamable-http."""
+        # Clear any existing env var to test the default
+        env_backup = os.environ.get("VOICEMODE_SERVE_TRANSPORT")
+        try:
+            # Remove env var if it exists
+            if "VOICEMODE_SERVE_TRANSPORT" in os.environ:
+                del os.environ["VOICEMODE_SERVE_TRANSPORT"]
+
+            # Need to reimport to get fresh config values
+            import importlib
+            import voice_mode.config
+            importlib.reload(voice_mode.config)
+
+            assert voice_mode.config.SERVE_TRANSPORT == "streamable-http"
+        finally:
+            # Restore env var
+            if env_backup is not None:
+                os.environ["VOICEMODE_SERVE_TRANSPORT"] = env_backup
+
+    def test_env_var_changes_default(self):
+        """Test that VOICEMODE_SERVE_TRANSPORT env var is respected."""
+        env_backup = os.environ.get("VOICEMODE_SERVE_TRANSPORT")
+        try:
+            os.environ["VOICEMODE_SERVE_TRANSPORT"] = "sse"
+            import importlib
+            import voice_mode.config
+            importlib.reload(voice_mode.config)
+
+            assert voice_mode.config.SERVE_TRANSPORT == "sse"
+        finally:
+            # Restore env var
+            if env_backup is not None:
+                os.environ["VOICEMODE_SERVE_TRANSPORT"] = env_backup
+            elif "VOICEMODE_SERVE_TRANSPORT" in os.environ:
+                del os.environ["VOICEMODE_SERVE_TRANSPORT"]
+            # Reload to reset
+            import importlib
+            import voice_mode.config
+            importlib.reload(voice_mode.config)
+
+    def test_transport_option_streamable_http(self):
+        """Test that --transport streamable-http uses /mcp path."""
+        from voice_mode.cli import voice_mode_main_cli
+
+        runner = CliRunner()
+
+        # Create a mock for the mcp object that will be imported
+        mock_mcp = MagicMock()
+        mock_app = MagicMock()
+        mock_mcp.http_app.return_value = mock_app
+
+        # Patch at the import location in voice_mode.cli
+        with patch.dict('sys.modules', {'voice_mode.server': MagicMock(mcp=mock_mcp)}):
+            with patch('uvicorn.run') as mock_uvicorn:
+                result = runner.invoke(
+                    voice_mode_main_cli,
+                    ['serve', '--transport', 'streamable-http']
+                )
+
+                # Check output contains /mcp path
+                assert '/mcp' in result.output
+                # Check it says Transport: streamable-http
+                assert 'streamable-http' in result.output
+
+    def test_transport_option_sse(self):
+        """Test that --transport sse uses /sse path."""
+        from voice_mode.cli import voice_mode_main_cli
+
+        runner = CliRunner()
+
+        mock_mcp = MagicMock()
+        mock_app = MagicMock()
+        mock_mcp.http_app.return_value = mock_app
+
+        with patch.dict('sys.modules', {'voice_mode.server': MagicMock(mcp=mock_mcp)}):
+            with patch('uvicorn.run') as mock_uvicorn:
+                result = runner.invoke(
+                    voice_mode_main_cli,
+                    ['serve', '--transport', 'sse']
+                )
+
+                # Check output contains /sse path
+                assert '/sse' in result.output
+
+    def test_sse_transport_shows_deprecation_warning(self):
+        """Test that using SSE transport shows deprecation warning."""
+        from voice_mode.cli import voice_mode_main_cli
+
+        runner = CliRunner()
+
+        mock_mcp = MagicMock()
+        mock_app = MagicMock()
+        mock_mcp.http_app.return_value = mock_app
+
+        with patch.dict('sys.modules', {'voice_mode.server': MagicMock(mcp=mock_mcp)}):
+            with patch('uvicorn.run') as mock_uvicorn:
+                result = runner.invoke(
+                    voice_mode_main_cli,
+                    ['serve', '--transport', 'sse']
+                )
+
+                # Check output for the deprecation warning
+                combined_output = result.output
+                assert 'Warning' in combined_output or 'deprecated' in combined_output.lower()
+
+    def test_streamable_http_no_deprecation_warning(self):
+        """Test that using streamable-http does NOT show deprecation warning."""
+        from voice_mode.cli import voice_mode_main_cli
+
+        runner = CliRunner()
+
+        mock_mcp = MagicMock()
+        mock_app = MagicMock()
+        mock_mcp.http_app.return_value = mock_app
+
+        with patch.dict('sys.modules', {'voice_mode.server': MagicMock(mcp=mock_mcp)}):
+            with patch('uvicorn.run') as mock_uvicorn:
+                result = runner.invoke(
+                    voice_mode_main_cli,
+                    ['serve', '--transport', 'streamable-http']
+                )
+
+                # Check that deprecation warning is NOT in output
+                output = result.output
+                assert 'SSE transport is deprecated' not in output
+
+    def test_cli_transport_overrides_env_var(self):
+        """Test that CLI --transport option overrides env var."""
+        from voice_mode.cli import voice_mode_main_cli
+
+        runner = CliRunner()
+
+        # Set env var to streamable-http but use CLI to specify sse
+        env_backup = os.environ.get("VOICEMODE_SERVE_TRANSPORT")
+        try:
+            os.environ["VOICEMODE_SERVE_TRANSPORT"] = "streamable-http"
+
+            mock_mcp = MagicMock()
+            mock_app = MagicMock()
+            mock_mcp.http_app.return_value = mock_app
+
+            with patch.dict('sys.modules', {'voice_mode.server': MagicMock(mcp=mock_mcp)}):
+                with patch('uvicorn.run') as mock_uvicorn:
+                    result = runner.invoke(
+                        voice_mode_main_cli,
+                        ['serve', '--transport', 'sse']
+                    )
+
+                    # CLI should override env var - output should show /sse
+                    assert '/sse' in result.output
+        finally:
+            if env_backup is not None:
+                os.environ["VOICEMODE_SERVE_TRANSPORT"] = env_backup
+            elif "VOICEMODE_SERVE_TRANSPORT" in os.environ:
+                del os.environ["VOICEMODE_SERVE_TRANSPORT"]
+
+    def test_short_option_t_works(self):
+        """Test that -t short option works for transport."""
+        from voice_mode.cli import voice_mode_main_cli
+
+        runner = CliRunner()
+
+        mock_mcp = MagicMock()
+        mock_app = MagicMock()
+        mock_mcp.http_app.return_value = mock_app
+
+        with patch.dict('sys.modules', {'voice_mode.server': MagicMock(mcp=mock_mcp)}):
+            with patch('uvicorn.run') as mock_uvicorn:
+                result = runner.invoke(
+                    voice_mode_main_cli,
+                    ['serve', '-t', 'sse']
+                )
+
+                # Should work with short option and show /sse
+                assert '/sse' in result.output
+
+    def test_invalid_transport_rejected(self):
+        """Test that invalid transport value is rejected."""
+        from voice_mode.cli import voice_mode_main_cli
+
+        runner = CliRunner()
+
+        result = runner.invoke(
+            voice_mode_main_cli,
+            ['serve', '--transport', 'invalid-transport']
+        )
+
+        # Click should reject invalid choices
+        assert result.exit_code != 0
+        assert 'invalid-transport' in result.output.lower() or 'invalid' in result.output.lower()
+
+    def test_transport_affects_displayed_endpoint(self):
+        """Test that transport selection affects displayed endpoint path."""
+        from voice_mode.cli import voice_mode_main_cli
+
+        runner = CliRunner()
+
+        mock_mcp = MagicMock()
+        mock_app = MagicMock()
+        mock_mcp.http_app.return_value = mock_app
+
+        with patch.dict('sys.modules', {'voice_mode.server': MagicMock(mcp=mock_mcp)}):
+            with patch('uvicorn.run') as mock_uvicorn:
+                # Test streamable-http shows /mcp
+                result = runner.invoke(
+                    voice_mode_main_cli,
+                    ['serve', '--transport', 'streamable-http']
+                )
+                assert '/mcp' in result.output
+
+        with patch.dict('sys.modules', {'voice_mode.server': MagicMock(mcp=mock_mcp)}):
+            with patch('uvicorn.run') as mock_uvicorn:
+                # Test sse shows /sse
+                result = runner.invoke(
+                    voice_mode_main_cli,
+                    ['serve', '--transport', 'sse']
+                )
+                assert '/sse' in result.output
+
+
+class TestServeTransportWithSecret:
+    """Tests for transport option combined with secret path."""
+
+    def test_streamable_http_with_secret(self):
+        """Test that streamable-http with secret uses /mcp/secret path."""
+        from voice_mode.cli import voice_mode_main_cli
+
+        runner = CliRunner()
+
+        mock_mcp = MagicMock()
+        mock_app = MagicMock()
+        mock_mcp.http_app.return_value = mock_app
+
+        with patch.dict('sys.modules', {'voice_mode.server': MagicMock(mcp=mock_mcp)}):
+            with patch('uvicorn.run') as mock_uvicorn:
+                result = runner.invoke(
+                    voice_mode_main_cli,
+                    ['serve', '--transport', 'streamable-http', '--secret', 'mysecret']
+                )
+
+                # Output should show /mcp/mysecret
+                assert '/mcp/mysecret' in result.output
+
+    def test_sse_with_secret(self):
+        """Test that sse with secret uses /sse/secret path."""
+        from voice_mode.cli import voice_mode_main_cli
+
+        runner = CliRunner()
+
+        mock_mcp = MagicMock()
+        mock_app = MagicMock()
+        mock_mcp.http_app.return_value = mock_app
+
+        with patch.dict('sys.modules', {'voice_mode.server': MagicMock(mcp=mock_mcp)}):
+            with patch('uvicorn.run') as mock_uvicorn:
+                result = runner.invoke(
+                    voice_mode_main_cli,
+                    ['serve', '--transport', 'sse', '--secret', 'mysecret']
+                )
+
+                # Output should show /sse/mysecret
+                assert '/sse/mysecret' in result.output

--- a/voice_mode/config.py
+++ b/voice_mode/config.py
@@ -1227,8 +1227,8 @@ SERVE_SECRET = os.getenv("VOICEMODE_SERVE_SECRET", "")
 # Bearer token for authentication (default: empty/disabled)
 SERVE_TOKEN = os.getenv("VOICEMODE_SERVE_TOKEN", "")
 
-# Transport protocol for serve command (streamable-http or sse, default: sse for backwards compat)
-SERVE_TRANSPORT = os.getenv("VOICEMODE_SERVE_TRANSPORT", "sse")
+# Transport protocol (streamable-http or sse)
+SERVE_TRANSPORT = os.getenv("VOICEMODE_SERVE_TRANSPORT", "streamable-http")
 
 # ==================== THINK OUT LOUD CONFIGURATION ====================
 


### PR DESCRIPTION
## Summary
- Adds `--transport` / `-t` option to select MCP transport protocol
- `streamable-http`: Default, recommended transport using `/mcp` endpoint
- `sse`: Server-Sent Events transport using `/sse` endpoint (deprecated)
- SSE transport shows deprecation warning
- `VOICEMODE_SERVE_TRANSPORT` environment variable to configure default transport
- Works with all existing serve options (security, port, host, etc.)

## Test plan
- [x] Unit tests for transport option selection (13 tests pass)
- [ ] Manual test with Claude Desktop using streamable-http
- [ ] Manual test with Claude.ai using streamable-http

🤖 Generated with [Claude Code](https://claude.com/claude-code)