### PR TITLE
fix: add .cargo/bin to Kokoro systemd PATH for ARM64 Linux

### DIFF
--- a/voice_mode/templates/systemd/voicemode-kokoro.service
+++ b/voice_mode/templates/systemd/voicemode-kokoro.service
@@ -17,7 +17,8 @@ RestartSec=10
 RestartPreventExitStatus=127
 
 # Environment - start script sources voicemode.env for port config
-Environment="PATH=%h/.local/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin"
+# Include .cargo/bin for ARM64 Linux where Rust may be needed to build dependencies
+Environment="PATH=%h/.cargo/bin:%h/.local/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin"
 
 # Resource limits
 MemoryLimit=4G


### PR DESCRIPTION
## Summary
- Add `~/.cargo/bin` to the PATH in Kokoro systemd service template
- Needed for ARM64 Linux where Rust is required to build Kokoro dependencies (sudachipy)
- Harmless on other platforms where the path simply doesn't exist

## Root Cause
When install.sh installs Rust via rustup on ARM64 Linux, cargo is placed in `~/.cargo/bin`. This path is added to the current shell session but not persisted in the systemd service environment.

When the Kokoro service starts, `uv pip install` tries to build sudachipy which requires Rust, but can't find `rustc` because `.cargo/bin` isn't in PATH.

## Test plan
- [ ] Deploy to fresh Ubuntu ARM64 VM
- [ ] Run install.sh
- [ ] Verify `voicemode service start kokoro` succeeds
- [ ] Verify Kokoro still works on macOS (no regression)

Related: VM-497 install.sh testing

🤖 Generated with [Claude Code](https://claude.com/claude-code)