### PR TITLE
fix(VM-746): discourage agents from overriding listen_duration defaults

### DIFF
--- a/.claude/skills/voicemode/SKILL.md
+++ b/.claude/skills/voicemode/SKILL.md
@@ -44,6 +44,7 @@ voicemode:converse("Searching the codebase now...", wait_for_response=False)
 ```
 
 For most conversations, just pass your message - defaults handle everything else.
+Use default converse tool parameters unless there's a good reason not to. Timing parameters (`listen_duration_max`, `listen_duration_min`) use smart defaults with silence detection - don't override unless the user requests it or you see a clear need. Defaults are configurable by the user via `~/.voicemode/voicemode.env`.
 
 | Parameter | Default | Description |
 |-----------|---------|-------------|

--- a/voice_mode/tools/converse.py
+++ b/voice_mode/tools/converse.py
@@ -1121,8 +1121,6 @@ Example: If user says "search for tasks created yesterday", check for and invoke
 KEY PARAMETERS:
 • message (required): The message to speak
 • wait_for_response (bool, default: true): Listen for response after speaking
-• listen_duration_max (number, default: 120): Max listen time in seconds
-• listen_duration_min (number, default: 2.0): Min recording time before silence detection
 • voice (string): TTS voice name (auto-selected unless specified)
 • tts_provider ("openai"|"kokoro"): Provider selection (auto-selected unless specified)
 • disable_silence_detection (bool, default: false): Disable auto-stop on silence
@@ -1138,6 +1136,13 @@ KEY PARAMETERS:
 • wait_for_conch (bool, default: false): Multi-agent coordination
   - false: If another agent is speaking, return status immediately
   - true: Wait until the other agent finishes, then speak
+
+TIMING PARAMETERS (usually leave at defaults):
+  Silence detection handles most cases automatically. Only override these if
+  silence detection is disabled or the user reports being cut off.
+  Defaults are configurable by the user via ~/.voicemode/voicemode.env.
+• listen_duration_max (number, default: 120): Max listen time in seconds
+• listen_duration_min (number, default: 2.0): Min recording time before silence detection
 
 PRIVACY: Microphone access required when wait_for_response=true.
          Audio processed via STT service, not stored.


### PR DESCRIPTION
## Summary

- Moved `listen_duration_max` and `listen_duration_min` out of KEY PARAMETERS into a new "TIMING PARAMETERS (usually leave at defaults)" section in the converse tool docstring
- Added guidance to VoiceMode SKILL.md to use default parameters unless there's a good reason not to
- Root cause: agents were setting `listen_duration_max: 30` because the tool description listed it as a KEY PARAMETER, implying it's commonly needed

## Test plan

- [x] All 1015 unit tests pass
- [ ] Verify agents stop overriding listen_duration_max in new sessions

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>