### PR TITLE
feat: Add STT prompt support for vocabulary biasing

### DIFF
--- a/voice_mode/config.py
+++ b/voice_mode/config.py
@@ -522,6 +522,10 @@ STT_BASE_URLS = parse_comma_list("VOICEMODE_STT_BASE_URLS", "http://127.0.0.1:20
 TTS_VOICES = parse_comma_list("VOICEMODE_VOICES", "af_sky,alloy")
 TTS_MODELS = parse_comma_list("VOICEMODE_TTS_MODELS", "tts-1,tts-1-hd,gpt-4o-mini-tts")
 
+# STT prompt for vocabulary biasing (helps with specialized terminology)
+# See: https://platform.openai.com/docs/guides/speech-to-text#prompting
+STT_PROMPT = os.getenv("VOICEMODE_STT_PROMPT", "")
+
 # Voice preferences cache
 _cached_voice_preferences: Optional[list] = None
 _voice_preferences_loaded = False


### PR DESCRIPTION
Add VOICEMODE_STT_PROMPT environment variable to improve recognition of specialized terminology (technical jargon, project-specific terms, non-English names, domain vocabulary).

The prompt parameter is passed to the OpenAI-compatible /v1/audio/transcriptions endpoint.

Usage:
  export VOICEMODE_STT_PROMPT="Skald, Karl, Jarl, Ulf, Bjorn"

Or in ~/.voicemode/voicemode.env:
  VOICEMODE_STT_PROMPT="technical terms here"

Closes #222