### PR TITLE
fix: break changelog/release_notes circular import (pytest 9 unblock)

### DIFF
--- a/tests/test_release_notes_prompt.py
+++ b/tests/test_release_notes_prompt.py
@@ -27,7 +27,7 @@ def test_release_notes_prompt_parses_changelog():
 - First version
 """
     
-    with patch("voice_mode.prompts.release_notes.changelog_resource") as mock_resource:
+    with patch("voice_mode.resources.changelog.changelog_resource") as mock_resource:
         mock_resource.fn.return_value = mock_changelog
         
         result = release_notes_prompt.fn(versions="2")
@@ -51,7 +51,7 @@ def test_release_notes_prompt_parses_changelog():
 
 def test_release_notes_prompt_handles_missing_changelog():
     """Test that the prompt handles missing CHANGELOG gracefully."""
-    with patch("voice_mode.prompts.release_notes.changelog_resource") as mock_resource:
+    with patch("voice_mode.resources.changelog.changelog_resource") as mock_resource:
         mock_resource.fn.return_value = "CHANGELOG.md not found in package."
         
         result = release_notes_prompt.fn()
@@ -61,7 +61,7 @@ def test_release_notes_prompt_handles_missing_changelog():
 
 def test_release_notes_prompt_handles_error():
     """Test that the prompt handles errors from the resource."""
-    with patch("voice_mode.prompts.release_notes.changelog_resource") as mock_resource:
+    with patch("voice_mode.resources.changelog.changelog_resource") as mock_resource:
         mock_resource.fn.return_value = "Error reading CHANGELOG.md: Permission denied"
         
         result = release_notes_prompt.fn()
@@ -98,7 +98,7 @@ def test_release_notes_prompt_default_versions():
 - Version 1
 """
     
-    with patch("voice_mode.prompts.release_notes.changelog_resource") as mock_resource:
+    with patch("voice_mode.resources.changelog.changelog_resource") as mock_resource:
         mock_resource.fn.return_value = mock_changelog
         
         result = release_notes_prompt.fn()  # No versions specified
@@ -141,7 +141,7 @@ def test_release_notes_prompt_handles_empty_string():
 - Version 1
 """
     
-    with patch("voice_mode.prompts.release_notes.changelog_resource") as mock_resource:
+    with patch("voice_mode.resources.changelog.changelog_resource") as mock_resource:
         mock_resource.fn.return_value = mock_changelog
         
         # Test with empty string (what Claude Code sends)
@@ -173,7 +173,7 @@ def test_release_notes_prompt_respects_version_limit():
 - Version 1
 """
     
-    with patch("voice_mode.prompts.release_notes.changelog_resource") as mock_resource:
+    with patch("voice_mode.resources.changelog.changelog_resource") as mock_resource:
         mock_resource.fn.return_value = mock_changelog
         
         # Test with 1 version

--- a/voice_mode/prompts/release_notes.py
+++ b/voice_mode/prompts/release_notes.py
@@ -1,17 +1,28 @@
 """Release notes prompt for displaying recent CHANGELOG entries."""
 
 from voice_mode.server import mcp
-# Import the resource at module level to ensure it's registered
-from voice_mode.resources.changelog import changelog_resource
 
 
 @mcp.prompt(name="release-notes")
 def release_notes_prompt(versions: str = "5") -> str:
     """View recent release notes from Voice Mode's CHANGELOG."""
+    # Lazy import to break a circular import:
+    #
+    #   voice_mode/resources/changelog.py
+    #     -> imports voice_mode/server.py
+    #       -> auto-imports voice_mode/prompts/ (this package)
+    #         -> loads release_notes.py (this module)
+    #
+    # Under pytest 9's stricter collection, importing changelog at
+    # module load time fails with "cannot import name 'changelog_resource'
+    # from partially initialized module". Deferring to call time breaks
+    # the cycle because server/prompts finish initializing first.
+    from voice_mode.resources.changelog import changelog_resource
+
     # Handle empty string from Claude Code
     if not versions or versions == "":
         versions = "5"
-    
+
     # Get the changelog content from the resource
     # Resources decorated with @mcp.resource need to access the fn attribute
     if hasattr(changelog_resource, 'fn'):


### PR DESCRIPTION
## Summary

Pytest 9 (released recently, picked up fresh on every CI run because the
test extra has no pytest pin) fails test collection with a circular
import between `voice_mode/resources/changelog.py` and
`voice_mode/prompts/release_notes.py`. Master would fail the same way if
its CI were re-run today -- the last successful run (2026-03-29) used
pytest 8.

The cycle:

```
voice_mode/resources/changelog.py
  imports voice_mode.server
    auto-imports voice_mode/prompts/ (package __init__)
      loads voice_mode/prompts/release_notes.py
        imports voice_mode.resources.changelog  ← cycle
```

Pytest 8 tolerated this; pytest 9 does not. Fixed by deferring the
import in `release_notes_prompt` to call time. The resource is still
registered at normal import time via `@mcp.resource` in `changelog.py`.

## Context

Blocking VM-922 (PR #316). Discovered when that PR's CI re-ran today
after the pytest 9 release.

## Test plan

- [ ] CI passes on all six python/OS combinations
- [ ] `release-notes` MCP prompt still returns changelog content
  (manual smoke test: invoke the prompt from a connected client)

🤖 Generated with [Claude Code](https://claude.com/claude-code)