### PR TITLE
fix(VM-464): add WorkingDirectory to Kokoro systemd template

### DIFF
--- a/voice_mode/templates/systemd/voicemode-kokoro.service
+++ b/voice_mode/templates/systemd/voicemode-kokoro.service
@@ -1,5 +1,5 @@
-# voicemode-kokoro.service v1.2.0
-# Last updated: 2025-12-01
+# voicemode-kokoro.service v1.2.1
+# Last updated: 2026-01-20
 # Compatible with: kokoro-fastapi v1.0.0+
 # Simplified: start script handles config via voicemode.env
 
@@ -10,6 +10,7 @@ After=network.target
 [Service]
 Type=simple
 ExecStart={START_SCRIPT}
+WorkingDirectory={KOKORO_DIR}
 Restart=on-failure
 RestartSec=10
 # Don't restart if the executable is missing


### PR DESCRIPTION
## Summary
- Adds missing `WorkingDirectory={KOKORO_DIR}` to the Linux systemd template for Kokoro
- Fixes an issue where `start-cpu.sh` fails on Linux because it relies on pwd being correct
- Brings systemd template to parity with macOS launchd template (which already has WorkingDirectory)

## Background
User @mchmielek [reported](https://github.com/mbailey/voicemode/issues/188#issuecomment-2600808161) needing to manually patch Kokoro's start-cpu.sh on Linux Mint. The root cause was our systemd template not setting the working directory, unlike our launchd template.

## Test plan
- [ ] Test on Linux system: `systemctl --user restart voicemode-kokoro`
- [ ] Verify Kokoro starts without manual script patches
- [ ] Verify TTS endpoint responds: `curl http://localhost:8880/health`

Fixes #188

🤖 Generated with [Claude Code](https://claude.com/claude-code)