### PR TITLE
chore: cleanup master — gitignore, connect tools, hooks, docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@
 # Environment configuration
 .env.local
 .env
+.voicemode.env
 
 # Python
 __pycache__/
@@ -91,6 +92,7 @@ node_modules/
 
 # Worktrees
 .worktrees/
+.claude/worktrees/
 
 # Misc
 .cache/

--- a/docs/plans/2026-02-16-message-hub-v1-design.md
+++ b/docs/plans/2026-02-16-message-hub-v1-design.md
@@ -1,0 +1,219 @@
+# Message Hub V1 Design
+
+**Task**: VM-714 (expanded scope)
+**Related**: VMD-102 (Wakeable Agents epic)
+**Date**: 2026-02-16
+**Status**: Implementation-ready
+
+## Problem
+
+Today, making an agent wakeable via VoiceMode Connect requires:
+
+1. Agent creates a Claude Code team (TeamCreate)
+2. Agent creates a symlink for a stable team name
+3. Agent calls `register_wakeable` MCP tool with team name
+4. Message delivery depends on `send-message` bash script being on PATH
+
+Every session restart loses wakeable status. The bash script dependency is fragile (PATH issues, subprocess overhead, no library reuse).
+
+## Design Decisions (from brainstorm session)
+
+These were agreed in a ~45 minute voice session on 2026-02-16:
+
+1. **Agent identity is VoiceMode-owned**, not tied to Claude Code teams. "cora" is a stable identity across sessions; the Claude team name is an ephemeral delivery detail.
+2. **Wakeable is a live capability**, not a static attribute. VoiceMode announces it only after an agent registers.
+3. **V1: local persistence only**. No server-side message storage. If agent is offline, voicemode.dev returns "agent offline".
+4. **Python library replaces bash dependency**. `send-message` CLI becomes a thin wrapper. VoiceMode calls the library directly.
+5. **Two layers**: stable identity (VoiceMode config) + ephemeral delivery target (per-session Claude team).
+
+## Components
+
+### 1. Configuration: `VOICEMODE_AGENT_NAME` env var
+
+**File**: `voice_mode/config.py`
+
+New config variables:
+
+```python
+# Agent identity for wakeable registration
+AGENT_NAME = os.getenv("VOICEMODE_AGENT_NAME", "")
+AGENT_PLATFORM = os.getenv("VOICEMODE_AGENT_PLATFORM", "claude-code")
+
+# Auto-register as wakeable on startup (requires AGENT_NAME to be set)
+AUTO_WAKEABLE = env_bool("VOICEMODE_AUTO_WAKEABLE", False)
+```
+
+Add to the default `voicemode.env` template:
+
+```env
+#############
+# Agent Identity
+#############
+
+# Agent display name for VoiceMode Connect dashboard
+# When set with AUTO_WAKEABLE, agent registers automatically on startup
+# VOICEMODE_AGENT_NAME=Cora 7
+
+# Agent platform identifier (default: claude-code)
+# VOICEMODE_AGENT_PLATFORM=claude-code
+
+# Auto-register as wakeable on MCP startup (true/false, default: false)
+# Requires VOICEMODE_AGENT_NAME to be set
+# VOICEMODE_AUTO_WAKEABLE=false
+```
+
+### 2. Python message delivery library
+
+**New file**: `voice_mode/messaging.py`
+
+Pure Python implementation of the `send-message` inbox injection protocol. No subprocess calls, no PATH dependency.
+
+```python
+"""Message delivery library for Claude Code agent inboxes.
+
+Implements the same inbox file protocol as the send-message bash script,
+but as a Python library callable from within VoiceMode directly.
+
+Protocol: Write JSON messages to ~/.claude/teams/{team}/inboxes/{recipient}.json
+Claude Code watches these files via FSEvents and wakes the agent automatically.
+"""
+
+def deliver_message(
+    team_name: str,
+    content: str,
+    recipient: str = "team-lead",
+    sender: str = "voicemode",
+    summary: str | None = None,
+) -> bool:
+    """Deliver a message to a Claude Code agent's team inbox.
+
+    Args:
+        team_name: Team name (directory under ~/.claude/teams/)
+        content: Message text
+        recipient: Target agent name (default: team-lead)
+        sender: Sender display name
+        summary: Brief summary (default: first 50 chars of content)
+
+    Returns:
+        True if message was written successfully, False otherwise.
+    """
+```
+
+Key implementation details:
+- Reads existing inbox JSON, appends new message, writes atomically (write to temp, rename)
+- Creates inbox directory if needed
+- Follows same JSON schema as `send-message`: `{from, text, summary, timestamp, read}`
+- Synchronous function (filesystem I/O only, no async needed)
+- No external dependencies
+
+### 3. Auto-register on startup
+
+**File**: `voice_mode/connect_registry.py`
+
+After the WebSocket connection is established and the `ready` message is sent, check if auto-wakeable is configured:
+
+```python
+# In _connection_loop(), after sending ready message:
+if self._wakeable_team_name:
+    # Re-registration (existing behavior)
+    await self._send_wakeable_registration(ws)
+elif AUTO_WAKEABLE and AGENT_NAME:
+    # Auto-registration on first connect
+    # Note: team_name comes from the agent at runtime, not config
+    # Auto-wakeable only pre-configures the agent name
+    logger.info(f"Auto-wakeable configured but no team registered yet "
+                f"(agent: {AGENT_NAME})")
+```
+
+The flow is:
+1. VoiceMode MCP starts, ConnectRegistry connects to voicemode.dev
+2. VoiceMode announces TTS/STT capabilities (existing behavior)
+3. Agent starts, creates team, calls `register_wakeable` with team name
+4. VoiceMode announces wakeable capability with agent name
+
+**Why not fully automatic?** The team name is ephemeral and created by the agent at runtime. VoiceMode can't know it ahead of time. What auto-wakeable does is:
+- Pre-configure the agent name so `register_wakeable` doesn't need to provide it
+- In future: if VoiceMode owns message storage (V2), it can auto-register without a team name at all
+
+For V1, `register_wakeable` is still called by the agent, but it's simpler because the name defaults from config:
+
+```python
+@mcp.tool()
+async def register_wakeable(
+    team_name: str,
+    agent_name: str = "",  # Empty = use VOICEMODE_AGENT_NAME config
+    agent_platform: str = "",  # Empty = use VOICEMODE_AGENT_PLATFORM config
+) -> str:
+```
+
+### 4. Wire `_handle_agent_message` to use library
+
+**File**: `voice_mode/connect_registry.py`
+
+Replace the subprocess call to `send-message` with a direct call to the messaging library:
+
+```python
+async def _handle_agent_message(self, text: str, sender: str):
+    """Handle an incoming agent_message by delivering to team inbox."""
+    from .messaging import deliver_message
+
+    team_name = self._wakeable_team_name
+    if not team_name:
+        logger.warning("Received agent_message but not registered as wakeable")
+        return
+
+    if not text.strip():
+        logger.warning("Received empty agent_message, ignoring")
+        return
+
+    success = await asyncio.to_thread(
+        deliver_message,
+        team_name=team_name,
+        content=text,
+        sender=sender,
+    )
+
+    if success:
+        logger.info(f"Message delivered to team '{team_name}' from '{sender}'")
+    else:
+        logger.error(f"Failed to deliver message to team '{team_name}'")
+```
+
+This eliminates the `shutil.which("send-message")` dependency and the `subprocess.run` overhead.
+
+## Files Changed
+
+| File | Change |
+|------|--------|
+| `voice_mode/config.py` | Add `AGENT_NAME`, `AGENT_PLATFORM`, `AUTO_WAKEABLE` config vars |
+| `voice_mode/messaging.py` | **New** - Python message delivery library |
+| `voice_mode/connect_registry.py` | Wire `_handle_agent_message` to use `messaging.deliver_message` |
+| `voice_mode/tools/connect.py` | Default `agent_name`/`agent_platform` from config |
+| `tests/test_messaging.py` | **New** - Unit tests for messaging library |
+| `tests/test_connect_registry.py` | Update tests for new message delivery path |
+
+## Implementation Order
+
+1. **`voice_mode/messaging.py`** + tests - standalone, no dependencies on other changes
+2. **`voice_mode/config.py`** - add new config vars
+3. **`voice_mode/connect_registry.py`** - replace subprocess with messaging library
+4. **`voice_mode/tools/connect.py`** - default params from config
+
+Steps 1-2 can be done in parallel. Steps 3-4 depend on both.
+
+## Testing Strategy
+
+- `test_messaging.py`: Test deliver_message with temp directories (create inbox, append to existing, handle missing team, atomic write)
+- `test_connect_registry.py`: Test `_handle_agent_message` calls `deliver_message` instead of subprocess
+- `test_config.py`: Verify new env vars are parsed correctly
+- Manual: Set `VOICEMODE_AGENT_NAME=Test` in voicemode.env, start MCP, verify register_wakeable uses the name
+
+## Out of Scope (V2+)
+
+- Server-side message storage on voicemode.dev
+- E2E encryption for stored messages
+- VoiceMode-owned message directory (`~/.voicemode/messages/`)
+- Pluggable delivery backends (WhatsApp, etc.)
+- DNS-style agent addressing (`cora.mike.connect.voicemode.dev`)
+- Message expiry / read receipts / QoS levels
+- Auto-registration without agent needing to provide team name

--- a/docs/plans/tool-signature-alignment.md
+++ b/docs/plans/tool-signature-alignment.md
@@ -1,0 +1,46 @@
+# Tool Signature Alignment: VoiceMode Local vs VoiceMode Connect
+
+**Date**: 2026-02-16
+**Source**: Voice conversation between Mike and Wimo
+**Status**: Proposed
+
+## Goal
+
+Align the tool names and function signatures between VoiceMode (local MCP) and VoiceMode Connect (cloud MCP) so that:
+
+1. A wake/call message to an agent can simply say "use `converse` to speak with Mike" and it works regardless of which MCP server handles the call
+2. The agent doesn't need to know whether it's using local audio or remote WebSocket transport — same interface, different transport
+
+## Current State
+
+### VoiceMode Local (`voice_mode/tools/`)
+Default tools exposed:
+- `converse(message, wait_for_response, voice, ...)` — TTS + STT via local mic/speakers
+- `service(service_name, action, lines)` — manage Whisper/Kokoro services
+
+Additional tools:
+- `register_wakeable(team_name, agent_name, agent_platform)` — register as wakeable via Connect
+- Various admin tools (devices, providers, diagnostics, etc.)
+
+### VoiceMode Connect (`mcp__claude_ai_voicemode-connect__*`)
+- `converse(message, wait_for_response, voice, speed, ...)` — TTS + STT via remote web/mobile client
+- `status(include_voices)` — list connected devices
+
+## Proposed Direction
+
+Review both `converse` signatures and align them so that:
+- Core parameters match (message, wait_for_response, voice, speed)
+- The wake/call message sent from the dashboard can just say "use converse to speak with [user]" without specifying which MCP server
+- Either server can handle the call transparently
+- Consider adding optional `device` parameter to local converse to route through WebSocket when a Connect device is available
+
+## Questions to Resolve
+
+1. Should local `converse` gain a `device` parameter that routes through Connect's WebSocket?
+2. Or should the message just work with whichever `converse` tool the agent has available?
+3. How do we handle the case where an agent has both local VoiceMode and VoiceMode Connect installed?
+4. Should `status` be unified to show both local and remote devices?
+
+## Context
+
+This emerged from discussing how the dashboard "call" button should work. Instead of a special "wake" message type, the call button sends a regular message telling the agent to use `converse` to respond. If the tool signatures are aligned, the message works regardless of which MCP server the agent has.

--- a/uv.lock
+++ b/uv.lock
@@ -5593,7 +5593,7 @@ requires-dist = [
     { name = "click", specifier = ">=8.0.0" },
     { name = "coremltools", marker = "extra == 'coreml'", specifier = ">=7.0" },
     { name = "coverage", extras = ["toml"], marker = "extra == 'test'", specifier = ">=7.4.0" },
-    { name = "fastmcp", specifier = ">=2.3.2" },
+    { name = "fastmcp", specifier = ">=2.3.2,<3" },
     { name = "flask", marker = "extra == 'scripts'", specifier = ">=3.0.0" },
     { name = "gradio", marker = "extra == 'notebooks'", specifier = ">=4.0.0" },
     { name = "httpx" },

--- a/voice_mode/data/hooks/connect-on-team-created.json
+++ b/voice_mode/data/hooks/connect-on-team-created.json
@@ -1,0 +1,16 @@
+{
+  "description": "VoiceMode Connect: PostToolUse hook for TeamCreate - wires up inbox delivery and registers user with Connect gateway",
+  "hooks": {
+    "PostToolUse": [
+      {
+        "matcher": "TeamCreate",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "${CLAUDE_PLUGIN_ROOT}/voice_mode/data/hooks/connect-on-team-created.sh"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/voice_mode/data/hooks/connect-session-start.json
+++ b/voice_mode/data/hooks/connect-session-start.json
@@ -1,0 +1,15 @@
+{
+  "description": "VoiceMode Connect: SessionStart hook - cleans up stale team dir and prompts agent to create team for Connect",
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "${CLAUDE_PLUGIN_ROOT}/voice_mode/data/hooks/connect-session-start.sh"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/voice_mode/tools/connect_status.py
+++ b/voice_mode/tools/connect_status.py
@@ -1,0 +1,210 @@
+"""VoiceMode Connect status and presence tool.
+
+Provides a single MCP tool for checking connection status and
+setting agent presence (available/away) on the Connect gateway.
+Idempotent — ensures user exists and is registered before setting presence.
+"""
+
+import logging
+from typing import Optional
+
+from voice_mode.server import mcp
+
+logger = logging.getLogger("voicemode")
+
+
+@mcp.tool()
+async def connect_status(
+    set_presence: Optional[str] = None,
+    username: Optional[str] = None,
+) -> str:
+    """VoiceMode Connect status and presence.
+
+    Check connection status and who's online, or set your availability.
+    Idempotent — safe to call multiple times. Creates user if needed.
+
+    Args:
+        set_presence: Optional. Set to "available" (green dot - ready for calls)
+            or "away" (amber dot - connected but not accepting calls).
+            Omit to just check status.
+        username: Optional. Your Connect username (e.g., "cora", "astrid").
+            Used to identify which user to register on this WebSocket.
+            The PostToolUse hook provides this in its systemMessage.
+
+    Returns:
+        Connection status, online contacts, and presence state.
+
+    Examples:
+        connect_status()                                         # Check status
+        connect_status(set_presence="available", username="cora") # Go available
+        connect_status(set_presence="away")                       # Go away
+    """
+    from voice_mode.connect.client import get_client
+    from voice_mode.connect import config as connect_config
+
+    if not connect_config.is_enabled():
+        return (
+            "VoiceMode Connect is disabled.\n"
+            "Set VOICEMODE_CONNECT_ENABLED=true in .voicemode.env to enable."
+        )
+
+    client = get_client()
+
+    # Ensure we're connected
+    if not client.is_connected and not client.is_connecting:
+        await client.connect()
+
+    # Handle presence change
+    if set_presence:
+        return await _set_presence(client, set_presence, username)
+
+    # Default: return status
+    return client.get_status_text()
+
+
+async def _ensure_user_registered(client, username: Optional[str] = None) -> list:
+    """Ensure this agent's user is registered on the MCP server's WebSocket.
+
+    Idempotent — if already registered, returns existing user. If username
+    is provided and user doesn't exist on filesystem, creates it.
+
+    Args:
+        client: The ConnectClient instance.
+        username: Optional explicit username. If provided and no filesystem
+            user exists, creates one with display name from VOICEMODE_AGENT_NAME.
+
+    Returns list of this agent's users.
+    """
+    from voice_mode.connect import config as connect_config
+
+    # Already registered — return it
+    if client._primary_user:
+        user = client.user_manager.get(client._primary_user.name)
+        if user:
+            return [user]
+
+    # Explicit username provided — find or create
+    if username:
+        username = username.lower().strip()
+        user = client.user_manager.get(username)
+        if not user:
+            # Create user on filesystem (idempotent)
+            display_name = connect_config.get_agent_name() or username
+            user = client.user_manager.add(
+                name=username,
+                display_name=display_name,
+            )
+            logger.info(f"Created Connect user: {username}")
+
+        # Register on this WebSocket
+        await client.register_user(user)
+        logger.info(f"Registered user {username} on MCP server WebSocket")
+        return [user]
+
+    # No username — discover from filesystem
+    # Look for users with inbox-live symlinks (set up by hooks)
+    subscribed_users = [
+        u for u in client.user_manager.list()
+        if client.user_manager.is_subscribed(u.name)
+    ]
+
+    if subscribed_users:
+        # Register the first subscribed user as our primary
+        user = subscribed_users[0]
+        await client.register_user(user)
+        logger.info(
+            f"Auto-registered user {user.name} on MCP server WebSocket"
+        )
+        return subscribed_users
+
+    # No subscribed users — check for preconfigured users
+    configured = connect_config.get_preconfigured_users()
+    if configured:
+        users = []
+        for name in configured:
+            user = client.user_manager.get(name)
+            if user:
+                users.append(user)
+        if users:
+            await client.register_user(users[0])
+            return users
+
+    # No users found at all — return empty
+    return []
+
+
+async def _set_presence(client, presence: str, username: Optional[str] = None) -> str:
+    """Set presence on the Connect gateway. Idempotent."""
+    presence = presence.lower().strip()
+
+    # Accept common aliases
+    if presence in ("unavailable", "busy", "dnd"):
+        presence = "away"
+
+    if presence not in ("available", "away"):
+        return (
+            f"Invalid presence: '{presence}'. "
+            "Use 'available' (green dot) or 'away' (amber dot)."
+        )
+
+    if not client.is_connected:
+        return (
+            "Not connected to VoiceMode Connect gateway. "
+            "Cannot set presence while disconnected."
+        )
+
+    # Ensure user is registered (idempotent, creates if needed)
+    my_users = await _ensure_user_registered(client, username)
+
+    if not my_users:
+        return (
+            "No Connect users found. Pass username parameter or ensure "
+            "the PostToolUse hook created a user after TeamCreate."
+        )
+
+    # For "available", verify inbox-live symlink exists
+    if presence == "available":
+        any_subscribed = any(
+            client.user_manager.is_subscribed(u.name) for u in my_users
+        )
+        if not any_subscribed:
+            return (
+                "Cannot go available: no inbox-live symlink found.\n"
+                "Create a Claude Code team first (TeamCreate), then try again.\n"
+                "The inbox-live symlink connects incoming messages to your team inbox."
+            )
+
+    # Build presence update for only this agent's users
+    user_entries = []
+    for user in my_users:
+        # Map "away" to "online" for the wire protocol (gateway treats
+        # anything != "available" as not-available, shows amber dot)
+        wire_presence = presence if presence == "available" else "online"
+        user_entries.append({
+            "name": user.name,
+            "host": user.host,
+            "display_name": user.display_name,
+            "presence": wire_presence,
+        })
+
+    try:
+        import json
+        msg = {
+            "type": "capabilities_update",
+            "users": user_entries,
+            "platform": "claude-code",
+        }
+        await client._ws.send(json.dumps(msg))
+
+        if presence == "available":
+            user_names = ", ".join(u.display_name or u.name for u in my_users)
+            return (
+                f"✅ Now Available (green dot). Users can call you.\n"
+                f"Registered as: {user_names}"
+            )
+        else:
+            return "✅ Now Away (amber dot). Messages will queue for later."
+
+    except Exception as e:
+        logger.error(f"Failed to set presence: {e}")
+        return f"Failed to set presence: {e}"


### PR DESCRIPTION
## Summary
- Add `.voicemode.env` and `.claude/worktrees/` to .gitignore
- Add `connect_status.py` tool for checking VoiceMode Connect status
- Add connect hook configs (team-created, session-start)
- Add message hub v1 and tool signature alignment design docs
- Sync uv.lock for fastmcp<3 version pin
- Delete junk files (foo.json, overwriteme.md, test-suite-review.docx)

🤖 Generated with [Claude Code](https://claude.com/claude-code)