### PR TITLE
Fix flaky tmux test on macOS CI

### DIFF
--- a/tests/test_agent_send.py
+++ b/tests/test_agent_send.py
@@ -118,7 +118,7 @@ class TestSendCommand:
 
     def test_send_no_start_fails_when_not_running(self, runner):
         """Should fail with --no-start when agent is not running."""
-        with patch('voice_mode.cli_commands.agent.is_operator_running', return_value=False):
+        with patch('voice_mode.cli_commands.agent.is_agent_running', return_value=False):
             result = runner.invoke(agent, ['send', '--no-start', 'Hello!'])
 
         assert result.exit_code == 1
@@ -164,7 +164,7 @@ class TestSendCommand:
     def test_send_handles_send_keys_error(self, runner):
         """Should handle errors from tmux send-keys."""
         mock_run = MagicMock(return_value=MagicMock(returncode=1))
-        with patch('voice_mode.cli_commands.agent.is_operator_running', return_value=True):
+        with patch('voice_mode.cli_commands.agent.is_agent_running', return_value=True):
             with patch('voice_mode.cli_commands.agent.subprocess.run', mock_run):
                 result = runner.invoke(agent, ['send', 'Hello!'])
 

--- a/voice_mode/cli_commands/agent.py
+++ b/voice_mode/cli_commands/agent.py
@@ -280,11 +280,14 @@ def tmux_session_exists(session: str) -> bool:
     Returns:
         True if session exists, False otherwise
     """
-    result = subprocess.run(
-        ['tmux', 'has-session', '-t', session],
-        capture_output=True
-    )
-    return result.returncode == 0
+    try:
+        result = subprocess.run(
+            ['tmux', 'has-session', '-t', session],
+            capture_output=True
+        )
+        return result.returncode == 0
+    except FileNotFoundError:
+        return False
 
 
 def tmux_window_exists(window: str) -> bool:
@@ -301,11 +304,14 @@ def tmux_window_exists(window: str) -> bool:
 
     session, name = window.split(':', 1)
 
-    result = subprocess.run(
-        ['tmux', 'list-windows', '-t', session, '-F', '#{window_name}'],
-        capture_output=True,
-        text=True
-    )
+    try:
+        result = subprocess.run(
+            ['tmux', 'list-windows', '-t', session, '-F', '#{window_name}'],
+            capture_output=True,
+            text=True
+        )
+    except FileNotFoundError:
+        return False
 
     if result.returncode != 0:
         return False
@@ -329,11 +335,14 @@ def is_agent_running_in_pane(window: str, pane: int = 0) -> bool:
     target = f"{window}.{pane}"
 
     # Get the current command running in the pane
-    result = subprocess.run(
-        ['tmux', 'display-message', '-t', target, '-p', '#{pane_current_command}'],
-        capture_output=True,
-        text=True
-    )
+    try:
+        result = subprocess.run(
+            ['tmux', 'display-message', '-t', target, '-p', '#{pane_current_command}'],
+            capture_output=True,
+            text=True
+        )
+    except FileNotFoundError:
+        return False
 
     if result.returncode != 0:
         return False
@@ -746,13 +755,16 @@ def scan_tmux_for_agents() -> list[dict]:
         List of dicts with keys: pane_id, session, window, pane_index,
                                  command, title, path
     """
-    result = subprocess.run(
-        ['tmux', 'list-panes', '-a', '-F',
-         '#{pane_id}\t#{session_name}\t#{window_name}\t#{pane_index}\t'
-         '#{pane_current_command}\t#{pane_title}\t#{pane_current_path}'],
-        capture_output=True,
-        text=True
-    )
+    try:
+        result = subprocess.run(
+            ['tmux', 'list-panes', '-a', '-F',
+             '#{pane_id}\t#{session_name}\t#{window_name}\t#{pane_index}\t'
+             '#{pane_current_command}\t#{pane_title}\t#{pane_current_path}'],
+            capture_output=True,
+            text=True
+        )
+    except FileNotFoundError:
+        return []
 
     if result.returncode != 0:
         return []


### PR DESCRIPTION
## Summary

Fixes `test_send_no_start_fails_when_not_running` failing on macOS CI where tmux isn't installed.

- **Tests**: Fixed mock targets — tests were mocking `is_operator_running` but the code calls `is_agent_running`
- **Code**: Added `FileNotFoundError` handling to tmux helper functions so they gracefully return `False` when tmux isn't installed

## Test Plan

- [x] All 19 agent send tests pass locally
- [x] tmux helper functions handle missing tmux gracefully

🤖 Generated with [Claude Code](https://claude.com/claude-code)