### PR TITLE
feat(VM-358): mitigate Kokoro memory leak via UVICORN_LIMIT_MAX_REQUESTS

### DIFF
--- a/docs/.archive/configuration/voicemode.env.example
+++ b/docs/.archive/configuration/voicemode.env.example
@@ -235,6 +235,11 @@
 ## See voice list: af_*, am_*, bf_*, bm_*, ef_*, em_*, etc.
 # export VOICEMODE_KOKORO_DEFAULT_VOICE=af_sky
 
+## Max requests before Kokoro worker restarts (default: 200)
+## Mitigates upstream memory leak (hexgrad/kokoro#152).
+## Lower values = less peak memory, more restarts. 0 = disabled.
+# export VOICEMODE_KOKORO_MAX_REQUESTS=200
+
 #############
 # Tool Management
 #############

--- a/tests/test_service_file_updates.py
+++ b/tests/test_service_file_updates.py
@@ -24,10 +24,12 @@ def test_get_service_config_vars():
     assert "HOME" in whisper_vars
     assert "START_SCRIPT" in whisper_vars
 
-    # Test kokoro config - now only has HOME and START_SCRIPT
+    # Test kokoro config - has HOME, START_SCRIPT, KOKORO_DIR, KOKORO_MAX_REQUESTS
     kokoro_vars = get_service_config_vars("kokoro")
     assert "HOME" in kokoro_vars
     assert "START_SCRIPT" in kokoro_vars
+    assert "KOKORO_MAX_REQUESTS" in kokoro_vars
+    assert int(kokoro_vars["KOKORO_MAX_REQUESTS"]) > 0
 
 
 def test_get_service_config_vars_handles_missing_start_script():

--- a/voice_mode/config.py
+++ b/voice_mode/config.py
@@ -202,6 +202,10 @@ def load_voicemode_env():
 # Default Kokoro voice
 # VOICEMODE_KOKORO_DEFAULT_VOICE=af_sky
 
+# Max requests before Kokoro worker restarts (mitigates memory leak)
+# See: https://github.com/hexgrad/kokoro/issues/152
+# VOICEMODE_KOKORO_MAX_REQUESTS=200
+
 #############
 # Recording & Voice Activity Detection
 #############
@@ -619,6 +623,7 @@ KOKORO_PORT = int(os.getenv("VOICEMODE_KOKORO_PORT", "8880"))
 KOKORO_MODELS_DIR = expand_path(os.getenv("VOICEMODE_KOKORO_MODELS_DIR", str(BASE_DIR / "models" / "kokoro")))
 KOKORO_CACHE_DIR = expand_path(os.getenv("VOICEMODE_KOKORO_CACHE_DIR", str(BASE_DIR / "cache" / "kokoro")))
 KOKORO_DEFAULT_VOICE = os.getenv("VOICEMODE_KOKORO_DEFAULT_VOICE", "af_sky")
+KOKORO_MAX_REQUESTS = int(os.getenv("VOICEMODE_KOKORO_MAX_REQUESTS", "200"))
 
 # ==================== SERVICE MANAGEMENT CONFIGURATION ====================
 

--- a/voice_mode/templates/launchd/com.voicemode.kokoro.plist
+++ b/voice_mode/templates/launchd/com.voicemode.kokoro.plist
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-<!-- com.voicemode.kokoro.plist v1.3.1 -->
-<!-- Last updated: 2025-12-02 -->
+<!-- com.voicemode.kokoro.plist v1.4.0 -->
+<!-- Last updated: 2026-02-18 -->
 <!-- Compatible with: kokoro-fastapi v1.0.0+ -->
 <!-- Simplified: start script handles config via voicemode.env -->
 <plist version="1.0">
@@ -26,6 +26,8 @@
     <dict>
         <key>PATH</key>
         <string>{HOME}/.local/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:/opt/homebrew/bin</string>
+        <key>UVICORN_LIMIT_MAX_REQUESTS</key>
+        <string>{KOKORO_MAX_REQUESTS}</string>
     </dict>
 </dict>
 </plist>

--- a/voice_mode/templates/systemd/voicemode-kokoro.service
+++ b/voice_mode/templates/systemd/voicemode-kokoro.service
@@ -1,5 +1,5 @@
-# voicemode-kokoro.service v1.2.1
-# Last updated: 2026-01-20
+# voicemode-kokoro.service v1.3.0
+# Last updated: 2026-02-18
 # Compatible with: kokoro-fastapi v1.0.0+
 # Simplified: start script handles config via voicemode.env
 
@@ -19,6 +19,8 @@ RestartPreventExitStatus=127
 # Environment - start script sources voicemode.env for port config
 # Include .cargo/bin for ARM64 Linux where Rust may be needed to build dependencies
 Environment="PATH=%h/.cargo/bin:%h/.local/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin"
+# Restart worker after N requests to mitigate memory leak (hexgrad/kokoro#152)
+Environment="UVICORN_LIMIT_MAX_REQUESTS={KOKORO_MAX_REQUESTS}"
 
 # Resource limits
 MemoryLimit=4G

--- a/voice_mode/tools/service.py
+++ b/voice_mode/tools/service.py
@@ -72,10 +72,13 @@ def get_service_config_vars(service_name: str) -> Dict[str, Any]:
                     start_script = script
                     break
 
+        from voice_mode.config import KOKORO_MAX_REQUESTS
+
         return {
             "HOME": home,
             "START_SCRIPT": str(start_script) if start_script and start_script.exists() else "",
             "KOKORO_DIR": kokoro_dir,
+            "KOKORO_MAX_REQUESTS": str(KOKORO_MAX_REQUESTS),
         }
     elif service_name == "voicemode":
         # VoiceMode serve service - runs the HTTP MCP server


### PR DESCRIPTION
## Summary

- Adds `UVICORN_LIMIT_MAX_REQUESTS` to Kokoro launchd plist and systemd service templates
- Configurable via `VOICEMODE_KOKORO_MAX_REQUESTS` env var (default: 200)
- Mitigates upstream memory leak ([hexgrad/kokoro#152](https://github.com/hexgrad/kokoro/issues/152)) — zero changes to third-party code

## Background

Kokoro TTS (kokoro-fastapi) leaks ~24 MB/request in native memory. After ~100 requests, memory reaches ~3 GB. This is an upstream bug in the kokoro library affecting all backends (MPS, CPU, CUDA).

### Experiments conducted on Mac Studio M4 Max:

| Experiment | Result |
|-----------|--------|
| Control (MPS baseline) | ~24.1 MB/req growth |
| MPS cache clearing (gc.collect + torch.mps.empty_cache) | No effect (24.6 MB/req) |
| CPU backend | Same leak rate (23.7 MB/req) |
| `UVICORN_LIMIT_MAX_REQUESTS=100` | Process restarts at limit, launchd auto-recovers |

## How it works

uvicorn natively reads `UVICORN_LIMIT_MAX_REQUESTS` from environment — no code changes needed. After N requests, the worker process exits. launchd (KeepAlive=true) or systemd (Restart=on-failure) restarts it automatically.

## Test plan

- [x] 842 unit tests pass
- [x] Validated on ms2 (Mac Studio M4 Max) with UVICORN_LIMIT_MAX_REQUESTS=50
- [x] Confirmed worker restarts and launchd auto-recovery
- [x] Confirmed zero failed requests during restart cycle
- [ ] Deploy on MBA for daily use validation

🤖 Generated with [Claude Code](https://claude.com/claude-code)