### PR TITLE
fix: don't steal pane focus when converse activates tmux window

### DIFF
--- a/tests/test_auto_focus_pane.py
+++ b/tests/test_auto_focus_pane.py
@@ -6,7 +6,7 @@ from unittest.mock import patch, MagicMock
 def _mk_run(display_session="worker", clients_on_session="", all_clients=""):
     """Build a subprocess.run side_effect that returns scripted results by argv.
 
-    - select-pane / select-window: rc=0, no stdout needed
+    - select-window: rc=0, no stdout needed
     - display-message: returns the session name
     - list-clients -t <session>: stdout lists clients already on that session
     - list-clients -F ...: stdout lists all clients with flags
@@ -53,19 +53,21 @@ class TestIsTmux:
 class TestFocusTmuxPane:
     """Test the focus_tmux_pane() function."""
 
-    def test_selects_pane_and_window(self):
-        """select-pane and select-window always run when TMUX_PANE is set."""
+    def test_selects_window_without_pane(self):
+        """select-window runs but select-pane does NOT (avoids stealing focus)."""
         with patch.dict("os.environ", {"TMUX_PANE": "%5"}, clear=False):
             with patch("subprocess.run", side_effect=_mk_run(clients_on_session="/dev/ttys001\n")) as mock_run:
                 from voice_mode.tools.converse import focus_tmux_pane
                 focus_tmux_pane()
 
                 mock_run.assert_any_call(
-                    ["tmux", "select-pane", "-t", "%5"], capture_output=True
-                )
-                mock_run.assert_any_call(
                     ["tmux", "select-window", "-t", "%5"], capture_output=True
                 )
+                # select-pane should NOT be called — it steals focus
+                for c in mock_run.call_args_list:
+                    argv = c.args[0]
+                    assert argv[:2] != ["tmux", "select-pane"], \
+                        "select-pane should not be called (it steals focus from user's active pane)"
 
     def test_skips_switch_client_when_session_already_visible(self):
         """If a client is already attached to the agent's session, don't steal focus."""

--- a/voice_mode/tools/converse.py
+++ b/voice_mode/tools/converse.py
@@ -131,16 +131,18 @@ def _is_focus_held() -> bool:
 
 
 def focus_tmux_pane() -> None:
-    """Focus the current tmux pane, its window, and optionally switch a client.
+    """Make the agent's tmux window visible, and optionally switch a client.
 
     Steps:
     1. Check focus-hold sentinel — skip if another tool recently took focus
-    2. select-pane + select-window: activate the pane within its session
+    2. select-window: make the agent's window current (without changing active pane)
     3. Check if any client is already showing this session — if so, stop
     4. If no client is showing the session, switch the focused client to it
 
-    This avoids "stealing" the user's focused terminal when the agent's
-    session is already visible in another terminal window.
+    Deliberately does NOT call select-pane — this avoids stealing focus from
+    whichever pane the user is currently working in.  The window becomes
+    visible so the user can see the agent is speaking, but their cursor stays
+    where it was.
 
     Silent no-op if not in tmux, TMUX_PANE is unset, or tmux is not found.
     """
@@ -155,8 +157,9 @@ def focus_tmux_pane() -> None:
         return
 
     try:
-        # Select the pane and its window within the session
-        subprocess.run(["tmux", "select-pane", "-t", tmux_pane], capture_output=True)
+        # Select the window containing our pane (without changing active pane).
+        # This makes the window visible but doesn't steal focus from whichever
+        # pane the user is currently looking at.
         subprocess.run(["tmux", "select-window", "-t", tmux_pane], capture_output=True)
 
         # Find which session owns this pane


### PR DESCRIPTION
## Summary
- Remove `select-pane` call from `focus_tmux_pane()` so only `select-window` runs
- Makes the agent's window visible without changing which pane the user is focused on
- Fixes the issue where converse would steal cursor focus from the user's active pane in multi-pane layouts

## Test plan
- [x] Updated test to verify `select-pane` is NOT called
- [x] Existing tests pass (window selection, client switching, sentinel, no-op cases)
- [ ] Manual test: run two panes in same window, confirm converse doesn't move focus

🤖 Generated with [Claude Code](https://claude.com/claude-code)