### PR TITLE
fix: remove unused LIVEKIT_PORT import from status.py

### DIFF
--- a/voice_mode/cli_commands/status.py
+++ b/voice_mode/cli_commands/status.py
@@ -21,7 +21,6 @@ import click
 from voice_mode.config import (
     WHISPER_PORT,
     KOKORO_PORT,
-    LIVEKIT_PORT,
     TTS_VOICES,
     OPENAI_API_KEY,
     env_bool,


### PR DESCRIPTION
## Summary
- Removes unused LIVEKIT_PORT import that was causing test failures

This import was leftover from the LiveKit removal in 8.0.0.

## Test plan
- [x] Tests pass locally