### PR TITLE
feat(agent): add --agent option for multi-agent support (VM-589)

### DIFF
--- a/voice_mode/cli_commands/agent.py
+++ b/voice_mode/cli_commands/agent.py
@@ -6,6 +6,7 @@ The default agent is 'operator' - accessible from the iOS app and web interface.
 
 import subprocess
 import sys
+import time
 from pathlib import Path
 from typing import Dict
 
@@ -574,14 +575,18 @@ def stop(agent_name: str, session: str, kill: bool):
             raise SystemExit(1)
         click.echo(f"✓ Agent '{agent_name}' window killed")
     else:
-        # Send Ctrl-C to stop Claude gracefully
-        result = subprocess.run(
-            ['tmux', 'send-keys', '-t', window, 'C-c'],
-            capture_output=True
-        )
-        if result.returncode != 0:
-            click.echo(f"Error: Failed to send stop signal", err=True)
-            raise SystemExit(1)
+        # Send multiple Ctrl-C signals to stop Claude gracefully
+        # Claude Code often needs 2-3 Ctrl-C signals to fully stop
+        for i in range(3):
+            result = subprocess.run(
+                ['tmux', 'send-keys', '-t', window, 'C-c'],
+                capture_output=True
+            )
+            if result.returncode != 0:
+                click.echo(f"Error: Failed to send stop signal", err=True)
+                raise SystemExit(1)
+            if i < 2:  # Don't sleep after the last signal
+                time.sleep(0.3)
         click.echo(f"✓ Sent stop signal to agent '{agent_name}'")
 
 


### PR DESCRIPTION
## Summary

- Add `--agent/-a` option to start, stop, send, and status commands
- Enable targeting specific agents by name (default: operator)
- Add shell completion for agent names
- Make `list` command visible (was hidden)
- Support running multiple agents simultaneously
- **NEW**: Add `--agent/-a` to `connect standby` to wake specific agents

## Changes

### Agent Commands
- Positional argument for agent name in `start`, `stop`, `status`
- `-a` flag for agent in `send` (has message argument)
- `get_agent_names()` discovers agents from `~/.voicemode/agents/`
- `agent_name_completion()` callback for shell tab completion
- Reliable 3x Ctrl-C stop sequence (fixes agent not stopping)

### Standby Command
- `--agent/-a` option to target specific agent on wake
- `VOICEMODE_AGENT_NAME` env var support
- Updated error messages and logging

## Usage

```bash
# Agent management
voicemode agent start research   # Start research agent
voicemode agent list             # See all agents
voicemode agent send -a research "Hello"

# Standby for specific agent
voicemode connect standby --agent cora  # Wake Cora on calls
voicemode connect standby -a tesi       # Wake Tesi on calls
```

## Test plan

- [x] `voicemode agent list` shows agents
- [x] `voicemode agent status <name>` checks specific agent
- [x] `voicemode agent start <name>` starts agent
- [x] `voicemode agent stop <name>` reliably stops with 3x Ctrl-C
- [x] `voicemode agent send -a <name>` sends to agent
- [x] Default operator behavior unchanged
- [x] `voicemode connect standby --help` shows --agent option
- [ ] Full standby integration test

🤖 Generated with [Claude Code](https://claude.com/claude-code)