### PR TITLE
fix: opus streaming -- map to ogg demuxer and skip mid-stream restart

### DIFF
--- a/voice_mode/streaming.py
+++ b/voice_mode/streaming.py
@@ -30,6 +30,16 @@ from .utils import get_event_logger, update_latest_symlinks
 
 
 
+def _pydub_format(fmt: str) -> str:
+    """Map TTS response_format to the container format pydub/ffmpeg expects.
+
+    Opus is always wrapped in an Ogg (or WebM) container -- ffmpeg has no
+    raw 'opus' demuxer. TTS providers (Kokoro, OpenAI) return Ogg/Opus when
+    response_format='opus', so we tell pydub format='ogg' for decoding.
+    """
+    return "ogg" if fmt == "opus" else fmt
+
+
 @dataclass
 class StreamMetrics:
     """Metrics for streaming playback performance."""
@@ -172,7 +182,7 @@ class AudioStreamPlayer:
             # This is tricky because we need complete frames
             try:
                 # Try to decode what we have
-                audio = AudioSegment.from_file(io.BytesIO(data), format=self.format)
+                audio = AudioSegment.from_file(io.BytesIO(data), format=_pydub_format(self.format))
                 samples = np.array(audio.get_array_of_samples()).astype(np.float32) / 32768.0
                 return samples
             except Exception:
@@ -498,26 +508,32 @@ async def stream_with_buffering(
                     if save_buffer:
                         save_buffer.write(chunk)
                     
-                    # Try to decode when we have enough data (e.g., 32KB)
-                    if buffer.tell() > 32768 and not audio_started:
+                    # Try to decode when we have enough data (e.g., 32KB).
+                    # Skip for Opus/Ogg: the container has codec-setup pages only at the
+                    # start, so resetting the buffer after a partial decode leaves the
+                    # remaining bytes unparseable. For Opus we buffer the full response
+                    # and decode once below (matches the docstring's stated intent).
+                    if (buffer.tell() > 32768
+                            and not audio_started
+                            and format != "opus"):
                         buffer.seek(0)
                         try:
                             # Attempt to decode what we have
-                            audio = AudioSegment.from_file(buffer, format=format)
+                            audio = AudioSegment.from_file(buffer, format=_pydub_format(format))
                             samples = np.array(audio.get_array_of_samples()).astype(np.float32) / 32768.0
-                            
+
                             # Start playback
                             metrics.ttfa = time.perf_counter() - start_time
                             audio_started = True
                             logger.info(f"Buffered streaming started - TTFA: {metrics.ttfa:.3f}s")
-                            
+
                             # Play audio
                             stream.write(samples)
                             metrics.chunks_played += len(samples) // 1024
-                            
+
                             # Reset buffer for next batch
                             buffer = io.BytesIO()
-                            
+
                         except Exception as e:
                             # Not enough valid data yet
                             buffer.seek(0, io.SEEK_END)
@@ -526,9 +542,9 @@ async def stream_with_buffering(
         if buffer.tell() > 0:
             buffer.seek(0)
             try:
-                audio = AudioSegment.from_file(buffer, format=format)
+                audio = AudioSegment.from_file(buffer, format=_pydub_format(format))
                 samples = np.array(audio.get_array_of_samples()).astype(np.float32) / 32768.0
-                
+
                 if not audio_started:
                     metrics.ttfa = time.perf_counter() - start_time
                     


### PR DESCRIPTION
## Summary

Two bugs were preventing opus playback in the streaming TTS path:

1. **Wrong demuxer name.** TTS providers return Ogg-wrapped Opus when `response_format='opus'`, but the streaming code passed `format='opus'` to pydub, which becomes `ffmpeg -f opus`. ffmpeg has no raw 'opus' demuxer (Opus is always wrapped in Ogg/WebM/Matroska). Fixed by introducing a `_pydub_format()` mapping (`opus -> ogg`) and applying it everywhere `AudioSegment.from_file(..., format=...)` is called.

2. **Buffer reset breaks Ogg mid-stream.** `stream_with_buffering` would try to decode the first 32 KB, succeed for ~1s of audio, then reset the buffer. The remaining Ogg pages have no codec-setup header, so neither subsequent decodes nor the final decode could parse them (`[ogg] Codec not found`). Fixed by skipping the early-decode path for opus and buffering the full response, matching the docstring's stated intent.

## Test plan

- [x] Verified against local Kokoro on port 8880 with `voicemode converse --no-wait -m "<long phrase>"` and `VOICEMODE_TTS_AUDIO_FORMAT=opus` -- full response plays cleanly.
- [x] Confirmed the saved opus file is valid Ogg/Opus and decodes via `ffprobe`.
- [x] Reproduced the original `Codec not found` failure on master, then re-ran with the fix on this branch.
- [ ] Sanity-check OpenAI TTS opus path (not exercised here -- only Kokoro tested).

## Caveat (not fixed here)

Kokoro buffers the entire opus encode before sending, so TTFA == full gen time. Opus is currently useful for bandwidth/disk savings (~14 MB/hr vs ~173 MB/hr for PCM), not low-latency playback. PCM/MP3 remain better choices for local low-latency playback. If we want incremental opus playback, we'd need either Kokoro to flush per-frame or a header-buffer-prepend approach in voicemode.

🤖 Generated with [Claude Code](https://claude.com/claude-code)