### PR TITLE
fix: pass WHISPER_LANGUAGE config to STT API

### DIFF
--- a/voice_mode/resources/docs/languages.md
+++ b/voice_mode/resources/docs/languages.md
@@ -128,7 +128,7 @@ OpenAI voices work for any language but maintain American English accent:
 1. **Always specify both `voice` and `tts_provider`** when using non-English
 2. **Never use `coral` voice** - it's not supported
 3. Kokoro provides native pronunciation for each language
-4. STT (speech-to-text) automatically detects language
+4. STT (speech-to-text) auto-detects language by default. Set `VOICEMODE_WHISPER_LANGUAGE` to a specific language code (e.g., `it` for Italian) for better accuracy with non-English audio
 
 ## See Also
 - `voicemode-parameters` - Full parameter reference


### PR DESCRIPTION
## Summary

- Pass `WHISPER_LANGUAGE` config to the transcription API
- Handle provider differences: whisper.cpp needs explicit "auto", OpenAI omits parameter
- Update documentation to clarify `VOICEMODE_WHISPER_LANGUAGE` usage

## Details

The config existed but was never used, causing whisper.cpp to default to English instead of auto-detecting language.

Fixes #252