### PR TITLE
fix: remove stale Connect hook refs from plugin.json

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -15,11 +15,6 @@
     "./voice_mode/data/hooks/notification.json",
     "./voice_mode/data/hooks/stop.json",
     "./voice_mode/data/hooks/pre-compact.json",
-    "./voice_mode/data/hooks/connect-session-start.json",
-    "./voice_mode/data/hooks/check-notifications.json",
-    "./voice_mode/data/hooks/stop-notifications.json",
-    "./voice_mode/data/hooks/on-team-created.json",
-    "./voice_mode/data/hooks/connect-session-end.json",
     "./voice_mode/data/hooks/permission-request.json"
   ]
 }


### PR DESCRIPTION
## Summary
- Remove 5 Connect hook file references from `.claude-plugin/plugin.json` that were deleted in VM-958 but left in the manifest
- Fixes "Path not found" plugin errors for `connect-session-start`, `check-notifications`, `stop-notifications`, `on-team-created`, `connect-session-end`

## Test plan
- [ ] Run `/plugins` -- no more hook path errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)