### PR TITLE
Add ESC key regression warning to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,9 @@
 
 > Natural voice conversations with Claude Code (and other MCP capable agents)
 
+> [!WARNING]
+> **Known Issue (2026-04-13):** Claude Code 2.1.105+ kills VoiceMode's MCP server when you press ESC to cancel a voice conversation. **Workaround:** Pin to Claude Code 2.1.104. See [discussion #349](https://github.com/mbailey/voicemode/discussions/349) for details.
+
 [![PyPI Downloads](https://static.pepy.tech/badge/voice-mode)](https://pepy.tech/project/voice-mode)
 [![PyPI Downloads](https://static.pepy.tech/badge/voice-mode/month)](https://pepy.tech/project/voice-mode)
 [![PyPI Downloads](https://static.pepy.tech/badge/voice-mode/week)](https://pepy.tech/project/voice-mode)


### PR DESCRIPTION
## Summary
- Adds a warning banner to the top of the README about the Claude Code 2.1.105+ ESC regression
- Links to discussion #349 which has the full workaround (pin to 2.1.104)

## Context
- Upstream bug: anthropics/claude-code#49479
- VoiceMode tracking: #337, discussion #349

## Test plan
- [ ] Warning renders correctly on GitHub README
- [ ] Discussion link works

🤖 Generated with [Claude Code](https://claude.com/claude-code)