### PR TITLE
fix: catch CancelledError in converse to keep MCP server alive (VM-1026)

### DIFF
--- a/tests/test_converse_cancellation.py
+++ b/tests/test_converse_cancellation.py
@@ -1,0 +1,98 @@
+"""Tests for converse's behaviour when the MCP tool call is cancelled.
+
+Context: VM-1026 / GH issue #337 -- pressing ESC during a `converse` call
+used to disconnect the whole MCP server because `asyncio.CancelledError`
+escaped the tool handler and tore down FastMCP's stdio transport.
+
+These tests verify that cancellation is caught inside the tool, cleanup
+runs, and a well-formed string result is returned instead of the
+exception escaping.
+"""
+
+import asyncio
+
+import pytest
+from unittest.mock import patch
+
+
+class TestConverseCancellation:
+    """CancelledError must be swallowed so the MCP server stays alive."""
+
+    @pytest.mark.asyncio
+    async def test_cancelled_during_tts_returns_cancellation_message(self):
+        """If TTS raises CancelledError, converse must return cleanly."""
+        from voice_mode.tools.converse import converse
+
+        with patch("voice_mode.core.text_to_speech") as mock_tts:
+            mock_tts.side_effect = asyncio.CancelledError()
+
+            with patch("voice_mode.config.TTS_BASE_URLS", ["https://api.openai.com/v1"]):
+                with patch("voice_mode.config.OPENAI_API_KEY", "test-api-key"):
+                    result = await converse.fn(
+                        message="Test message",
+                        wait_for_response=False,
+                    )
+
+        assert isinstance(result, str), (
+            "converse must return a string on cancellation, not raise"
+        )
+        assert "cancel" in result.lower(), (
+            f"Expected cancellation to be reflected in result, got: {result!r}"
+        )
+
+    @pytest.mark.asyncio
+    async def test_cancellation_releases_conch(self):
+        """After cancellation, the conch must be released so other agents can speak."""
+        from voice_mode.tools.converse import converse
+        from voice_mode.conch import Conch
+
+        with patch("voice_mode.core.text_to_speech") as mock_tts:
+            mock_tts.side_effect = asyncio.CancelledError()
+
+            with patch("voice_mode.config.TTS_BASE_URLS", ["https://api.openai.com/v1"]):
+                with patch("voice_mode.config.OPENAI_API_KEY", "test-api-key"):
+                    await converse.fn(
+                        message="Test message",
+                        wait_for_response=False,
+                    )
+
+        # No holder after cancellation — the finally block ran and released it.
+        holder = Conch.get_holder()
+        assert holder is None or holder.get("agent") != "converse", (
+            f"Conch still held by converse after cancellation: {holder}"
+        )
+
+    @pytest.mark.asyncio
+    async def test_outer_task_cancel_is_swallowed(self):
+        """Cancelling the converse task from the outside must not raise past the await."""
+        from voice_mode.tools.converse import converse
+
+        # Make TTS hang so we can cancel it cleanly.
+        hang_event = asyncio.Event()
+
+        async def hang(*_args, **_kwargs):
+            await hang_event.wait()
+            return True, None, {}
+
+        with patch("voice_mode.core.text_to_speech", new=hang):
+            with patch("voice_mode.config.TTS_BASE_URLS", ["https://api.openai.com/v1"]):
+                with patch("voice_mode.config.OPENAI_API_KEY", "test-api-key"):
+                    task = asyncio.create_task(
+                        converse.fn(message="Hello", wait_for_response=False)
+                    )
+                    # Give it a moment to get into TTS
+                    await asyncio.sleep(0.1)
+                    task.cancel()
+
+                    # awaiting a cancelled task normally raises CancelledError.
+                    # After our fix, converse catches it internally and returns,
+                    # so the task completes with a string result rather than
+                    # raising.
+                    try:
+                        result = await task
+                    except asyncio.CancelledError:
+                        pytest.fail(
+                            "converse leaked CancelledError — would tear down FastMCP stdio"
+                        )
+                    assert isinstance(result, str)
+                    assert "cancel" in result.lower()

--- a/voice_mode/tools/converse.py
+++ b/voice_mode/tools/converse.py
@@ -2045,13 +2045,37 @@ consult the MCP resources listed above.
             result = f"Error: {str(e)}"
             return result
         
+    except asyncio.CancelledError:
+        # Tool call was cancelled by the MCP client (e.g. user pressed ESC).
+        #
+        # We intentionally DO NOT re-raise. Under FastMCP 2.x stdio transport,
+        # an uncaught CancelledError escaping the tool handler tears down the
+        # MCP server process, leaving the client with a failed connection that
+        # requires `/mcp` reconnect. That surfaces to the user as VoiceMode
+        # "disappearing" after every ESC (see VM-1026 / GH issue #337).
+        #
+        # Swallowing cancellation here is safe because this function is a leaf
+        # coroutine invoked by FastMCP -- there is no outer task that needs to
+        # observe the cancellation signal. The `finally` block below still
+        # releases the conch, logs TOOL_REQUEST_END, and updates timing state,
+        # so cleanup invariants hold.
+        logger.info("Converse cancelled by client (ESC or tool-call cancel)")
+        if event_logger:
+            event_logger.log_event("TOOL_CANCELLED", {
+                "tool_name": "converse",
+                "reason": "client_cancel",
+            })
+        result = "Cancelled by user."
+        success = False
+        return result
+
     except Exception as e:
         logger.error(f"Unexpected error in converse: {e}")
         if DEBUG:
             logger.error(f"Full traceback: {traceback.format_exc()}")
         result = f"Unexpected error: {str(e)}"
         return result
-        
+
     finally:
         # Release the conch to signal voice conversation has ended
         if CONCH_ENABLED and conch._acquired:


### PR DESCRIPTION
## Summary

Fixes [#337](https://github.com/mbailey/voicemode/issues/337) -- pressing
ESC during an in-flight `converse` call used to knock the voicemode
MCP server offline in the Claude Code client. `/mcp` would show
`voicemode ✘ failed` and require an explicit reconnect before the next
`/voice` worked. Mike reproduced on master this afternoon.

## Root cause

`converse` had no handler for `asyncio.CancelledError`. When the MCP
client cancels a tool call, asyncio raises CancelledError inside the
coroutine. Python 3.8+ excludes CancelledError from `except Exception`,
so the existing generic handler never caught it, and the exception
propagated up to FastMCP's tool dispatcher -- which (under the 2.x
stdio transport) tears down the whole server process on uncaught
exceptions from a tool handler.

The issue reporter closed #337 after concluding the MCP child was
being SIGKILLed by the client. That diagnosis is refuted by a
`grep -r CancelledError voice_mode/` returning zero hits. Nothing in
voicemode was ever going to unwind cancellation cleanly.

## Fix

Add `except asyncio.CancelledError` before the generic Exception
handler in `converse`. We intentionally do **not** re-raise -- `converse`
is a leaf coroutine invoked by FastMCP, no outer task needs to observe
cancellation. The existing `finally` block still runs (releasing the
conch, logging `TOOL_REQUEST_END`, updating timing state), so cleanup
invariants hold. A new `TOOL_CANCELLED` event is emitted so the
cancellation is visible in the event log (the original bug report
noted the absence of any cancel marker between `RECORDING_START` and
`CONCH_RELEASE`).

## Tests

New `tests/test_converse_cancellation.py` covers:

1. CancelledError raised from TTS → converse returns a string result
2. Conch is released after cancellation
3. Outer `task.cancel()` while TTS hangs (simulating ESC) produces a
   well-formed string result instead of leaking CancelledError

All three pass locally. Full suite: **771 passed, 57 skipped**.

## Test plan

- [ ] Merge, wait for release
- [ ] Mike tests in Claude Code: start a converse, press ESC, check `/mcp` still shows ✔ connected
- [ ] Next `/voice` works without reconnect

🤖 Generated with [Claude Code](https://claude.com/claude-code)