### PR TITLE
Fix Getting Started link to use master branch

### DIFF
--- a/docs/web/index.html
+++ b/docs/web/index.html
@@ -617,7 +617,7 @@ claude converse
                 </li>
             </ul>
             <p style="margin-top: 1.5rem; color: var(--text-secondary);">
-                For manual setup or detailed instructions, see the <a href="https://github.com/mbailey/voicemode/blob/main/docs/tutorials/getting-started.md" style="color: var(--accent); text-decoration: none; border-bottom: 1px dotted var(--accent);">Getting Started Guide</a>.
+                For manual setup or detailed instructions, see the <a href="https://github.com/mbailey/voicemode/blob/master/docs/tutorials/getting-started.md" style="color: var(--accent); text-decoration: none; border-bottom: 1px dotted var(--accent);">Getting Started Guide</a>.
             </p>
         </section>
 


### PR DESCRIPTION
## Summary

- Changes the Getting Started link from `/blob/main/` to `/blob/master/` since the repo uses `master` as default branch

Fixes #228

## Test plan

- [x] Verified the updated link returns HTTP 200

🤖 Generated with [Claude Code](https://claude.com/claude-code)