### PR TITLE
fix: opus playback -- resample to stream rate and force 16-bit samples

### DIFF
--- a/voice_mode/streaming.py
+++ b/voice_mode/streaming.py
@@ -520,6 +520,17 @@ async def stream_with_buffering(
                         try:
                             # Attempt to decode what we have
                             audio = AudioSegment.from_file(buffer, format=_pydub_format(format))
+                            # Normalize decoded audio to match the playback stream:
+                            #   - frame rate: Opus always decodes to 48kHz; the stream is
+                            #     opened at sample_rate (24kHz default). Without resampling,
+                            #     audio plays at 2x speed and sounds chipmunk-like.
+                            #   - sample width: Opus decodes to 32-bit, but the / 32768.0
+                            #     normalization assumes 16-bit, producing ~12,000x amplitude
+                            #     and instant clipping. Force 16-bit to match.
+                            if audio.frame_rate != sample_rate:
+                                audio = audio.set_frame_rate(sample_rate)
+                            if audio.sample_width != 2:
+                                audio = audio.set_sample_width(2)
                             samples = np.array(audio.get_array_of_samples()).astype(np.float32) / 32768.0
 
                             # Start playback
@@ -543,6 +554,15 @@ async def stream_with_buffering(
             buffer.seek(0)
             try:
                 audio = AudioSegment.from_file(buffer, format=_pydub_format(format))
+                # Normalize decoded audio to match the playback stream. Opus always
+                # decodes to 48kHz / 32-bit, but the stream is opened at sample_rate
+                # (24kHz default) and the / 32768.0 line below assumes 16-bit. Without
+                # both conversions, audio is at 2x speed and ~12,000x amplitude
+                # (chipmunk-like and clipped to silence-by-distortion).
+                if audio.frame_rate != sample_rate:
+                    audio = audio.set_frame_rate(sample_rate)
+                if audio.sample_width != 2:
+                    audio = audio.set_sample_width(2)
                 samples = np.array(audio.get_array_of_samples()).astype(np.float32) / 32768.0
 
                 if not audio_started:


### PR DESCRIPTION
## Summary

Follow-up to #353. After that fix the opus stream decoded successfully, but playback sounded distorted, loud, and chipmunk-like. Two more bugs in the decode path:

1. **Sample rate mismatch.** Opus always decodes to 48kHz, but the sounddevice OutputStream is opened at \`sample_rate\` (24kHz default). Writing 48kHz samples into a 24kHz stream plays at 2x speed.
2. **Sample-width assumption.** Opus decodes to 32-bit samples in pydub, but the normalization line assumed 16-bit (\`/ 32768.0\` = \`2**15\`). For int32 samples this produces values in the ~±27,000 range instead of ±1.0 -- about 12,000x amplitude. Sounddevice clips immediately, which is what made it "loud and terrible".

Fix: normalize the decoded \`AudioSegment\` to \`(sample_rate, 16-bit)\` before extracting samples, in both the early-decode and final-decode paths of \`stream_with_buffering\`.

## Test plan

Verified programmatically against a saved opus file:

| State | Frame rate | Bit depth | Sample range | RMS |
|---|---|---|---|---|
| Decoded raw | 48000 Hz | 32-bit | ±27,000 (clipped) | -- |
| After fix | 24000 Hz | 16-bit | ±0.30 | 0.0407 |
| PCM reference | 24000 Hz | 16-bit | ±0.32 | 0.0413 |

The fixed range/RMS matches the PCM reference, so playback should now sound the same as PCM (just delayed by full-encode buffering -- see #353 caveat).

- [x] Programmatic verification (above)
- [ ] Live playback test through Kokoro (will confirm with Mike post-merge)

🤖 Generated with [Claude Code](https://claude.com/claude-code)