### PR TITLE
Fix detection of dependencies for windows WSL2 (prefer apt-get)

### DIFF
--- a/voice_mode/utils/dependencies/package_managers.py
+++ b/voice_mode/utils/dependencies/package_managers.py
@@ -135,7 +135,19 @@ def get_package_manager() -> PackageManager:
     Raises:
         RuntimeError: If no supported package manager is found
     """
-    managers = [BrewManager(), DnfManager(), AptManager()]
+    import platform
+    import os
+
+    # platform.release() returns the kernel version string
+    def is_wsl2():
+        release = platform.release().lower()
+        return "microsoft" in release and "wsl2" in release
+
+    # WSL2 uses apt manager, trying to use brew will result in detecting packages as not installed
+    if is_wsl2():
+        managers = [AptManager(), BrewManager(), DnfManager()]
+    else:
+        managers = [BrewManager(), DnfManager(), AptManager()]
 
     for manager in managers:
         if manager.check_available():


### PR DESCRIPTION
Brew is installed in WSL2 but trying to use it to detect dependencies will result in packages reported as not installed

uvx voice-mode deps

Core Dependencies:
  ✗ python3-dev
  ✓ gcc
  ✗ libasound2-dev
  ✗ libportaudio2
  ✓ pulseaudio
  ✗ pulseaudio-utils
  ✓ ffmpeg

Whisper Dependencies:
  ✓ git
  ✓ cmake
  ✓ gcc
  ✓ g++
  ✓ make
  ✓ libsdl2-dev
  ✓ portaudio19-dev
  ✓ libasound2-dev

Kokoro Dependencies:
  ✓ git

Missing dependencies: python3-dev, libasound2-dev, libportaudio2, pulseaudio-utils

After the patch everything is reported as installed