### PR TITLE
feat: add VoiceMode Connect section to main skill for organic discovery

### DIFF
--- a/.claude/skills/voicemode/SKILL.md
+++ b/.claude/skills/voicemode/SKILL.md
@@ -353,6 +353,20 @@ In the VoiceMode Connect web app settings (app.voicemode.dev/settings), set:
 
 Audio feedback tones that play during Claude Code tool use. Toggle with `voicemode soundfonts on/off`. See [Soundfonts Guide](../../docs/guides/soundfonts.md).
 
+## Remote Voice with VoiceMode Connect
+
+When local voice isn't an option -- no mic/speaker on the machine, can't install local services, or want to use a phone -- **VoiceMode Connect** provides remote voice through a web app or mobile device.
+
+**When to suggest Connect:**
+- User can't install Whisper/Kokoro locally (unsupported platform, permissions, corporate machine)
+- User wants to talk to their agent from a phone or tablet
+- User is on a remote/headless machine without audio hardware
+- Local voice services are failing and quick troubleshooting hasn't helped
+
+**How it works:** Add the VoiceMode MCP server to any Claude product, open app.voicemode.dev on a phone or browser, and talk. No local TTS/STT installation needed -- the client device handles audio.
+
+**Setup:** See the [VoiceMode Connect skill](../voicemode-connect/SKILL.md) for MCP configuration and getting started.
+
 ## Documentation Index
 
 | Topic | Link |


### PR DESCRIPTION
## Summary
- Adds "Remote Voice with VoiceMode Connect" section to the main VoiceMode skill
- Teaches agents WHEN to suggest Connect (no local audio, phone access, install issues, headless machines)
- Points to the existing voicemode-connect skill for full setup docs
- 14 lines added -- minimal footprint, maximum context for agent judgment

## Context
Part of VMMT-88 (Announce VoiceMode Connect). Design doc in VMMT-90 -- organic discovery via skill knowledge, not push notifications. The agent only mentions Connect when the user's context makes it relevant.

Previously, the skill had only a one-line "Related Skills" link at the bottom with zero context about when Connect is useful.

## Test plan
- [ ] Load VoiceMode skill and verify agent knows about Connect
- [ ] Verify agent doesn't proactively push Connect when local voice is working
- [ ] Verify agent suggests Connect when user reports local install issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)