### PR TITLE
fix: switch to webrtcvad-wheels for setuptools>=81 compatibility

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,8 +41,7 @@ dependencies = [
     "websockets>=12.0",  # Required for voicemode connect command
     "aiohttp",  # Required for Whisper and Kokoro service installers
     "psutil>=5.9.0",
-    "setuptools",  # Required for pkg_resources used by webrtcvad
-    "webrtcvad>=2.0.10",
+    "webrtcvad-wheels>=2.0.14",  # Maintained fork with importlib.metadata (no pkg_resources)
     "click>=8.0.0",
     "pyyaml>=6.0.0",
 ]

--- a/voice_mode/cli.py
+++ b/voice_mode/cli.py
@@ -37,8 +37,7 @@ from voice_mode.config import (
 if not os.environ.get('VOICEMODE_DEBUG', '').lower() in ('true', '1', 'yes'):
     # Suppress audioop deprecation warning from pydub
     warnings.filterwarnings('ignore', message='.*audioop.*deprecated.*', category=DeprecationWarning)
-    # Suppress pkg_resources deprecation warning from webrtcvad
-    warnings.filterwarnings('ignore', message='.*pkg_resources.*deprecated.*', category=UserWarning)
+    # webrtcvad-wheels uses importlib.metadata, no pkg_resources warning to suppress
     # Suppress psutil connections() deprecation warning
     warnings.filterwarnings('ignore', message='.*connections.*deprecated.*', category=DeprecationWarning)
     


### PR DESCRIPTION
## Summary

- Switch dependency from [`webrtcvad`](https://github.com/wiseman/py-webrtcvad) (unmaintained, last commit 2021) to [`webrtcvad-wheels`](https://github.com/daanzu/py-webrtcvad-wheels) (maintained fork)
- `webrtcvad-wheels` uses `importlib.metadata` instead of `pkg_resources`, fixing silent VAD failure on `setuptools>=81`
- Drop-in replacement — same Python API, same C extension
- Remove now-unnecessary `setuptools` dependency and `pkg_resources` deprecation warning suppression

Fixes #256
Alternative approach to #255 (shim-based fix)

## Context

`setuptools>=81` removed `pkg_resources` as a top-level module. `webrtcvad` imports it only to get its version string. When this import fails, VAD silently becomes unavailable and silence detection stops working — recordings run for the full max duration with no warning.

## Test plan

- [x] `webrtcvad-wheels` loads and VAD creates successfully
- [x] Silence detection test passes (silent frame correctly detected as non-speech)
- [x] 840 unit tests pass, 60 skipped
- [x] Tested on M1 Max Mac Studio (ms1) with live VoiceMode installation

🤖 Generated with [Claude Code](https://claude.com/claude-code)