### PR TITLE
feat: auto-focus tmux pane when agent speaks (VM-922)

### DIFF
--- a/.claude/skills/voicemode/SKILL.md
+++ b/.claude/skills/voicemode/SKILL.md
@@ -297,6 +297,22 @@ voicemode:converse("Transferring you back to the assistant.", wait_for_response=
 3. **Distinct voices**: Different voices make handoffs audible
 4. **Provide context**: Tell receiving agent why user is being transferred
 
+### Auto-focus tmux pane on speak (opt-in)
+
+When you run multiple voice agents in separate tmux panes, set
+`VOICEMODE_AUTO_FOCUS_PANE=true` to make tmux follow the speaker. Focus
+switches **after conch acquisition**, so agents waiting on the conch never
+steal focus -- only the agent about to speak does. It also respects the
+`~/.voicemode/focus-hold` sentinel written by the show-me plugin, so a
+file you just opened stays on screen for its hold window.
+
+```bash
+# ~/.voicemode/voicemode.env
+VOICEMODE_AUTO_FOCUS_PANE=true
+```
+
+Off by default. Silent no-op outside tmux.
+
 ### Detailed Documentation
 
 See [Call Routing](../../../docs/guides/agents/call-routing/) for comprehensive guides:

--- a/docs/guides/configuration.md
+++ b/docs/guides/configuration.md
@@ -169,6 +169,32 @@ VOICEMODE_MIN_RECORDING_TIME=0.5    # Minimum recording
 VOICEMODE_MAX_RECORDING_TIME=120.0  # Maximum recording
 ```
 
+### Multi-Agent Voice
+
+When running multiple voice agents (e.g. separate Claude Code sessions in
+different tmux panes), the "conch" mechanism serialises speech so only one
+agent talks at a time, and `VOICEMODE_AUTO_FOCUS_PANE` can visually follow
+the speaker.
+
+```bash
+# Auto-focus tmux pane when an agent starts speaking (default: false)
+# Switches tmux focus to the speaking agent's pane *after* conch acquisition,
+# so agents waiting on the conch never steal focus. Respects the focus-hold
+# sentinel written by show-me (~/.voicemode/focus-hold) so a shown file is
+# not yanked away. Silent no-op outside tmux.
+VOICEMODE_AUTO_FOCUS_PANE=false
+
+# Override the default focus-hold duration if the sentinel file has no
+# explicit value (default: 30 seconds)
+VOICEMODE_FOCUS_HOLD_SECONDS=30
+
+# Conch coordination (serialises speech across agents)
+VOICEMODE_CONCH_ENABLED=true
+VOICEMODE_CONCH_TIMEOUT=60           # Seconds to wait for the conch
+VOICEMODE_CONCH_CHECK_INTERVAL=0.5   # Polling interval
+VOICEMODE_CONCH_LOCK_EXPIRY=300      # Stale-lock expiry (0 disables)
+```
+
 ### LiveKit Configuration
 
 ```bash

--- a/tests/test_auto_focus_pane.py
+++ b/tests/test_auto_focus_pane.py
@@ -1,7 +1,34 @@
 """Tests for auto-focus tmux pane feature (VM-922)."""
 
-import subprocess
-from unittest.mock import patch, call
+from unittest.mock import patch, MagicMock
+
+
+def _mk_run(display_session="worker", clients_on_session="", all_clients=""):
+    """Build a subprocess.run side_effect that returns scripted results by argv.
+
+    - select-pane / select-window: rc=0, no stdout needed
+    - display-message: returns the session name
+    - list-clients -t <session>: stdout lists clients already on that session
+    - list-clients -F ...: stdout lists all clients with flags
+    - switch-client: rc=0
+    """
+    def fake_run(argv, *_args, **_kwargs):
+        result = MagicMock()
+        result.returncode = 0
+        result.stdout = ""
+        if not isinstance(argv, list) or len(argv) < 2 or argv[0] != "tmux":
+            return result
+        sub = argv[1]
+        if sub == "display-message":
+            result.stdout = display_session + "\n"
+        elif sub == "list-clients":
+            # "-t <session>" form includes "-t" at index 2
+            if "-t" in argv:
+                result.stdout = clients_on_session
+            else:
+                result.stdout = all_clients
+        return result
+    return fake_run
 
 
 class TestIsTmux:
@@ -26,18 +53,50 @@ class TestIsTmux:
 class TestFocusTmuxPane:
     """Test the focus_tmux_pane() function."""
 
-    def test_runs_select_pane_and_select_window(self):
-        with patch.dict("os.environ", {"TMUX_PANE": "%5"}):
-            with patch("subprocess.run") as mock_run:
+    def test_selects_pane_and_window(self):
+        """select-pane and select-window always run when TMUX_PANE is set."""
+        with patch.dict("os.environ", {"TMUX_PANE": "%5"}, clear=False):
+            with patch("subprocess.run", side_effect=_mk_run(clients_on_session="/dev/ttys001\n")) as mock_run:
                 from voice_mode.tools.converse import focus_tmux_pane
                 focus_tmux_pane()
 
-                assert mock_run.call_count == 2
                 mock_run.assert_any_call(
                     ["tmux", "select-pane", "-t", "%5"], capture_output=True
                 )
                 mock_run.assert_any_call(
                     ["tmux", "select-window", "-t", "%5"], capture_output=True
+                )
+
+    def test_skips_switch_client_when_session_already_visible(self):
+        """If a client is already attached to the agent's session, don't steal focus."""
+        with patch.dict("os.environ", {"TMUX_PANE": "%5"}, clear=False):
+            with patch("subprocess.run", side_effect=_mk_run(
+                display_session="worker",
+                clients_on_session="/dev/ttys003\n",
+            )) as mock_run:
+                from voice_mode.tools.converse import focus_tmux_pane
+                focus_tmux_pane()
+
+                # No switch-client call should have happened
+                for c in mock_run.call_args_list:
+                    argv = c.args[0]
+                    assert argv[:2] != ["tmux", "switch-client"], \
+                        "switch-client should be skipped when session is already attached"
+
+    def test_switches_focused_client_when_session_unattached(self):
+        """If nothing is showing the agent's session, switch the focused client."""
+        with patch.dict("os.environ", {"TMUX_PANE": "%5"}, clear=False):
+            with patch("subprocess.run", side_effect=_mk_run(
+                display_session="worker",
+                clients_on_session="",
+                all_clients="/dev/ttys000 (detached)\n/dev/ttys004 (focused)\n",
+            )) as mock_run:
+                from voice_mode.tools.converse import focus_tmux_pane
+                focus_tmux_pane()
+
+                mock_run.assert_any_call(
+                    ["tmux", "switch-client", "-c", "/dev/ttys004", "-t", "worker"],
+                    capture_output=True,
                 )
 
     def test_noop_when_tmux_pane_missing(self):
@@ -65,6 +124,16 @@ class TestFocusTmuxPane:
                 from voice_mode.tools.converse import focus_tmux_pane
                 # Should not raise
                 focus_tmux_pane()
+
+    def test_respects_focus_hold_sentinel(self):
+        """When the focus-hold sentinel is active, focus is suppressed entirely."""
+        with patch.dict("os.environ", {"TMUX_PANE": "%5"}, clear=False):
+            with patch("voice_mode.tools.converse._is_focus_held", return_value=True):
+                with patch("subprocess.run") as mock_run:
+                    from voice_mode.tools.converse import focus_tmux_pane
+                    focus_tmux_pane()
+
+                    mock_run.assert_not_called()
 
 
 class TestAutoFocusPaneConfig:

--- a/tests/test_auto_focus_pane.py
+++ b/tests/test_auto_focus_pane.py
@@ -1,0 +1,98 @@
+"""Tests for auto-focus tmux pane feature (VM-922)."""
+
+import subprocess
+from unittest.mock import patch, call
+
+
+class TestIsTmux:
+    """Test the is_tmux() helper function."""
+
+    def test_returns_true_when_tmux_env_set(self):
+        with patch.dict("os.environ", {"TMUX": "/tmp/tmux-501/default,12345,0"}):
+            from voice_mode.tools.converse import is_tmux
+            assert is_tmux() is True
+
+    def test_returns_false_when_tmux_env_missing(self):
+        with patch.dict("os.environ", {}, clear=True):
+            from voice_mode.tools.converse import is_tmux
+            assert is_tmux() is False
+
+    def test_returns_false_when_tmux_env_empty(self):
+        with patch.dict("os.environ", {"TMUX": ""}):
+            from voice_mode.tools.converse import is_tmux
+            assert is_tmux() is False
+
+
+class TestFocusTmuxPane:
+    """Test the focus_tmux_pane() function."""
+
+    def test_runs_select_pane_and_select_window(self):
+        with patch.dict("os.environ", {"TMUX_PANE": "%5"}):
+            with patch("subprocess.run") as mock_run:
+                from voice_mode.tools.converse import focus_tmux_pane
+                focus_tmux_pane()
+
+                assert mock_run.call_count == 2
+                mock_run.assert_any_call(
+                    ["tmux", "select-pane", "-t", "%5"], capture_output=True
+                )
+                mock_run.assert_any_call(
+                    ["tmux", "select-window", "-t", "%5"], capture_output=True
+                )
+
+    def test_noop_when_tmux_pane_missing(self):
+        with patch.dict("os.environ", {}, clear=True):
+            with patch("subprocess.run") as mock_run:
+                from voice_mode.tools.converse import focus_tmux_pane
+                focus_tmux_pane()
+
+                mock_run.assert_not_called()
+
+    def test_noop_when_tmux_pane_empty(self):
+        with patch.dict("os.environ", {"TMUX_PANE": ""}):
+            with patch("subprocess.run") as mock_run:
+                from voice_mode.tools.converse import focus_tmux_pane
+                focus_tmux_pane()
+
+                mock_run.assert_not_called()
+
+    def test_silent_when_tmux_binary_not_found(self):
+        with patch.dict("os.environ", {"TMUX_PANE": "%5"}):
+            with patch(
+                "subprocess.run",
+                side_effect=FileNotFoundError("tmux not found"),
+            ):
+                from voice_mode.tools.converse import focus_tmux_pane
+                # Should not raise
+                focus_tmux_pane()
+
+
+class TestAutoFocusPaneConfig:
+    """Test the AUTO_FOCUS_PANE config option."""
+
+    def test_default_is_false(self):
+        import os
+        os.environ.pop("VOICEMODE_AUTO_FOCUS_PANE", None)
+        from voice_mode.config import env_bool
+        assert env_bool("VOICEMODE_AUTO_FOCUS_PANE", False) is False
+
+    def test_enabled_when_set_true(self):
+        with patch.dict("os.environ", {"VOICEMODE_AUTO_FOCUS_PANE": "true"}):
+            from voice_mode.config import env_bool
+            assert env_bool("VOICEMODE_AUTO_FOCUS_PANE", False) is True
+
+    def test_enabled_with_various_truthy_values(self):
+        from voice_mode.config import env_bool
+        for value in ("true", "1", "yes", "on", "TRUE", "True"):
+            with patch.dict("os.environ", {"VOICEMODE_AUTO_FOCUS_PANE": value}):
+                assert env_bool("VOICEMODE_AUTO_FOCUS_PANE", False) is True, (
+                    f"Expected True for value '{value}'"
+                )
+
+    def test_disabled_with_falsy_values(self):
+        from voice_mode.config import env_bool
+        for value in ("false", "0", "no", "off", ""):
+            with patch.dict("os.environ", {"VOICEMODE_AUTO_FOCUS_PANE": value}):
+                assert env_bool("VOICEMODE_AUTO_FOCUS_PANE", False) is False, (
+                    f"Expected False for value '{value}'"
+                )

--- a/tests/test_release_notes_prompt.py
+++ b/tests/test_release_notes_prompt.py
@@ -27,7 +27,7 @@ def test_release_notes_prompt_parses_changelog():
 - First version
 """
     
-    with patch("voice_mode.prompts.release_notes.changelog_resource") as mock_resource:
+    with patch("voice_mode.resources.changelog.changelog_resource") as mock_resource:
         mock_resource.fn.return_value = mock_changelog
         
         result = release_notes_prompt.fn(versions="2")
@@ -51,7 +51,7 @@ def test_release_notes_prompt_parses_changelog():
 
 def test_release_notes_prompt_handles_missing_changelog():
     """Test that the prompt handles missing CHANGELOG gracefully."""
-    with patch("voice_mode.prompts.release_notes.changelog_resource") as mock_resource:
+    with patch("voice_mode.resources.changelog.changelog_resource") as mock_resource:
         mock_resource.fn.return_value = "CHANGELOG.md not found in package."
         
         result = release_notes_prompt.fn()
@@ -61,7 +61,7 @@ def test_release_notes_prompt_handles_missing_changelog():
 
 def test_release_notes_prompt_handles_error():
     """Test that the prompt handles errors from the resource."""
-    with patch("voice_mode.prompts.release_notes.changelog_resource") as mock_resource:
+    with patch("voice_mode.resources.changelog.changelog_resource") as mock_resource:
         mock_resource.fn.return_value = "Error reading CHANGELOG.md: Permission denied"
         
         result = release_notes_prompt.fn()
@@ -98,7 +98,7 @@ def test_release_notes_prompt_default_versions():
 - Version 1
 """
     
-    with patch("voice_mode.prompts.release_notes.changelog_resource") as mock_resource:
+    with patch("voice_mode.resources.changelog.changelog_resource") as mock_resource:
         mock_resource.fn.return_value = mock_changelog
         
         result = release_notes_prompt.fn()  # No versions specified
@@ -141,7 +141,7 @@ def test_release_notes_prompt_handles_empty_string():
 - Version 1
 """
     
-    with patch("voice_mode.prompts.release_notes.changelog_resource") as mock_resource:
+    with patch("voice_mode.resources.changelog.changelog_resource") as mock_resource:
         mock_resource.fn.return_value = mock_changelog
         
         # Test with empty string (what Claude Code sends)
@@ -173,7 +173,7 @@ def test_release_notes_prompt_respects_version_limit():
 - Version 1
 """
     
-    with patch("voice_mode.prompts.release_notes.changelog_resource") as mock_resource:
+    with patch("voice_mode.resources.changelog.changelog_resource") as mock_resource:
         mock_resource.fn.return_value = mock_changelog
         
         # Test with 1 version

--- a/voice_mode/config.py
+++ b/voice_mode/config.py
@@ -365,6 +365,10 @@ TTS \\bAPI\\b A P I # API as individual letters
 # Download progress style: auto, rich, simple (default: auto)
 # VOICEMODE_PROGRESS_STYLE=auto
 
+# Auto-focus tmux pane when speaking (for multi-agent setups)
+# Switches tmux focus to the agent's pane after conch acquisition
+# VOICEMODE_AUTO_FOCUS_PANE=false
+
 #############
 # Credential Storage
 #############
@@ -522,6 +526,10 @@ CONCH_CHECK_INTERVAL = float(os.getenv("VOICEMODE_CONCH_CHECK_INTERVAL", "0.5"))
 # Should be longer than your typical conversation turn (listen + TTS + buffer)
 # Default 300s (5 min) covers 2 min listen + long TTS. Set to 0 to disable.
 CONCH_LOCK_EXPIRY = float(os.getenv("VOICEMODE_CONCH_LOCK_EXPIRY", "300"))
+
+# Auto-focus tmux pane when conch is acquired (for multi-agent setups)
+# When enabled, automatically switches tmux focus to the speaking agent's pane
+AUTO_FOCUS_PANE = env_bool("VOICEMODE_AUTO_FOCUS_PANE", False)
 
 # ==================== SERVICE CONFIGURATION ====================
 

--- a/voice_mode/prompts/release_notes.py
+++ b/voice_mode/prompts/release_notes.py
@@ -1,17 +1,28 @@
 """Release notes prompt for displaying recent CHANGELOG entries."""
 
 from voice_mode.server import mcp
-# Import the resource at module level to ensure it's registered
-from voice_mode.resources.changelog import changelog_resource
 
 
 @mcp.prompt(name="release-notes")
 def release_notes_prompt(versions: str = "5") -> str:
     """View recent release notes from Voice Mode's CHANGELOG."""
+    # Lazy import to break a circular import:
+    #
+    #   voice_mode/resources/changelog.py
+    #     -> imports voice_mode/server.py
+    #       -> auto-imports voice_mode/prompts/ (this package)
+    #         -> loads release_notes.py (this module)
+    #
+    # Under pytest 9's stricter collection, importing changelog at
+    # module load time fails with "cannot import name 'changelog_resource'
+    # from partially initialized module". Deferring to call time breaks
+    # the cycle because server/prompts finish initializing first.
+    from voice_mode.resources.changelog import changelog_resource
+
     # Handle empty string from Claude Code
     if not versions or versions == "":
         versions = "5"
-    
+
     # Get the changelog content from the resource
     # Resources decorated with @mcp.resource need to access the fn attribute
     if hasattr(changelog_resource, 'fn'):

--- a/voice_mode/tools/converse.py
+++ b/voice_mode/tools/converse.py
@@ -63,7 +63,8 @@ from voice_mode.config import (
     MP3_BITRATE,
     CONCH_ENABLED,
     CONCH_TIMEOUT,
-    CONCH_CHECK_INTERVAL
+    CONCH_CHECK_INTERVAL,
+    AUTO_FOCUS_PANE
 )
 import voice_mode.config
 from voice_mode.provider_discovery import provider_registry
@@ -96,6 +97,31 @@ logger = logging.getLogger("voicemode")
 
 # Log silence detection config at module load time
 logger.info(f"Module loaded with DISABLE_SILENCE_DETECTION={DISABLE_SILENCE_DETECTION}")
+
+
+def is_tmux() -> bool:
+    """Check if the current process is running inside a tmux session."""
+    return bool(os.environ.get("TMUX"))
+
+
+def focus_tmux_pane() -> None:
+    """Focus the current tmux pane and its window.
+
+    Runs tmux select-pane and select-window to bring the current agent's
+    pane into view. Silent no-op if not in tmux, TMUX_PANE is unset,
+    or the tmux binary is not found.
+    """
+    import subprocess
+
+    tmux_pane = os.environ.get("TMUX_PANE", "")
+    if not tmux_pane:
+        return
+
+    try:
+        subprocess.run(["tmux", "select-pane", "-t", tmux_pane], capture_output=True)
+        subprocess.run(["tmux", "select-window", "-t", tmux_pane], capture_output=True)
+    except FileNotFoundError:
+        pass  # tmux binary not installed
 
 
 # DJ Ducking Configuration
@@ -1334,6 +1360,10 @@ consult the MCP resources listed above.
                     "pid": os.getpid(),
                     "agent": "converse"
                 })
+
+            # Auto-focus tmux pane after conch acquisition, before audio playback
+            if AUTO_FOCUS_PANE and is_tmux():
+                focus_tmux_pane()
 
         # Local microphone approach with timing
         transport = "local"

--- a/voice_mode/tools/converse.py
+++ b/voice_mode/tools/converse.py
@@ -105,11 +105,13 @@ def is_tmux() -> bool:
 
 
 def focus_tmux_pane() -> None:
-    """Focus the current tmux pane and its window.
+    """Focus the current tmux pane, its window, and switch the focused client.
 
-    Runs tmux select-pane and select-window to bring the current agent's
-    pane into view. Silent no-op if not in tmux, TMUX_PANE is unset,
-    or the tmux binary is not found.
+    Runs tmux select-pane, select-window, and switch-client to bring the
+    current agent's pane into view. Handles multi-session setups where each
+    terminal window is attached to a different tmux session.
+
+    Silent no-op if not in tmux, TMUX_PANE is unset, or tmux is not found.
     """
     import subprocess
 
@@ -118,8 +120,33 @@ def focus_tmux_pane() -> None:
         return
 
     try:
+        # Select the pane and its window within the session
         subprocess.run(["tmux", "select-pane", "-t", tmux_pane], capture_output=True)
         subprocess.run(["tmux", "select-window", "-t", tmux_pane], capture_output=True)
+
+        # Find which session owns this pane
+        r = subprocess.run(
+            ["tmux", "display-message", "-t", tmux_pane, "-p", "#{session_name}"],
+            capture_output=True, text=True
+        )
+        if r.returncode != 0:
+            return
+        session_name = r.stdout.strip()
+
+        # Find the focused client and switch it to our session
+        r = subprocess.run(
+            ["tmux", "list-clients", "-F", "#{client_tty} #{client_flags}"],
+            capture_output=True, text=True
+        )
+        for line in r.stdout.strip().split("\n"):
+            parts = line.split(" ", 1)
+            if len(parts) == 2 and "focused" in parts[1]:
+                client_tty = parts[0]
+                subprocess.run(
+                    ["tmux", "switch-client", "-c", client_tty, "-t", session_name],
+                    capture_output=True
+                )
+                break
     except FileNotFoundError:
         pass  # tmux binary not installed
 

--- a/voice_mode/tools/converse.py
+++ b/voice_mode/tools/converse.py
@@ -105,11 +105,15 @@ def is_tmux() -> bool:
 
 
 def focus_tmux_pane() -> None:
-    """Focus the current tmux pane, its window, and switch the focused client.
+    """Focus the current tmux pane, its window, and optionally switch a client.
 
-    Runs tmux select-pane, select-window, and switch-client to bring the
-    current agent's pane into view. Handles multi-session setups where each
-    terminal window is attached to a different tmux session.
+    Steps:
+    1. select-pane + select-window: activate the pane within its session
+    2. Check if any client is already showing this session — if so, stop
+    3. If no client is showing the session, switch the focused client to it
+
+    This avoids "stealing" the user's focused terminal when the agent's
+    session is already visible in another terminal window.
 
     Silent no-op if not in tmux, TMUX_PANE is unset, or tmux is not found.
     """
@@ -133,7 +137,16 @@ def focus_tmux_pane() -> None:
             return
         session_name = r.stdout.strip()
 
-        # Find the focused client and switch it to our session
+        # Check if any client is already attached to this session
+        r = subprocess.run(
+            ["tmux", "list-clients", "-t", session_name, "-F", "#{client_tty}"],
+            capture_output=True, text=True
+        )
+        if r.returncode == 0 and r.stdout.strip():
+            # Session already visible in a terminal — don't steal focus
+            return
+
+        # No client is showing our session — switch the focused client to it
         r = subprocess.run(
             ["tmux", "list-clients", "-F", "#{client_tty} #{client_flags}"],
             capture_output=True, text=True

--- a/voice_mode/tools/converse.py
+++ b/voice_mode/tools/converse.py
@@ -110,11 +110,21 @@ def _is_focus_held() -> bool:
     Returns True if ~/.voicemode/focus-hold exists and was modified within
     the hold period, meaning auto-focus should be suppressed to let the
     user view what was shown (e.g. a file opened by show-me).
+
+    The hold duration is read from the file contents (written by show-me's
+    --hold flag), falling back to VOICEMODE_FOCUS_HOLD_SECONDS env var,
+    then 30 seconds.
     """
     hold_file = os.path.expanduser("~/.voicemode/focus-hold")
-    hold_seconds = float(os.environ.get("VOICEMODE_FOCUS_HOLD_SECONDS", "30"))
+    default_hold = float(os.environ.get("VOICEMODE_FOCUS_HOLD_SECONDS", "30"))
     try:
         age = time.time() - os.path.getmtime(hold_file)
+        # Read hold duration from file (written by show-me --hold)
+        try:
+            with open(hold_file) as f:
+                hold_seconds = float(f.read().strip())
+        except (ValueError, OSError):
+            hold_seconds = default_hold
         return age < hold_seconds
     except (OSError, ValueError):
         return False

--- a/voice_mode/tools/converse.py
+++ b/voice_mode/tools/converse.py
@@ -104,13 +104,30 @@ def is_tmux() -> bool:
     return bool(os.environ.get("TMUX"))
 
 
+def _is_focus_held() -> bool:
+    """Check if another tool recently took visual focus (the 'visual conch').
+
+    Returns True if ~/.voicemode/focus-hold exists and was modified within
+    the hold period, meaning auto-focus should be suppressed to let the
+    user view what was shown (e.g. a file opened by show-me).
+    """
+    hold_file = os.path.expanduser("~/.voicemode/focus-hold")
+    hold_seconds = float(os.environ.get("VOICEMODE_FOCUS_HOLD_SECONDS", "30"))
+    try:
+        age = time.time() - os.path.getmtime(hold_file)
+        return age < hold_seconds
+    except (OSError, ValueError):
+        return False
+
+
 def focus_tmux_pane() -> None:
     """Focus the current tmux pane, its window, and optionally switch a client.
 
     Steps:
-    1. select-pane + select-window: activate the pane within its session
-    2. Check if any client is already showing this session — if so, stop
-    3. If no client is showing the session, switch the focused client to it
+    1. Check focus-hold sentinel — skip if another tool recently took focus
+    2. select-pane + select-window: activate the pane within its session
+    3. Check if any client is already showing this session — if so, stop
+    4. If no client is showing the session, switch the focused client to it
 
     This avoids "stealing" the user's focused terminal when the agent's
     session is already visible in another terminal window.
@@ -121,6 +138,10 @@ def focus_tmux_pane() -> None:
 
     tmux_pane = os.environ.get("TMUX_PANE", "")
     if not tmux_pane:
+        return
+
+    # Respect the visual conch — another tool recently took focus
+    if _is_focus_held():
         return
 
     try:


### PR DESCRIPTION
## Summary
- Adds `VOICEMODE_AUTO_FOCUS_PANE` config option (default: `false`)
- When enabled, automatically switches tmux focus to the speaking agent's pane
- Focus switch happens **after conch acquisition, before TTS playback** — no visual barge-in
- Graceful no-op when not in tmux or tmux binary missing

## Problem
With multiple voice agents in separate tmux panes, the user hears a voice but doesn't know which pane to look at. A naive PreToolUse hook caused "visual barge-in" — switching focus even when the agent was waiting for the conch and never spoke.

## Solution
Move the focus switch inside the converse tool, between conch acquisition and audio playback. This ensures the pane only switches when the agent actually speaks.

## Changes
- `voice_mode/config.py` — new `AUTO_FOCUS_PANE` config constant
- `voice_mode/tools/converse.py` — `is_tmux()` + `focus_tmux_pane()` helpers, called after conch
- `tests/test_auto_focus_pane.py` — 11 tests covering all edge cases

## Test plan
- [x] 11 unit tests pass (tmux detection, pane focus, config, edge cases)
- [ ] Manual test: 2 agents in separate tmux windows, verify correct pane switches
- [ ] Manual test: conch contention — verify no visual barge-in
- [ ] Manual test: graceful no-op outside tmux

## Enable
```bash
# ~/.voicemode/voicemode.env
VOICEMODE_AUTO_FOCUS_PANE=true
```

Then remove the PreToolUse hook for `mcp__voicemode__converse` from `~/.claude/settings.json`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)