### PR TITLE
Fix command syntax in install skill instructions

### DIFF
--- a/.claude/commands/install.md
+++ b/.claude/commands/install.md
@@ -13,8 +13,8 @@ For a fast, fully automated install on Apple Silicon:
 
 ```bash
 uvx voice-mode-install --yes
-voicemode whisper service install
-voicemode kokoro install
+voicemode service install whisper
+voicemode service install kokoro
 ```
 
 ## What Gets Installed
@@ -42,14 +42,14 @@ voicemode kokoro install
    uvx voice-mode-install --yes
 
    # Install local services
-   voicemode whisper service install
-   voicemode kokoro install
+   voicemode service install whisper
+   voicemode service install kokoro
    ```
 
 4. **Verify services are running:**
    ```bash
-   voicemode whisper service status
-   voicemode kokoro status
+   voicemode service status whisper
+   voicemode service status kokoro
    ```
 
 5. **Reconnect MCP server:**


### PR DESCRIPTION
## Summary

Updates the `/voicemode:install` skill instructions to use the correct command format for service management.

## Changes

- `voicemode whisper service install` → `voicemode service install whisper`
- `voicemode kokoro install` → `voicemode service install kokoro`  
- `voicemode whisper service status` → `voicemode service status whisper`
- `voicemode kokoro status` → `voicemode service status kokoro`

## Why

The skill instructions had outdated command syntax. The correct format matches:
- `docs/tutorials/getting-started.md`
- `installer/voicemode_install/cli.py` (lines 434, 455)

## Related

Fixes part of #203

---

🤖 Generated with [Claude Code](https://claude.ai/code)