### PR TITLE
docs: clarify fork-first workflow for external contributors

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,9 +14,14 @@ Thank you for your interest in contributing to VoiceMode. This guide will help y
 
 ### Getting Started
 
-1. **Clone the repository**
+1. **Fork and clone the repository**
+
+   External contributors need to fork the repository first (you can't push directly to the main repo):
+
+   - Click **Fork** at https://github.com/mbailey/voicemode
+   - Clone your fork:
    ```bash
-   git clone https://github.com/mbailey/voicemode.git
+   git clone https://github.com/YOUR-USERNAME/voicemode.git
    cd voicemode
    ```
 
@@ -91,7 +96,11 @@ python -c "from voice_mode.core import text_to_speech; import asyncio; asyncio.r
 2. Make your changes
 3. Run tests to ensure nothing is broken
 4. Commit with descriptive messages
-5. Push and create a pull request
+5. Push to your fork and create a pull request
+   ```bash
+   git push origin feature/your-feature-name
+   ```
+   Then open a PR from your fork to `mbailey/voicemode`
 
 ## Debugging
 

--- a/docs/tutorials/development-setup.md
+++ b/docs/tutorials/development-setup.md
@@ -26,9 +26,11 @@ pip install uv
 
 ## Cloning the Repository
 
+**For contributors:** Fork the repo first at https://github.com/mbailey/voicemode, then clone your fork:
+
 ```bash
-# Clone the repository
-git clone https://github.com/mbailey/voicemode
+# Clone your fork (replace YOUR-USERNAME)
+git clone https://github.com/YOUR-USERNAME/voicemode
 cd voicemode
 
 # Install in development mode


### PR DESCRIPTION
## Summary
- Updated CONTRIBUTING.md to explain that external contributors need to fork the repo first
- Updated docs/tutorials/development-setup.md with the same guidance
- Added example commands showing how to push to your fork and create a PR

## Context
Issue #222 showed a new contributor got confused because the docs said "clone the repo" and "push and create a PR" without mentioning that external contributors can't push directly to mbailey/voicemode.

Closes #222

## Test plan
- [x] Docs render correctly
- [x] Instructions are clear and actionable

🤖 Generated with [Claude Code](https://claude.com/claude-code)