### PR TITLE
feat(nix): add whisper.cpp derivation with CUDA support

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -20,11 +20,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1751984180,
-        "narHash": "sha256-LwWRsENAZJKUdD3SpLluwDmdXY9F45ZEgCb0X+xgOL0=",
+        "lastModified": 1773646010,
+        "narHash": "sha256-iYrs97hS7p5u4lQzuNWzuALGIOdkPXvjz7bviiBjUu8=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "9807714d6944a957c2e036f84b0ff8caf9930bc0",
+        "rev": "5b2c2d84341b2afb5647081c1386a80d7a8d8605",
         "type": "github"
       },
       "original": {
@@ -34,10 +34,28 @@
         "type": "github"
       }
     },
+    "nixpkgs-cuda11": {
+      "locked": {
+        "lastModified": 1735563628,
+        "narHash": "sha256-OnSAY7XDSx7CtDoqNh8jwVwh4xNL/2HaJxGjryLWzX8=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "b134951a4c9f3c995fd7be05f3243f8ecd65d798",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-24.05",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
     "root": {
       "inputs": {
         "flake-utils": "flake-utils",
-        "nixpkgs": "nixpkgs"
+        "nixpkgs": "nixpkgs",
+        "nixpkgs-cuda11": "nixpkgs-cuda11",
+        "whisper-cpp-src": "whisper-cpp-src"
       }
     },
     "systems": {
@@ -52,6 +70,23 @@
       "original": {
         "owner": "nix-systems",
         "repo": "default",
+        "type": "github"
+      }
+    },
+    "whisper-cpp-src": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1768470871,
+        "narHash": "sha256-TeS1lGKEzkHOoBemy/tMGtIsy0iouj9DTYIgTjUNcQk=",
+        "owner": "ggerganov",
+        "repo": "whisper.cpp",
+        "rev": "2eeeba56e9edd762b4b38467bab96c2517163158",
+        "type": "github"
+      },
+      "original": {
+        "owner": "ggerganov",
+        "ref": "v1.8.3",
+        "repo": "whisper.cpp",
         "type": "github"
       }
     }

--- a/flake.nix
+++ b/flake.nix
@@ -3,12 +3,109 @@
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
     flake-utils.url = "github:numtide/flake-utils";
+
+    # nixos-24.05 is the last channel with cudaPackages_11_8 and gcc11.
+    # CUDA 11.8 supports compute 3.5–8.9, covering Pascal (GTX 10xx) through
+    # Ada Lovelace (RTX 40xx). Both cudaPackages_11_8 and gcc11 have been
+    # removed from nixos-unstable, so we need a second nixpkgs input.
+    nixpkgs-cuda11.url = "github:NixOS/nixpkgs/nixos-24.05";
+
+    # Pinned to the latest stable release tag, not main.
+    whisper-cpp-src = {
+      url = "github:ggerganov/whisper.cpp/v1.8.3";
+      flake = false;
+    };
   };
-  outputs = { self, nixpkgs, flake-utils }:
+  outputs = { self, nixpkgs, flake-utils, nixpkgs-cuda11, whisper-cpp-src }:
     flake-utils.lib.eachDefaultSystem (system:
       let
         pkgs = nixpkgs.legacyPackages.${system};
-        
+        lib = pkgs.lib;
+
+        isLinuxX86 = system == "x86_64-linux";
+
+        # CUDA 11.8 toolchain — only instantiated on x86_64-linux.
+        # GCC 11 is required because CUDA 11.8's nvcc rejects GCC >= 12.
+        # Uses import (not legacyPackages) so we can set allowUnfree for
+        # the CUDA redistribution packages without affecting the main pkgs.
+        pkgsCuda11 = import nixpkgs-cuda11 {
+          inherit system;
+          config.allowUnfree = true;
+        };
+
+        whisperVersion = "1.8.3";
+
+        # ------------------------------------------------------------------
+        # whisper.cpp builder
+        # ------------------------------------------------------------------
+        #
+        # Compute capability reference (set cudaArch to match your GPU):
+        #   Pascal  (GTX 10xx)       → "61"
+        #   Volta   (Tesla V100)     → "70"
+        #   Turing  (RTX 20xx)       → "75"
+        #   Ampere  (RTX 30xx)       → "86"
+        #   Ada     (RTX 40xx)       → "89"
+        #
+        # The build sandbox has no GPU, so CMAKE_CUDA_ARCHITECTURES must be
+        # set explicitly — auto-detection would fail.
+        buildWhisperCpp = {
+          cudaSupport ? false,
+          cudaArch ? "61", # Pascal default — override for your GPU
+          cudaPackages ? pkgsCuda11.cudaPackages_11_8,
+          hostCompiler ? pkgsCuda11.gcc11,
+        }: pkgs.stdenv.mkDerivation {
+          pname = "whisper-cpp" + lib.optionalString cudaSupport "-cuda";
+          version = whisperVersion;
+          src = whisper-cpp-src;
+
+          nativeBuildInputs = [ pkgs.cmake pkgs.pkg-config ]
+            ++ lib.optionals cudaSupport [
+              cudaPackages.cuda_nvcc
+
+              # Adds an RPATH entry so libcuda.so.1 (the userspace driver)
+              # resolves at runtime. The driver lives outside the nix store
+              # (/run/opengl-driver/lib on NixOS) and is not available during
+              # the build. autoPatchelfHook is intentionally omitted — it
+              # clobbers the driver RPATH, and cmake already handles library
+              # references correctly for source builds.
+              pkgs.autoAddDriverRunpath
+            ];
+
+          buildInputs = lib.optionals cudaSupport [
+            cudaPackages.cuda_cudart
+            cudaPackages.cuda_cccl   # CUB + Thrust headers
+            cudaPackages.libcublas
+            # libstdc++ from the host compiler — the CUDA runtime links against it.
+            (lib.getLib hostCompiler.cc)
+          ];
+
+          cmakeFlags = lib.optionals cudaSupport [
+            "-DGGML_CUDA=ON"
+            "-DCMAKE_CUDA_ARCHITECTURES=${cudaArch}"
+            "-DCMAKE_C_COMPILER=${hostCompiler}/bin/gcc"
+            "-DCMAKE_CXX_COMPILER=${hostCompiler}/bin/g++"
+          ];
+
+          # libcuda.so.1 is the userspace driver — only present on the host,
+          # never in the build sandbox. autoAddDriverRunpath handles runtime
+          # resolution via /run/opengl-driver/lib RPATH entry.
+
+          meta = {
+            description = "whisper.cpp speech-to-text engine"
+              + lib.optionalString cudaSupport " (CUDA, compute ${cudaArch})";
+            homepage = "https://github.com/ggerganov/whisper.cpp";
+            license = lib.licenses.mit;
+            platforms = [ "x86_64-linux" ]
+              ++ lib.optionals (!cudaSupport) [ "aarch64-linux" "aarch64-darwin" "x86_64-darwin" ];
+          };
+        };
+
+        # ------------------------------------------------------------------
+        # whisper-cpp package variants
+        # ------------------------------------------------------------------
+        whisper-cpp = buildWhisperCpp { };
+        whisper-cpp-cuda = buildWhisperCpp { cudaSupport = true; };
+
         pythonEnv = pkgs.python312.withPackages (ps: with ps; [
           pip
           setuptools
@@ -16,8 +113,11 @@
           virtualenv
         ]);
         
-        # Wrapper script that uses uvx with proper environment
-        voice-mode = pkgs.writeShellScriptBin "voice-mode" ''
+        # Wrapper script that uses uvx with proper environment.
+        # When whisperPackage is set, its bin/ is added to PATH so that
+        # VoiceMode's find_whisper_server() discovers whisper-server
+        # via `which`.
+        mkVoiceMode = { whisperPackage ? null }: pkgs.writeShellScriptBin "voice-mode" ''
           export LD_LIBRARY_PATH="${pkgs.lib.makeLibraryPath [
             pkgs.portaudio
             pkgs.libpulseaudio
@@ -47,19 +147,30 @@
           ]}:$LIBRARY_PATH"
           
           # Make sure gcc, pkg-config, and ffmpeg are available
-          export PATH="${pkgs.gcc}/bin:${pkgs.pkg-config}/bin:${pkgs.ffmpeg}/bin:$PATH"
+          export PATH="${pkgs.gcc}/bin:${pkgs.pkg-config}/bin:${pkgs.ffmpeg}/bin${
+            lib.optionalString (whisperPackage != null) ":${whisperPackage}/bin"
+          }:$PATH"
           
           exec ${pkgs.uv}/bin/uvx voice-mode "$@"
         '';
+
+        voice-mode = mkVoiceMode { };
+        voice-mode-cuda = mkVoiceMode { whisperPackage = whisper-cpp-cuda; };
       in
       {
-        packages.default = voice-mode;
+        packages = {
+          default = voice-mode;
+          inherit voice-mode whisper-cpp;
+        } // lib.optionalAttrs isLinuxX86 {
+          inherit whisper-cpp-cuda voice-mode-cuda;
+        };
         
         devShells.default = pkgs.mkShell {
           # Build-time dependencies (available during build)
           nativeBuildInputs = with pkgs; [
             pkg-config
             gcc
+            cmake
           ] ++ pkgs.lib.optionals pkgs.stdenv.isLinux [
             alsa-lib.dev  # ALSA headers for building simpleaudio
             libpulseaudio.dev # PulseAudio headers

--- a/flake.nix
+++ b/flake.nix
@@ -16,22 +16,21 @@
       flake = false;
     };
   };
-  outputs = { self, nixpkgs, flake-utils, nixpkgs-cuda11, whisper-cpp-src }:
-    flake-utils.lib.eachDefaultSystem (system:
+  outputs =
+    {
+      self,
+      nixpkgs,
+      flake-utils,
+      nixpkgs-cuda11,
+      whisper-cpp-src,
+    }:
+    flake-utils.lib.eachDefaultSystem (
+      system:
       let
         pkgs = nixpkgs.legacyPackages.${system};
         lib = pkgs.lib;
 
         isLinuxX86 = system == "x86_64-linux";
-
-        # CUDA 11.8 toolchain — only instantiated on x86_64-linux.
-        # GCC 11 is required because CUDA 11.8's nvcc rejects GCC >= 12.
-        # Uses import (not legacyPackages) so we can set allowUnfree for
-        # the CUDA redistribution packages without affecting the main pkgs.
-        pkgsCuda11 = import nixpkgs-cuda11 {
-          inherit system;
-          config.allowUnfree = true;
-        };
 
         whisperVersion = "1.8.3";
 
@@ -48,17 +47,22 @@
         #
         # The build sandbox has no GPU, so CMAKE_CUDA_ARCHITECTURES must be
         # set explicitly — auto-detection would fail.
-        buildWhisperCpp = {
-          cudaSupport ? false,
-          cudaArch ? "61", # Pascal default — override for your GPU
-          cudaPackages ? pkgsCuda11.cudaPackages_11_8,
-          hostCompiler ? pkgsCuda11.gcc11,
-        }: pkgs.stdenv.mkDerivation {
-          pname = "whisper-cpp" + lib.optionalString cudaSupport "-cuda";
-          version = whisperVersion;
-          src = whisper-cpp-src;
+        buildWhisperCpp =
+          {
+            cudaSupport ? false,
+            cudaArch ? "61", # Pascal default — override for your GPU
+            cudaPackages ? null,
+            hostCompiler ? null,
+          }:
+          pkgs.stdenv.mkDerivation {
+            pname = "whisper-cpp" + lib.optionalString cudaSupport "-cuda";
+            version = whisperVersion;
+            src = whisper-cpp-src;
 
-          nativeBuildInputs = [ pkgs.cmake pkgs.pkg-config ]
+            nativeBuildInputs = [
+              pkgs.cmake
+              pkgs.pkg-config
+            ]
             ++ lib.optionals cudaSupport [
               cudaPackages.cuda_nvcc
 
@@ -71,167 +75,213 @@
               pkgs.autoAddDriverRunpath
             ];
 
-          buildInputs = lib.optionals cudaSupport [
-            cudaPackages.cuda_cudart
-            cudaPackages.cuda_cccl   # CUB + Thrust headers
-            cudaPackages.libcublas
-            # libstdc++ from the host compiler — the CUDA runtime links against it.
-            (lib.getLib hostCompiler.cc)
-          ];
+            buildInputs = lib.optionals cudaSupport [
+              cudaPackages.cuda_cudart
+              cudaPackages.cuda_cccl # CUB + Thrust headers
+              cudaPackages.libcublas
+              # libstdc++ from the host compiler — the CUDA runtime links against it.
+              (lib.getLib hostCompiler.cc)
+            ];
 
-          cmakeFlags = lib.optionals cudaSupport [
-            "-DGGML_CUDA=ON"
-            "-DCMAKE_CUDA_ARCHITECTURES=${cudaArch}"
-            "-DCMAKE_C_COMPILER=${hostCompiler}/bin/gcc"
-            "-DCMAKE_CXX_COMPILER=${hostCompiler}/bin/g++"
-          ];
+            cmakeFlags = lib.optionals cudaSupport [
+              "-DGGML_CUDA=ON"
+              "-DCMAKE_CUDA_ARCHITECTURES=${cudaArch}"
+              "-DCMAKE_CUDA_HOST_COMPILER=${lib.getExe hostCompiler}"
+            ];
 
-          # libcuda.so.1 is the userspace driver — only present on the host,
-          # never in the build sandbox. autoAddDriverRunpath handles runtime
-          # resolution via /run/opengl-driver/lib RPATH entry.
+            # libcuda.so.1 is the userspace driver — only present on the host,
+            # never in the build sandbox. autoAddDriverRunpath handles runtime
+            # resolution via /run/opengl-driver/lib RPATH entry.
 
-          meta = {
-            description = "whisper.cpp speech-to-text engine"
-              + lib.optionalString cudaSupport " (CUDA, compute ${cudaArch})";
-            homepage = "https://github.com/ggerganov/whisper.cpp";
-            license = lib.licenses.mit;
-            platforms = [ "x86_64-linux" ]
-              ++ lib.optionals (!cudaSupport) [ "aarch64-linux" "aarch64-darwin" "x86_64-darwin" ];
+            meta = {
+              description =
+                "whisper.cpp speech-to-text engine" + lib.optionalString cudaSupport " (CUDA, compute ${cudaArch})";
+              homepage = "https://github.com/ggerganov/whisper.cpp";
+              license = lib.licenses.mit;
+              platforms = [
+                "x86_64-linux"
+              ]
+              ++ lib.optionals (!cudaSupport) [
+                "aarch64-linux"
+                "aarch64-darwin"
+                "x86_64-darwin"
+              ];
+            };
           };
-        };
 
         # ------------------------------------------------------------------
         # whisper-cpp package variants
         # ------------------------------------------------------------------
         whisper-cpp = buildWhisperCpp { };
-        whisper-cpp-cuda = buildWhisperCpp { cudaSupport = true; };
+        cudaPackageSet = lib.optionalAttrs isLinuxX86 (
+          let
+            # CUDA 11.8 toolchain — only instantiated on x86_64-linux.
+            # GCC 11 is required because CUDA 11.8's nvcc rejects GCC >= 12.
+            # Uses import (not legacyPackages) so we can set allowUnfree for
+            # the CUDA redistribution packages without affecting the main pkgs.
+            pkgsCuda11 = import nixpkgs-cuda11 {
+              inherit system;
+              config.allowUnfree = true;
+            };
 
-        pythonEnv = pkgs.python312.withPackages (ps: with ps; [
-          pip
-          setuptools
-          wheel
-          virtualenv
-        ]);
-        
+            whisper-cpp-cuda = buildWhisperCpp {
+              cudaSupport = true;
+              cudaPackages = pkgsCuda11.cudaPackages_11_8;
+              hostCompiler = pkgsCuda11.gcc11;
+            };
+          in
+          {
+            inherit whisper-cpp-cuda;
+            voice-mode-cuda = mkVoiceMode { whisperPackage = whisper-cpp-cuda; };
+          }
+        );
+
+        pythonEnv = pkgs.python312.withPackages (
+          ps: with ps; [
+            pip
+            setuptools
+            wheel
+            virtualenv
+          ]
+        );
+
         # Wrapper script that uses uvx with proper environment.
         # When whisperPackage is set, its bin/ is added to PATH so that
         # VoiceMode's find_whisper_server() discovers whisper-server
         # via `which`.
-        mkVoiceMode = { whisperPackage ? null }: pkgs.writeShellScriptBin "voice-mode" ''
-          export LD_LIBRARY_PATH="${pkgs.lib.makeLibraryPath [
-            pkgs.portaudio
-            pkgs.libpulseaudio
-            pkgs.alsa-lib
-            pkgs.stdenv.cc.cc.lib
-          ]}:$LD_LIBRARY_PATH"
-          
-          # Add build-time dependencies for compilation
-          export PKG_CONFIG_PATH="${pkgs.lib.makeSearchPathOutput "dev" "lib/pkgconfig" [
-            pkgs.alsa-lib
-            pkgs.portaudio
-            pkgs.libpulseaudio
-          ]}:$PKG_CONFIG_PATH"
-          
-          # Add development headers to C include path
-          export CPATH="${pkgs.lib.makeSearchPathOutput "dev" "include" [
-            pkgs.alsa-lib
-            pkgs.portaudio
-            pkgs.libpulseaudio
-          ]}:$CPATH"
-          
-          # Add library paths for linking
-          export LIBRARY_PATH="${pkgs.lib.makeLibraryPath [
-            pkgs.alsa-lib
-            pkgs.portaudio
-            pkgs.libpulseaudio
-          ]}:$LIBRARY_PATH"
-          
-          # Make sure gcc, pkg-config, and ffmpeg are available
-          export PATH="${pkgs.gcc}/bin:${pkgs.pkg-config}/bin:${pkgs.ffmpeg}/bin${
-            lib.optionalString (whisperPackage != null) ":${whisperPackage}/bin"
-          }:$PATH"
-          
-          exec ${pkgs.uv}/bin/uvx voice-mode "$@"
-        '';
+        mkVoiceMode =
+          {
+            whisperPackage ? null,
+          }:
+          pkgs.writeShellScriptBin "voice-mode" ''
+            export LD_LIBRARY_PATH="${
+              pkgs.lib.makeLibraryPath [
+                pkgs.portaudio
+                pkgs.libpulseaudio
+                pkgs.alsa-lib
+                pkgs.stdenv.cc.cc.lib
+              ]
+            }:$LD_LIBRARY_PATH"
+
+            # Add build-time dependencies for compilation
+            export PKG_CONFIG_PATH="${
+              pkgs.lib.makeSearchPathOutput "dev" "lib/pkgconfig" [
+                pkgs.alsa-lib
+                pkgs.portaudio
+                pkgs.libpulseaudio
+              ]
+            }:$PKG_CONFIG_PATH"
+
+            # Add development headers to C include path
+            export CPATH="${
+              pkgs.lib.makeSearchPathOutput "dev" "include" [
+                pkgs.alsa-lib
+                pkgs.portaudio
+                pkgs.libpulseaudio
+              ]
+            }:$CPATH"
+
+            # Add library paths for linking
+            export LIBRARY_PATH="${
+              pkgs.lib.makeLibraryPath [
+                pkgs.alsa-lib
+                pkgs.portaudio
+                pkgs.libpulseaudio
+              ]
+            }:$LIBRARY_PATH"
+
+            # Make sure gcc, pkg-config, and ffmpeg are available
+            export PATH="${pkgs.gcc}/bin:${pkgs.pkg-config}/bin:${pkgs.ffmpeg}/bin${
+              lib.optionalString (whisperPackage != null) ":${whisperPackage}/bin"
+            }:$PATH"
+
+            exec ${pkgs.uv}/bin/uvx voice-mode "$@"
+          '';
 
         voice-mode = mkVoiceMode { };
-        voice-mode-cuda = mkVoiceMode { whisperPackage = whisper-cpp-cuda; };
       in
       {
         packages = {
           default = voice-mode;
           inherit voice-mode whisper-cpp;
-        } // lib.optionalAttrs isLinuxX86 {
-          inherit whisper-cpp-cuda voice-mode-cuda;
-        };
-        
+        }
+        // cudaPackageSet;
+
         devShells.default = pkgs.mkShell {
           # Build-time dependencies (available during build)
-          nativeBuildInputs = with pkgs; [
-            pkg-config
-            gcc
-            cmake
-          ] ++ pkgs.lib.optionals pkgs.stdenv.isLinux [
-            alsa-lib.dev  # ALSA headers for building simpleaudio
-            libpulseaudio.dev # PulseAudio headers
-          ];
-          
+          nativeBuildInputs =
+            with pkgs;
+            [
+              pkg-config
+              gcc
+              cmake
+            ]
+            ++ pkgs.lib.optionals pkgs.stdenv.isLinux [
+              alsa-lib.dev # ALSA headers for building simpleaudio
+              libpulseaudio.dev # PulseAudio headers
+            ];
+
           # Runtime dependencies
           buildInputs = with pkgs; [
             # Python
             pythonEnv
             uv
-            
+
             # Audio libraries (runtime)
             portaudio
             libpulseaudio
             alsa-lib
             ffmpeg
-            
+
             # Audio tools
             pulseaudio
             alsa-utils
-            
+
             # Additional tools
             git
           ];
-          
+
           shellHook = ''
             echo "Voice Mode NixOS development environment"
             echo "Python ${pkgs.python312.version} with uv and audio dependencies"
-            
+
             # Set up library paths
-            export LD_LIBRARY_PATH="${pkgs.lib.makeLibraryPath [
-              pkgs.portaudio
-              pkgs.libpulseaudio
-              pkgs.alsa-lib
-              pkgs.stdenv.cc.cc.lib
-            ]}:$LD_LIBRARY_PATH"
-            
+            export LD_LIBRARY_PATH="${
+              pkgs.lib.makeLibraryPath [
+                pkgs.portaudio
+                pkgs.libpulseaudio
+                pkgs.alsa-lib
+                pkgs.stdenv.cc.cc.lib
+              ]
+            }:$LD_LIBRARY_PATH"
+
             # Set up pkg-config for build-time compilation
             export PKG_CONFIG_PATH="${pkgs.alsa-lib.dev}/lib/pkgconfig:${pkgs.portaudio}/lib/pkgconfig:${pkgs.libpulseaudio.dev}/lib/pkgconfig:$PKG_CONFIG_PATH"
-            
+
             # Add development headers to C include path
             export CPATH="${pkgs.alsa-lib.dev}/include:${pkgs.portaudio}/include:${pkgs.libpulseaudio.dev}/include:$CPATH"
-            
+
             # Add library paths for linking
-            export LIBRARY_PATH="${pkgs.lib.makeLibraryPath [
-              pkgs.alsa-lib
-              pkgs.portaudio
-              pkgs.libpulseaudio
-            ]}:$LIBRARY_PATH"
-            
+            export LIBRARY_PATH="${
+              pkgs.lib.makeLibraryPath [
+                pkgs.alsa-lib
+                pkgs.portaudio
+                pkgs.libpulseaudio
+              ]
+            }:$LIBRARY_PATH"
+
             # Create venv if it doesn't exist
             if [ ! -d .venv ]; then
               echo "Creating virtual environment..."
               uv venv
             fi
-            
+
             echo ""
             echo "To activate the virtual environment, run: source .venv/bin/activate"
             echo "Then install voice-mode with: uv pip install -e ."
             echo "Or run directly with: uvx voice-mode"
           '';
         };
-      });
+      }
+    );
 }

--- a/voice_mode/tools/kokoro/install.py
+++ b/voice_mode/tools/kokoro/install.py
@@ -142,6 +142,33 @@ async def kokoro_install(
         # Check for and migrate old installations
         migration_msg = auto_migrate_if_needed("kokoro")
 
+        # NixOS needs two fixes for Kokoro's GPU path:
+        # 1. SSL: uv's standalone Python can't find NixOS CA certificates.
+        # 2. CUDA driver: PyTorch's pip wheels can't find libcuda.so.1
+        #    (lives at /run/opengl-driver/lib on NixOS).
+        # 3. Pascal GPUs (GTX 10xx, sm_61): torch 2.8+ dropped support.
+        #    Use torch 2.7.x+cu118 from the cu118 wheel index instead.
+        if os.path.isfile("/etc/NIXOS"):
+            return {
+                "success": False,
+                "error": "NixOS detected — Kokoro requires manual setup on NixOS.",
+                "nixos_guidance": {
+                    "install": "The standard install (clone + venv + start script) "
+                               "works, but the start script must run with: "
+                               "SSL_CERT_FILE=/etc/ssl/certs/ca-certificates.crt "
+                               "LD_LIBRARY_PATH=/run/opengl-driver/lib",
+                    "pascal_gpu": "For Pascal GPUs (GTX 10xx, sm_61): torch 2.8+ "
+                                  "dropped support. After install, swap PyTorch: "
+                                  "uv pip install torch==2.7.1+cu118 "
+                                  "--index-url https://download.pytorch.org/whl/cu118",
+                    "volta_plus": "For Volta+ GPUs (RTX 20xx and newer): the default "
+                                  "torch GPU wheels work, just set the environment "
+                                  "variables above when starting the service.",
+                    "cpu": "Kokoro's 82M model also runs well on CPU — use "
+                           "start-cpu.sh if GPU setup is not needed."
+                }
+            }
+
         # Check kokoro dependencies (unless skipped)
         if not skip_deps:
             from voice_mode.utils.dependencies.checker import (

--- a/voice_mode/tools/kokoro/install.py
+++ b/voice_mode/tools/kokoro/install.py
@@ -136,6 +136,33 @@ async def kokoro_install(
         # Check for and migrate old installations
         migration_msg = auto_migrate_if_needed("kokoro")
 
+        # NixOS needs two fixes for Kokoro's GPU path:
+        # 1. SSL: uv's standalone Python can't find NixOS CA certificates.
+        # 2. CUDA driver: PyTorch's pip wheels can't find libcuda.so.1
+        #    (lives at /run/opengl-driver/lib on NixOS).
+        # 3. Pascal GPUs (GTX 10xx, sm_61): torch 2.8+ dropped support.
+        #    Use torch 2.7.x+cu118 from the cu118 wheel index instead.
+        if os.path.isfile("/etc/NIXOS"):
+            return {
+                "success": False,
+                "error": "NixOS detected — Kokoro requires manual setup on NixOS.",
+                "nixos_guidance": {
+                    "install": "The standard install (clone + venv + start script) "
+                               "works, but the start script must run with: "
+                               "SSL_CERT_FILE=/etc/ssl/certs/ca-certificates.crt "
+                               "LD_LIBRARY_PATH=/run/opengl-driver/lib",
+                    "pascal_gpu": "For Pascal GPUs (GTX 10xx, sm_61): torch 2.8+ "
+                                  "dropped support. After install, swap PyTorch: "
+                                  "uv pip install torch==2.7.1+cu118 "
+                                  "--index-url https://download.pytorch.org/whl/cu118",
+                    "volta_plus": "For Volta+ GPUs (RTX 20xx and newer): the default "
+                                  "torch GPU wheels work, just set the environment "
+                                  "variables above when starting the service.",
+                    "cpu": "Kokoro's 82M model also runs well on CPU — use "
+                           "start-cpu.sh if GPU setup is not needed."
+                }
+            }
+
         # Check kokoro dependencies (unless skipped)
         if not skip_deps:
             from voice_mode.utils.dependencies.checker import (

--- a/voice_mode/tools/whisper/install.py
+++ b/voice_mode/tools/whisper/install.py
@@ -346,6 +346,25 @@ async def whisper_install(
         # Check for and migrate old installations
         migration_msg = auto_migrate_if_needed("whisper")
 
+        # NixOS cannot build whisper.cpp through the standard FHS path —
+        # cmake/gcc/CUDA expect paths like /usr/local/cuda/ and /usr/include/
+        # that don't exist on NixOS.  The VoiceMode flake.nix provides Nix-
+        # native packages instead.
+        if os.path.isfile("/etc/NIXOS"):
+            return {
+                "success": False,
+                "error": "NixOS detected — the standard whisper installer cannot "
+                         "build on NixOS because it expects FHS paths that don't exist.",
+                "nixos_guidance": {
+                    "cpu": "nix build github:mbailey/voicemode#whisper-cpp",
+                    "cuda": "nix build github:mbailey/voicemode#whisper-cpp-cuda",
+                    "wrapper": "nix build github:mbailey/voicemode#voice-mode-cuda",
+                    "note": "The voice-mode-cuda wrapper puts whisper-server on PATH "
+                            "so VoiceMode discovers it automatically. See flake.nix "
+                            "for GPU architecture options (cudaArch)."
+                }
+            }
+
         # Check whisper build dependencies (unless skipped)
         if not skip_deps:
             from voice_mode.utils.dependencies.checker import (


### PR DESCRIPTION
## Summary

Apologies for the drive-by PR — we hit these issues setting up VoiceMode on NixOS and figured the fixes might save the next person some time. Happy for any of this to live in the wiki instead of the CLI help if that's a better fit.

VoiceMode's built-in whisper installer fails on NixOS because it expects FHS paths (`/usr/local/cuda/`, `gcc` on PATH, ALSA headers in `/usr/include/`). This adds a proper Nix derivation that builds whisper.cpp from source with configurable CUDA acceleration, and adds NixOS detection to the install tools so users get actionable guidance instead of a cryptic build failure.

### Flake additions

- **`whisper-cpp`** — CPU-only build, all platforms
- **`whisper-cpp-cuda`** — CUDA 11.8 build, x86_64-linux, targets Pascal (sm_61) by default
- **`voice-mode-cuda`** — voice-mode wrapper with `whisper-server` on PATH for automatic discovery by `find_whisper_server()`
- **`buildWhisperCpp`** — configurable builder function accepting `cudaArch`, `cudaPackages`, and `hostCompiler` overrides

### NixOS detection in install tools

Both `whisper_install()` and `kokoro_install()` now detect NixOS (via `/etc/NIXOS`) and return early with specific guidance:
- **Whisper**: points users at the flake outputs (`nix build .#whisper-cpp-cuda`, etc.)
- **Kokoro**: documents the manual setup steps including SSL cert path, `LD_LIBRARY_PATH` for CUDA driver discovery, and PyTorch version constraints for Pascal GPUs

### Known limitation: MCP plugin build on NixOS

The VoiceMode MCP server plugin uses `simpleaudio`, which is a C extension requiring ALSA headers (`alsa/asoundlib.h`). On NixOS these aren't in a standard FHS path, so `uv run voice-mode` fails when the plugin system tries to build the venv. NixOS users need to provide `C_INCLUDE_PATH` and `LIBRARY_PATH` pointing at their Nix store's `alsa-lib.dev` package — either via a wrapper script or session environment variables. A flake output that wraps the MCP server startup with the right environment would solve this properly; happy to follow up with that if there's interest.

## Why CUDA 11.8 / nixos-24.05

CUDA 11.8 supports compute 3.5–8.9, covering Pascal (GTX 10xx) through Ada Lovelace (RTX 40xx) in a single toolkit. A second nixpkgs input pinned to `nixos-24.05` provides `cudaPackages_11_8` and `gcc11` — both have been removed from nixos-unstable. GCC 11 is required because CUDA 11.8's nvcc rejects GCC ≥ 12.

## GPU compatibility

| GPU generation | Compute | `cudaArch` value |
|---|---|---|
| Pascal (GTX 10xx) | 6.1 | `"61"` (default) |
| Volta (Tesla V100) | 7.0 | `"70"` |
| Turing (RTX 20xx) | 7.5 | `"75"` |
| Ampere (RTX 30xx) | 8.6 | `"86"` |
| Ada (RTX 40xx) | 8.9 | `"89"` |

Users override `cudaArch` for their GPU, e.g.:

```nix
whisper-cpp-cuda = buildWhisperCpp { cudaSupport = true; cudaArch = "86"; };
```

## Verified

- `nix build .#whisper-cpp` — CPU build succeeds, `whisper-server --help` runs
- `nix build .#whisper-cpp-cuda` — CUDA build succeeds on GTX 1070 (Pascal)
- `ldd` confirms `libcudart.so.11.0`, `libcublas.so.11`, `libggml-cuda.so.0` linked
- `nix flake show` — all outputs evaluate cleanly across all default systems
- CUDA packages gated to `x86_64-linux` only; other platforms unaffected

## Test plan

- [ ] `nix build .#whisper-cpp` succeeds
- [ ] `nix build .#whisper-cpp-cuda` succeeds (requires NVIDIA GPU host)
- [ ] `./result/bin/whisper-server --help` exits 0
- [ ] `nix build .#voice-mode-cuda` produces wrapper with whisper-server on PATH
- [ ] Existing `nix build` (default voice-mode) still works unchanged