### PR TITLE
feat: add voicemode connect command for remote voice control

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,6 +38,7 @@ dependencies = [
     "audioop-lts; python_version >= '3.13'",
     "simpleaudio",
     "httpx",
+    "websockets>=12.0",  # Required for voicemode connect command
     "aiohttp",  # Required for Whisper and Kokoro service installers
     "psutil>=5.9.0",
     "setuptools",  # Required for pkg_resources used by webrtcvad

--- a/uv.lock
+++ b/uv.lock
@@ -5533,6 +5533,7 @@ dependencies = [
     { name = "sounddevice" },
     { name = "uv" },
     { name = "webrtcvad" },
+    { name = "websockets" },
 ]
 
 [package.optional-dependencies]
@@ -5633,6 +5634,7 @@ requires-dist = [
     { name = "twine", marker = "extra == 'dev'", specifier = ">=4.0.0" },
     { name = "uv", specifier = ">=0.4.0" },
     { name = "webrtcvad", specifier = ">=2.0.10" },
+    { name = "websockets", specifier = ">=12.0" },
 ]
 provides-extras = ["coreml", "dev", "docs", "livekit", "notebooks", "scripts", "test"]
 


### PR DESCRIPTION
## Summary
- Add `voicemode connect` command group with `standby` subcommand
- Connects to voicemode.dev via WebSocket
- Authenticates and sends ready message with canStartOperator capability
- Waits for wake signals from iOS app or web client
- Starts Claude Code when wake signal received
- Reports operator status back to server
- Adds websockets>=12.0 as a dependency

## Related
- Requires voicemode-dev wake signal support (mbailey/voicemode-dev PR)
- OAuth login flow will be added in VM-549

## Test plan
- [ ] Run `uv run voicemode connect --help` to verify command exists
- [ ] Run `uv run voicemode connect standby --help` to see options
- [ ] Manual test with voicemode.dev token (after auth PR merged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)