### PR TITLE
fix: soundfonts disabled by default when config file exists

### DIFF
--- a/voice_mode/data/hooks/voicemode-hook-receiver.sh
+++ b/voice_mode/data/hooks/voicemode-hook-receiver.sh
@@ -141,8 +141,10 @@ soundfonts_enabled() {
   local config_file="$HOME/.voicemode/voicemode.env"
   if [[ -f "$config_file" ]]; then
     enabled=$(grep -E '^VOICEMODE_SOUNDFONTS_ENABLED=' "$config_file" 2>/dev/null | cut -d= -f2 | tr -d '"' | tr -d "'" || echo "")
-    [[ "$enabled" == "true" || "$enabled" == "1" || "$enabled" == "yes" || "$enabled" == "on" ]]
-    return
+    if [[ -n "$enabled" ]]; then
+      [[ "$enabled" == "true" || "$enabled" == "1" || "$enabled" == "yes" || "$enabled" == "on" ]]
+      return
+    fi
   fi
 
   # Default: enabled


### PR DESCRIPTION
## Summary

- Fixed bug where soundfonts were silently disabled for all users with a voicemode.env config file
- When `VOICEMODE_SOUNDFONTS_ENABLED` was commented out (the default), `soundfonts_enabled()` in the hook receiver returned false instead of falling through to the default (enabled)
- Root cause: grep returned empty, boolean test failed, and `return` captured that failure exit code

## Test plan

- [ ] Verify soundfonts play when setting is commented out (default)
- [ ] Verify soundfonts play when explicitly set to `true`
- [ ] Verify soundfonts don't play when explicitly set to `false`

🤖 Generated with [Claude Code](https://claude.com/claude-code)