### PR TITLE
feat(VM-712): add configurable wake command to connect standby

### DIFF
--- a/tests/test_standby_integration.py
+++ b/tests/test_standby_integration.py
@@ -47,6 +47,44 @@ class TestStandbyStartOperator:
         assert "no such option" in result.output.lower() or "error" in result.output.lower()
 
 
+class TestStandbyWakeCommand:
+    """Test the --wake-command option."""
+
+    def test_standby_help_shows_wake_command(self):
+        """Test that standby help shows the --wake-command option."""
+        from click.testing import CliRunner
+        from voice_mode.cli import connect
+
+        runner = CliRunner()
+        result = runner.invoke(connect, ["standby", "--help"])
+
+        assert result.exit_code == 0
+        assert "--wake-command" in result.output
+
+    def test_standby_accepts_wake_command_option(self):
+        """Test that --wake-command is accepted as a valid option."""
+        from click.testing import CliRunner
+        from voice_mode.cli import connect
+
+        runner = CliRunner()
+        # This will fail due to no auth, but should NOT fail with "no such option"
+        result = runner.invoke(connect, ["standby", "--wake-command", "send-message cora"])
+
+        # Should not be an option error
+        assert "no such option" not in (result.output or "").lower()
+
+    def test_wake_command_env_var(self):
+        """Test that VOICEMODE_WAKE_COMMAND env var is documented in help."""
+        from click.testing import CliRunner
+        from voice_mode.cli import connect
+
+        runner = CliRunner()
+        result = runner.invoke(connect, ["standby", "--help"])
+
+        assert result.exit_code == 0
+        assert "VOICEMODE_WAKE_COMMAND" in result.output
+
+
 class TestStartOperatorFunction:
     """Test the start_operator nested function behavior.
 

--- a/voice_mode/templates/scripts/start-voicemode-connect.sh
+++ b/voice_mode/templates/scripts/start-voicemode-connect.sh
@@ -23,6 +23,7 @@ fi
 
 # Configuration from environment
 WAKE_MESSAGE="${VOICEMODE_WAKE_MESSAGE:-}"
+WAKE_COMMAND="${VOICEMODE_WAKE_COMMAND:-}"
 
 echo "[$(date '+%Y-%m-%d %H:%M:%S')] Starting VoiceMode Connect standby" >> "$STARTUP_LOG"
 
@@ -32,6 +33,11 @@ CMD_ARGS=()
 if [ -n "$WAKE_MESSAGE" ]; then
     CMD_ARGS+=(--wake-message "$WAKE_MESSAGE")
     echo "[$(date '+%Y-%m-%d %H:%M:%S')] Wake message: $WAKE_MESSAGE" >> "$STARTUP_LOG"
+fi
+
+if [ -n "$WAKE_COMMAND" ]; then
+    CMD_ARGS+=(--wake-command "$WAKE_COMMAND")
+    echo "[$(date '+%Y-%m-%d %H:%M:%S')] Wake command: $WAKE_COMMAND" >> "$STARTUP_LOG"
 fi
 
 echo "[$(date '+%Y-%m-%d %H:%M:%S')] Executing: voicemode connect standby ${CMD_ARGS[*]}" >> "$STARTUP_LOG"


### PR DESCRIPTION
## Summary

- Add `--wake-command` option and `VOICEMODE_WAKE_COMMAND` env var to `voicemode connect standby`
- When set, uses the custom command instead of the default `voicemode agent send` for wake message delivery
- Enables integration with alternative delivery systems like `send-message` for team inbox injection (VMD-102 wakeable agents)

## Changes

- **cli.py**: New `--wake-command` option with `VOICEMODE_WAKE_COMMAND` env var, `shlex.split` for safe command parsing, restored `user_text` handling in wake messages
- **start-voicemode-connect.sh**: Updated startup script template to pass through `VOICEMODE_WAKE_COMMAND`
- **test_standby_integration.py**: 3 new tests for wake command option, acceptance, and env var documentation

## Usage

```bash
# Default behavior unchanged
voicemode connect standby

# Custom wake command
voicemode connect standby --wake-command "send-message cora"

# Via environment variable
VOICEMODE_WAKE_COMMAND="send-message cora" voicemode connect standby
```

## Test plan

- [x] All 10 standby integration tests pass
- [ ] Manual test: run standby with `--wake-command "echo"` and trigger a wake signal
- [ ] Manual test: verify default behavior still works without `--wake-command`

🤖 Generated with [Claude Code](https://claude.com/claude-code)