### PR TITLE
fix: detect versioned libportaudio.so.2 on Debian/Ubuntu

### DIFF
--- a/voice_mode/cli_commands/status.py
+++ b/voice_mode/cli_commands/status.py
@@ -112,10 +112,15 @@ def check_portaudio() -> DependencyInfo:
         return DependencyInfo(name="portaudio", installed=False)
 
     # On Linux, check for the library
+    # Include versioned .so.2 names since Debian/Ubuntu only install
+    # the unversioned symlink with -dev packages
     lib_paths = [
         "/usr/lib/libportaudio.so",
+        "/usr/lib/libportaudio.so.2",
         "/usr/lib/x86_64-linux-gnu/libportaudio.so",
+        "/usr/lib/x86_64-linux-gnu/libportaudio.so.2",
         "/usr/lib/aarch64-linux-gnu/libportaudio.so",
+        "/usr/lib/aarch64-linux-gnu/libportaudio.so.2",
     ]
     for path in lib_paths:
         if Path(path).exists():


### PR DESCRIPTION
## Summary
- Add versioned `.so.2` paths to portaudio detection on Linux
- Debian/Ubuntu install runtime library as `libportaudio.so.2` - unversioned symlink only in -dev package
- Fixes `voicemode status` showing "PortAudio not found" on fresh Ubuntu installs

## Test plan
- [ ] Verify `voicemode status` shows portaudio on fresh Ubuntu
- [ ] Verify no regressions on macOS

Fixes VM-520

🤖 Generated with [Claude Code](https://claude.com/claude-code)