### PR TITLE
fix: opus playback -- drain output buffer before stopping stream

### DIFF
--- a/voice_mode/streaming.py
+++ b/voice_mode/streaming.py
@@ -520,6 +520,17 @@ async def stream_with_buffering(
                         try:
                             # Attempt to decode what we have
                             audio = AudioSegment.from_file(buffer, format=_pydub_format(format))
+                            # Normalize decoded audio to match the playback stream:
+                            #   - frame rate: Opus always decodes to 48kHz; the stream is
+                            #     opened at sample_rate (24kHz default). Without resampling,
+                            #     audio plays at 2x speed and sounds chipmunk-like.
+                            #   - sample width: Opus decodes to 32-bit, but the / 32768.0
+                            #     normalization assumes 16-bit, producing ~12,000x amplitude
+                            #     and instant clipping. Force 16-bit to match.
+                            if audio.frame_rate != sample_rate:
+                                audio = audio.set_frame_rate(sample_rate)
+                            if audio.sample_width != 2:
+                                audio = audio.set_sample_width(2)
                             samples = np.array(audio.get_array_of_samples()).astype(np.float32) / 32768.0
 
                             # Start playback
@@ -543,6 +554,15 @@ async def stream_with_buffering(
             buffer.seek(0)
             try:
                 audio = AudioSegment.from_file(buffer, format=_pydub_format(format))
+                # Normalize decoded audio to match the playback stream. Opus always
+                # decodes to 48kHz / 32-bit, but the stream is opened at sample_rate
+                # (24kHz default) and the / 32768.0 line below assumes 16-bit. Without
+                # both conversions, audio is at 2x speed and ~12,000x amplitude
+                # (chipmunk-like and clipped to silence-by-distortion).
+                if audio.frame_rate != sample_rate:
+                    audio = audio.set_frame_rate(sample_rate)
+                if audio.sample_width != 2:
+                    audio = audio.set_sample_width(2)
                 samples = np.array(audio.get_array_of_samples()).astype(np.float32) / 32768.0
 
                 if not audio_started:

--- a/voice_mode/streaming.py
+++ b/voice_mode/streaming.py
@@ -570,7 +570,15 @@ async def stream_with_buffering(
                     
                 stream.write(samples)
                 metrics.chunks_played += len(samples) // 1024
-                
+
+                # Drain PortAudio's output buffer before the finally block stops
+                # the stream. stream.write() returns when samples are queued, not
+                # when they have played; on macOS CoreAudio stream.stop() can
+                # truncate the tail (~100-300ms). Sleep for the reported output
+                # latency plus a small safety margin.
+                drain_secs = (stream.latency or 0.0) + 0.3
+                await asyncio.sleep(drain_secs)
+
             except Exception as e:
                 logger.error(f"Failed to decode final buffer: {e}")
         


### PR DESCRIPTION
## Summary

Follow-up to #353 and #354. Reported by Mike: opus playback cuts out early; the last bit is missing.

After the final \`stream.write(samples)\` returns, samples have been queued into PortAudio's output buffer but have not necessarily played from the audio device. The \`finally\` block then calls \`stream.stop()\` and \`stream.close()\`. On macOS CoreAudio, \`stop()\` does not reliably wait for the output buffer to drain, so the tail (~100-300ms) is truncated.

For PCM streaming this is barely noticeable because chunks arrive continuously and each blocking write naturally paces playback to within one buffer-size of real time. For Opus we write ALL samples in a single big call after Kokoro finishes encoding, so the cut tail is more audible.

## Fix

After the final write, \`await asyncio.sleep\` for the stream's reported output latency plus a 300 ms safety margin, before falling through to the finally cleanup.

## Test plan

- [ ] Manual: play a long opus utterance through Kokoro and confirm the final word is no longer truncated
- [x] Adds latency only at end-of-utterance, not to TTFA
- [x] Conservative drain estimate (latency + 0.3s) — too long is harmless, too short reproduces the bug

🤖 Generated with [Claude Code](https://claude.com/claude-code)