### PR TITLE
refactor: Remove connect up/down, agent-only presence (VM-824)

### DIFF
--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -958,8 +958,8 @@ class TestAuthStatusCLI:
             assert "expired" in result.output.lower()
 
 
-class TestStandbyRemoved:
-    """Verify the standby command has been removed (replaced by 'up')."""
+class TestStandbyAndUpRemoved:
+    """Verify standby, up, and down commands have been removed (VM-824)."""
 
     def test_standby_command_not_registered(self):
         """standby command should not exist under connect group."""
@@ -968,17 +968,22 @@ class TestStandbyRemoved:
 
         runner = CliRunner()
         result = runner.invoke(connect, ["standby", "--help"])
-
-        # Should fail because standby no longer exists
         assert result.exit_code != 0
 
-    def test_up_command_exists(self):
-        """'up' command should exist as the replacement."""
+    def test_up_command_not_registered(self):
+        """up command was removed — agents handle their own presence."""
         from click.testing import CliRunner
         from voice_mode.cli import connect
 
         runner = CliRunner()
         result = runner.invoke(connect, ["up", "--help"])
+        assert result.exit_code != 0
 
-        assert result.exit_code == 0
-        assert "voicemode.dev" in result.output
+    def test_down_command_not_registered(self):
+        """down command was removed along with up."""
+        from click.testing import CliRunner
+        from voice_mode.cli import connect
+
+        runner = CliRunner()
+        result = runner.invoke(connect, ["down", "--help"])
+        assert result.exit_code != 0

--- a/tests/test_connect_cli.py
+++ b/tests/test_connect_cli.py
@@ -174,65 +174,20 @@ class TestStatus:
         assert "2026-02-17T10:00:00Z" in result.output
 
 
-class TestUp:
-    def test_up_help(self, runner):
+class TestUpRemoved:
+    """Verify connect up command has been removed (VM-824)."""
+
+    def test_up_command_not_registered(self, runner):
         result = runner.invoke(voice_mode_main_cli, ["connect", "up", "--help"])
-        assert result.exit_code == 0
-        assert "Bring up connection" in result.output
-        assert "voicemode connect up" in result.output
-
-    def test_up_requires_connect_enabled(self, runner, monkeypatch):
-        import voice_mode.config as config_mod
-        monkeypatch.setattr(config_mod, "CONNECT_ENABLED", False)
-
-        result = runner.invoke(voice_mode_main_cli, ["connect", "up"])
         assert result.exit_code != 0
-        assert "not enabled" in result.output
-
-    def test_up_requires_credentials(self, runner, connect_env, monkeypatch):
-        """up should fail gracefully when not logged in."""
-        monkeypatch.setattr(
-            "voice_mode.auth.get_valid_credentials",
-            lambda auto_refresh=False: None,
-        )
-        result = runner.invoke(voice_mode_main_cli, ["connect", "up"])
-        assert result.exit_code != 0
-        assert "Not logged in" in result.output
 
 
-class TestDown:
-    def test_down_help(self, runner):
+class TestDownRemoved:
+    """Verify connect down command has been removed (VM-824)."""
+
+    def test_down_command_not_registered(self, runner):
         result = runner.invoke(voice_mode_main_cli, ["connect", "down", "--help"])
-        assert result.exit_code == 0
-        assert "Disconnect" in result.output
-
-    def test_down_no_process_running(self, runner, connect_env, tmp_path, monkeypatch):
-        """down should report when no process is running."""
-        import voice_mode.connect.users as users_mod
-        connect_dir = tmp_path / "connect"
-        connect_dir.mkdir(exist_ok=True)
-        monkeypatch.setattr(users_mod, "CONNECT_DIR", connect_dir)
-
-        result = runner.invoke(voice_mode_main_cli, ["connect", "down"])
-        assert result.exit_code == 0
-        assert "No connect process running" in result.output
-
-    def test_down_stale_pid(self, runner, connect_env, tmp_path, monkeypatch):
-        """down should clean up stale PID file for dead process."""
-        import voice_mode.connect.users as users_mod
-        connect_dir = tmp_path / "connect"
-        connect_dir.mkdir(exist_ok=True)
-        monkeypatch.setattr(users_mod, "CONNECT_DIR", connect_dir)
-
-        # Write a PID that doesn't exist (use a very high PID)
-        pid_file = connect_dir / "pid"
-        pid_file.write_text("999999999")
-
-        result = runner.invoke(voice_mode_main_cli, ["connect", "down"])
-        assert result.exit_code == 0
-        assert "not running" in result.output
-        # PID file should be cleaned up
-        assert not pid_file.exists()
+        assert result.exit_code != 0
 
 
 class TestStandbyRemoved:

--- a/tests/test_standby_integration.py
+++ b/tests/test_standby_integration.py
@@ -1,7 +1,7 @@
-"""Tests verifying the standby command has been removed.
+"""Tests verifying the standby and connect up/down commands have been removed.
 
-The standby command was replaced by 'voicemode connect up' which has
-proper VOICEMODE_CONNECT_ENABLED guard and the new connect architecture.
+The standalone daemon model (standby → connect up) was replaced by
+agent-driven presence via the connect_status MCP tool (VM-824).
 """
 
 
@@ -19,13 +19,22 @@ class TestStandbyRemoved:
         # Should fail because standby no longer exists
         assert result.exit_code != 0
 
-    def test_up_command_exists(self):
-        """'up' command should exist as the replacement."""
+
+class TestConnectUpDownRemoved:
+    """Verify connect up and down are gone (VM-824)."""
+
+    def test_up_command_not_registered(self):
         from click.testing import CliRunner
         from voice_mode.cli import connect
 
         runner = CliRunner()
         result = runner.invoke(connect, ["up", "--help"])
+        assert result.exit_code != 0
 
-        assert result.exit_code == 0
-        assert "voicemode.dev" in result.output
+    def test_down_command_not_registered(self):
+        from click.testing import CliRunner
+        from voice_mode.cli import connect
+
+        runner = CliRunner()
+        result = runner.invoke(connect, ["down", "--help"])
+        assert result.exit_code != 0


### PR DESCRIPTION
## Summary

- **Remove `voicemode connect up` and `voicemode connect down` CLI commands** — the standalone daemon model is replaced by agent-driven presence
- **Fix ghost contacts bug** (also in PR #290 / VM-822) — ConnectClient no longer scans filesystem and announces all users on WebSocket connect
- Each agent announces only itself via `connect_status` MCP tool

## What changed

**`voice_mode/cli.py`:**
- Removed `up()` command (~150 lines) including async WebSocket loop, file watcher integration, PID file management
- Removed `down()` command (~45 lines) including PID-based signal handling
- Updated `connect` group help text and `auth login` success message

**`voice_mode/connect/client.py`:**
- `send_capabilities_update()`: Only announces registered primary user, never scans filesystem
- `_connection_loop()`: Only re-announces on reconnect if primary user registered
- `unregister_user()`: Simplified to send empty capabilities_update directly

**Tests updated:**
- `test_connect_cli.py`: Up/Down test classes replaced with removal verification tests
- `test_connect_client.py`: Tests updated for agent-only announcement model
- `test_standby_integration.py`: Added up/down removal verification
- `test_auth.py`: Updated standby removal test to also verify up/down removed

## Context

VM-822 research found that `connect up` was causing ghost contacts on the dashboard by announcing ALL users from `~/.voicemode/connect/users/` on every WebSocket connection. With the new hook-based presence model (VM-802), each agent handles its own presence — no daemon needed.

## Test plan

- [x] 1072 tests pass, 58 skipped
- [x] New tests verify up/down commands are not registered
- [ ] Verify `voicemode connect --help` no longer shows up/down
- [ ] Verify agent presence still works via connect_status MCP tool

🤖 Generated with [Claude Code](https://claude.com/claude-code)