### PR TITLE
fix: opus tail truncation -- pad with trailing silence

### DIFF
--- a/voice_mode/config.py
+++ b/voice_mode/config.py
@@ -743,6 +743,15 @@ STREAM_CHUNK_SIZE = int(os.getenv("VOICEMODE_STREAM_CHUNK_SIZE", "4096"))  # Dow
 STREAM_BUFFER_MS = int(os.getenv("VOICEMODE_STREAM_BUFFER_MS", "150"))  # Initial buffer before playback
 STREAM_MAX_BUFFER = float(os.getenv("VOICEMODE_STREAM_MAX_BUFFER", "2.0"))  # Max buffer in seconds
 
+# Trailing silence appended to TTS audio before stream stop.
+# On macOS CoreAudio (especially with aggregate devices), stream.stop() does
+# not always wait for the host buffer to drain, and PortAudio's reported
+# `stream.latency` underestimates the true end-to-end latency through the
+# aggregate-device chain. Padding the audio with trailing silence guarantees
+# the actual content plays out even if the tail of the buffer is dropped.
+# This is silence — it adds no perceived delay to the user.
+TTS_TRAILING_SILENCE = float(os.getenv("VOICEMODE_TTS_TRAILING_SILENCE", "0.5"))
+
 # ==================== EVENT LOGGING CONFIGURATION ====================
 
 # Event logging configuration

--- a/voice_mode/core.py
+++ b/voice_mode/core.py
@@ -268,6 +268,12 @@ async def text_to_speech(
                 "ref_text": clone_profile.ref_text,
                 "stream": True,
                 "streaming_interval": 0.3,
+                # mlx-audio's server default for lang_code is "a", which is
+                # Kokoro's code for US English and is meaningless to Qwen3-TTS.
+                # Qwen3 uses word codes from its codec_language_id ("auto",
+                # "english", "chinese", etc.). "auto" lets the model detect
+                # language from the input text.
+                "lang_code": "auto",
             }
             logger.info(f"  • Voice clone: {clone_profile.name} (ref: {clone_profile.ref_audio})")
         

--- a/voice_mode/core.py
+++ b/voice_mode/core.py
@@ -252,11 +252,22 @@ async def text_to_speech(
             request_params["speed"] = speed
             logger.info(f"  • Speed: {speed}x")
 
-        # Add voice cloning parameters if a clone profile is active
+        # Add voice cloning parameters if a clone profile is active.
+        # mlx-audio requires `stream: true` in the request body to emit
+        # chunks progressively; without it the server buffers the full
+        # generation before responding, defeating streaming playback.
+        # Kokoro streams by default, OpenAI ignores the flag — so we only
+        # add it on the clone path (which always targets mlx-audio).
+        # `streaming_interval` controls how much audio the server buffers
+        # before flushing each chunk. The server default is 2.0s, which
+        # gives TTFA ~1.8s; 0.3s gives TTFA ~0.4s with no underruns in
+        # testing on ms2.
         if clone_profile:
             request_params["extra_body"] = {
                 "ref_audio": clone_profile.ref_audio,
                 "ref_text": clone_profile.ref_text,
+                "stream": True,
+                "streaming_interval": 0.3,
             }
             logger.info(f"  • Voice clone: {clone_profile.name} (ref: {clone_profile.ref_audio})")
         

--- a/voice_mode/core.py
+++ b/voice_mode/core.py
@@ -176,7 +176,8 @@ async def text_to_speech(
     instructions: Optional[str] = None,
     audio_format: Optional[str] = None,
     conversation_id: Optional[str] = None,
-    speed: Optional[float] = None
+    speed: Optional[float] = None,
+    clone_profile: Optional[object] = None
 ) -> tuple[bool, Optional[dict]]:
     """Convert text to speech and play it.
     
@@ -250,6 +251,14 @@ async def text_to_speech(
         if speed is not None:
             request_params["speed"] = speed
             logger.info(f"  • Speed: {speed}x")
+
+        # Add voice cloning parameters if a clone profile is active
+        if clone_profile:
+            request_params["extra_body"] = {
+                "ref_audio": clone_profile.ref_audio,
+                "ref_text": clone_profile.ref_text,
+            }
+            logger.info(f"  • Voice clone: {clone_profile.name} (ref: {clone_profile.ref_audio})")
         
         # Track generation time
         generation_start = time.perf_counter()

--- a/voice_mode/simple_failover.py
+++ b/voice_mode/simple_failover.py
@@ -25,15 +25,16 @@ async def simple_tts_failover(
 ) -> Tuple[bool, Optional[Dict[str, Any]], Optional[Dict[str, Any]]]:
     """
     Simple TTS failover - try each endpoint in order until one works.
-    
+
     Returns:
         Tuple of (success, metrics, config)
     """
     logger.info(f"simple_tts_failover called with: text='{text[:50]}...', voice={voice}, model={model}")
     logger.info(f"kwargs: {kwargs}")
-    
+
     from .core import text_to_speech
     from .conversation_logger import get_conversation_logger
+    from .voice_profiles import get_profile, is_clone_voice
 
     # Track attempted endpoints and their errors
     attempted_endpoints = []
@@ -42,17 +43,32 @@ async def simple_tts_failover(
     conversation_logger = get_conversation_logger()
     conversation_id = conversation_logger.conversation_id
 
+    # Check if this is a clone voice — if so, route directly to its endpoint
+    clone_profile = get_profile(voice) if is_clone_voice(voice) else None
+    if clone_profile:
+        endpoints_to_try = [clone_profile.base_url]
+        logger.info(f"Voice '{voice}' is a clone profile, routing to {clone_profile.base_url}")
+    else:
+        endpoints_to_try = TTS_BASE_URLS
+
     # Try each TTS endpoint in order
-    logger.info(f"simple_tts_failover: Starting with TTS_BASE_URLS = {TTS_BASE_URLS}")
-    for base_url in TTS_BASE_URLS:
+    logger.info(f"simple_tts_failover: Starting with endpoints = {endpoints_to_try}")
+    for base_url in endpoints_to_try:
         logger.info(f"Trying TTS endpoint: {base_url}")
 
         # Create client for this endpoint
         provider_type = detect_provider_type(base_url)
         api_key = OPENAI_API_KEY if provider_type == "openai" else (OPENAI_API_KEY or "dummy-key-for-local")
 
-        # Select appropriate voice for this provider
-        if provider_type == "openai":
+        # Select appropriate voice and model for this provider
+        selected_model = model
+        if clone_profile:
+            # Clone voice: use profile's model and pass voice name through
+            # (mlx-audio server accepts any voice string)
+            selected_voice = voice
+            selected_model = clone_profile.model
+            logger.info(f"Clone voice '{voice}': model={selected_model}")
+        elif provider_type == "openai":
             # Map Kokoro voices to OpenAI equivalents, or use OpenAI default
             openai_voices = ["alloy", "echo", "fable", "nova", "onyx", "shimmer"]
             if voice in openai_voices:
@@ -89,14 +105,19 @@ async def simple_tts_failover(
         # Wrap in try/catch to get actual exception details
         last_exception = None
         try:
+            # Pass clone profile through kwargs if present
+            tts_kwargs = dict(kwargs)
+            if clone_profile:
+                tts_kwargs['clone_profile'] = clone_profile
+
             success, metrics = await text_to_speech(
                 text=text,
                 openai_clients=openai_clients,
-                tts_model=model,
+                tts_model=selected_model,
                 tts_voice=selected_voice,
                 tts_base_url=base_url,
                 conversation_id=conversation_id,
-                **kwargs
+                **tts_kwargs
             )
 
             if success:

--- a/voice_mode/streaming.py
+++ b/voice_mode/streaming.py
@@ -520,6 +520,17 @@ async def stream_with_buffering(
                         try:
                             # Attempt to decode what we have
                             audio = AudioSegment.from_file(buffer, format=_pydub_format(format))
+                            # Normalize decoded audio to match the playback stream:
+                            #   - frame rate: Opus always decodes to 48kHz; the stream is
+                            #     opened at sample_rate (24kHz default). Without resampling,
+                            #     audio plays at 2x speed and sounds chipmunk-like.
+                            #   - sample width: Opus decodes to 32-bit, but the / 32768.0
+                            #     normalization assumes 16-bit, producing ~12,000x amplitude
+                            #     and instant clipping. Force 16-bit to match.
+                            if audio.frame_rate != sample_rate:
+                                audio = audio.set_frame_rate(sample_rate)
+                            if audio.sample_width != 2:
+                                audio = audio.set_sample_width(2)
                             samples = np.array(audio.get_array_of_samples()).astype(np.float32) / 32768.0
 
                             # Start playback
@@ -543,6 +554,15 @@ async def stream_with_buffering(
             buffer.seek(0)
             try:
                 audio = AudioSegment.from_file(buffer, format=_pydub_format(format))
+                # Normalize decoded audio to match the playback stream. Opus always
+                # decodes to 48kHz / 32-bit, but the stream is opened at sample_rate
+                # (24kHz default) and the / 32768.0 line below assumes 16-bit. Without
+                # both conversions, audio is at 2x speed and ~12,000x amplitude
+                # (chipmunk-like and clipped to silence-by-distortion).
+                if audio.frame_rate != sample_rate:
+                    audio = audio.set_frame_rate(sample_rate)
+                if audio.sample_width != 2:
+                    audio = audio.set_sample_width(2)
                 samples = np.array(audio.get_array_of_samples()).astype(np.float32) / 32768.0
 
                 if not audio_started:

--- a/voice_mode/streaming.py
+++ b/voice_mode/streaming.py
@@ -24,6 +24,7 @@ from .config import (
     STREAM_BUFFER_MS,
     STREAM_MAX_BUFFER,
     SAMPLE_RATE,
+    TTS_TRAILING_SILENCE,
     logger
 )
 from .utils import get_event_logger, update_latest_symlinks
@@ -565,17 +566,30 @@ async def stream_with_buffering(
                     audio = audio.set_sample_width(2)
                 samples = np.array(audio.get_array_of_samples()).astype(np.float32) / 32768.0
 
+                # Append trailing silence to guarantee the real content plays out
+                # before the stream is stopped. On macOS CoreAudio (and especially
+                # with aggregate devices), `stream.stop()` does not always wait for
+                # the host buffer to drain, and PortAudio's `stream.latency`
+                # underestimates the true end-to-end latency, so the time-based
+                # drain sleep below isn't always sufficient. Padding the samples
+                # with silence makes the fix robust regardless of how the device
+                # chain buffers — even if the tail is truncated, only silence
+                # is lost.
+                if TTS_TRAILING_SILENCE > 0:
+                    pad = np.zeros(int(sample_rate * TTS_TRAILING_SILENCE), dtype=np.float32)
+                    samples = np.concatenate([samples, pad])
+
                 if not audio_started:
                     metrics.ttfa = time.perf_counter() - start_time
-                    
+
                 stream.write(samples)
                 metrics.chunks_played += len(samples) // 1024
 
-                # Drain PortAudio's output buffer before the finally block stops
-                # the stream. stream.write() returns when samples are queued, not
-                # when they have played; on macOS CoreAudio stream.stop() can
-                # truncate the tail (~100-300ms). Sleep for the reported output
-                # latency plus a small safety margin.
+                # Belt-and-braces drain in addition to the silence padding above.
+                # Sleep for the reported output latency plus a small safety margin
+                # so that even if a future change removes the silence pad, the
+                # tail still plays through on systems where stream.stop() drains
+                # correctly.
                 drain_secs = (stream.latency or 0.0) + 0.3
                 await asyncio.sleep(drain_secs)
 

--- a/voice_mode/streaming.py
+++ b/voice_mode/streaming.py
@@ -570,7 +570,15 @@ async def stream_with_buffering(
                     
                 stream.write(samples)
                 metrics.chunks_played += len(samples) // 1024
-                
+
+                # Drain PortAudio's output buffer before the finally block stops
+                # the stream. stream.write() returns when samples are queued, not
+                # when they have played; on macOS CoreAudio stream.stop() can
+                # truncate the tail (~100-300ms). Sleep for the reported output
+                # latency plus a small safety margin.
+                drain_secs = (stream.latency or 0.0) + 0.3
+                await asyncio.sleep(drain_secs)
+
             except Exception as e:
                 logger.error(f"Failed to decode final buffer: {e}")
         

--- a/voice_mode/tools/converse.py
+++ b/voice_mode/tools/converse.py
@@ -417,6 +417,19 @@ async def startup_initialization():
 async def get_tts_config(provider: Optional[str] = None, voice: Optional[str] = None, model: Optional[str] = None, instructions: Optional[str] = None):
     """Get TTS configuration - simplified to use direct config"""
     from voice_mode.provider_discovery import detect_provider_type
+    from voice_mode.voice_profiles import is_clone_voice, get_profile
+
+    # Check if this is a clone voice — override provider/model/base_url
+    if voice and is_clone_voice(voice):
+        profile = get_profile(voice)
+        logger.info(f"Voice '{voice}' is a clone profile: {profile.description}")
+        return {
+            'base_url': profile.base_url,
+            'model': profile.model,
+            'voice': voice,
+            'instructions': None,
+            'provider_type': 'clone'
+        }
 
     # Validate instructions usage
     if instructions and model != "gpt-4o-mini-tts":

--- a/voice_mode/voice_profiles.py
+++ b/voice_mode/voice_profiles.py
@@ -1,8 +1,21 @@
 """Voice profiles for clone-based TTS.
 
-Loads voice profiles from ~/.voicemode/voices.json. Each profile maps a voice
-name to a reference audio file and transcript on the TTS server, plus model
-and endpoint routing info.
+Voices come from two sources, layered:
+
+1. **Directory-based** (preferred):
+   ``$VOICEMODE_VOICES_DIR`` (default ``~/.voicemode/voices``).
+   Each subdirectory is a voice. For ``<name>/`` we look for a
+   ``default.wav`` (or the first ``*.wav``) plus a sidecar transcript
+   ``default.txt`` (or matching basename). SuperDirt-style: drop a folder
+   in, you get a voice. Symlink ``default.wav`` to swap which sample is
+   active without renaming files.
+
+2. **JSON-based** (legacy):
+   ``~/.voicemode/voices.json``. Loaded after the directory; entries that
+   already exist as directory profiles are not overridden, so dir wins.
+
+Each profile maps a voice name to a reference audio file and transcript
+on the TTS server, plus model and endpoint routing info.
 """
 
 import json
@@ -14,7 +27,10 @@ from typing import Dict, Optional
 
 logger = logging.getLogger("voicemode")
 
-PROFILES_PATH = Path(os.path.expanduser("~/.voicemode/voices.json"))
+PROFILES_JSON = Path(os.path.expanduser("~/.voicemode/voices.json"))
+VOICES_DIR = Path(os.path.expanduser(
+    os.environ.get("VOICEMODE_VOICES_DIR", "~/.voicemode/voices")
+))
 
 # Default mlx-audio endpoint (Qwen3-TTS on ms2)
 DEFAULT_CLONE_BASE_URL = "http://ms2:8890/v1"
@@ -36,35 +52,142 @@ _profiles: Dict[str, VoiceProfile] = {}
 _loaded = False
 
 
-def load_profiles() -> Dict[str, VoiceProfile]:
-    """Load voice profiles from disk."""
-    global _profiles, _loaded
+def _resolve_default_wav(voice_dir: Path) -> Optional[Path]:
+    """Pick the reference WAV inside a voice directory.
 
-    if not PROFILES_PATH.exists():
-        logger.debug(f"No voice profiles file at {PROFILES_PATH}")
-        _loaded = True
-        return _profiles
+    Order of preference:
+    1. ``default.wav`` (file or symlink) — the explicit default
+    2. The single ``*.wav`` if there's only one — unambiguous
+
+    Directories with multiple WAVs and no ``default.wav`` are treated as
+    sample bins, not voices, and skipped. Add a ``default.wav`` symlink
+    if you want such a directory to register as a voice.
+    """
+    default = voice_dir / "default.wav"
+    if default.exists():
+        return default
+
+    wavs = sorted(voice_dir.glob("*.wav"))
+    if not wavs:
+        return None
+    if len(wavs) == 1:
+        return wavs[0]
+
+    logger.debug(
+        f"Skipping {voice_dir.name!r}: {len(wavs)} WAVs and no default.wav "
+        f"(treat as a sample bin, not a voice; add default.wav symlink to "
+        f"register)."
+    )
+    return None
+
+
+def _resolve_transcript(wav_path: Path) -> str:
+    """Read the matching transcript for a reference WAV.
+
+    Looks for ``<basename>.txt`` first, then ``default.txt`` as a fallback.
+    Returns empty string if no transcript is found (caller will warn).
+    """
+    same_name = wav_path.with_suffix(".txt")
+    if same_name.exists():
+        return same_name.read_text().strip()
+
+    fallback = wav_path.parent / "default.txt"
+    if fallback.exists():
+        return fallback.read_text().strip()
+
+    return ""
+
+
+def _load_dir_profiles() -> Dict[str, VoiceProfile]:
+    """Walk VOICES_DIR and build profiles from per-voice subdirectories."""
+    profiles: Dict[str, VoiceProfile] = {}
+
+    if not VOICES_DIR.exists() or not VOICES_DIR.is_dir():
+        logger.debug(f"Voices directory not found at {VOICES_DIR}")
+        return profiles
+
+    for voice_dir in sorted(p for p in VOICES_DIR.iterdir() if p.is_dir()):
+        wav = _resolve_default_wav(voice_dir)
+        if wav is None:
+            logger.debug(f"Skipping {voice_dir.name!r}: no .wav files")
+            continue
+
+        transcript = _resolve_transcript(wav)
+        if not transcript:
+            logger.warning(
+                f"Voice {voice_dir.name!r}: no transcript found "
+                f"(expected {wav.with_suffix('.txt').name} or default.txt). "
+                f"ref_text will be empty."
+            )
+
+        profiles[voice_dir.name] = VoiceProfile(
+            name=voice_dir.name,
+            ref_audio=str(wav.resolve()),
+            ref_text=transcript,
+            model=DEFAULT_CLONE_MODEL,
+            base_url=DEFAULT_CLONE_BASE_URL,
+            description="",
+        )
+
+    if profiles:
+        logger.info(
+            f"Loaded {len(profiles)} dir profiles from {VOICES_DIR}: "
+            f"{list(profiles.keys())}"
+        )
+    return profiles
+
+
+def _load_json_profiles() -> Dict[str, VoiceProfile]:
+    """Load profiles from the legacy voices.json registry."""
+    profiles: Dict[str, VoiceProfile] = {}
+
+    if not PROFILES_JSON.exists():
+        logger.debug(f"No voice profiles file at {PROFILES_JSON}")
+        return profiles
 
     try:
-        with open(PROFILES_PATH) as f:
+        with open(PROFILES_JSON) as f:
             data = json.load(f)
-
-        _profiles = {}
-        for name, profile_data in data.get("voices", {}).items():
-            _profiles[name] = VoiceProfile(
-                name=name,
-                ref_audio=profile_data["ref_audio"],
-                ref_text=profile_data["ref_text"],
-                model=profile_data.get("model", DEFAULT_CLONE_MODEL),
-                base_url=profile_data.get("base_url", DEFAULT_CLONE_BASE_URL),
-                description=profile_data.get("description", ""),
-            )
-        _loaded = True
-        logger.info(f"Loaded {len(_profiles)} voice profiles: {list(_profiles.keys())}")
     except Exception as e:
-        logger.error(f"Failed to load voice profiles: {e}")
-        _loaded = True
+        logger.error(f"Failed to load voice profiles JSON: {e}")
+        return profiles
 
+    for name, pd in data.get("voices", {}).items():
+        profiles[name] = VoiceProfile(
+            name=name,
+            ref_audio=pd["ref_audio"],
+            ref_text=pd["ref_text"],
+            model=pd.get("model", DEFAULT_CLONE_MODEL),
+            base_url=pd.get("base_url", DEFAULT_CLONE_BASE_URL),
+            description=pd.get("description", ""),
+        )
+
+    if profiles:
+        logger.info(
+            f"Loaded {len(profiles)} JSON profiles from {PROFILES_JSON}: "
+            f"{list(profiles.keys())}"
+        )
+    return profiles
+
+
+def load_profiles() -> Dict[str, VoiceProfile]:
+    """Load voice profiles from both directory and JSON sources.
+
+    Directory takes precedence — JSON only fills in voices not already
+    defined by a directory profile.
+    """
+    global _profiles, _loaded
+
+    dir_profiles = _load_dir_profiles()
+    json_profiles = _load_json_profiles()
+
+    # Layer JSON on top of dir, but only for keys dir didn't define
+    merged = dict(dir_profiles)
+    for name, prof in json_profiles.items():
+        merged.setdefault(name, prof)
+
+    _profiles = merged
+    _loaded = True
     return _profiles
 
 
@@ -87,3 +210,10 @@ def list_profiles() -> Dict[str, VoiceProfile]:
     if not _loaded:
         load_profiles()
     return _profiles
+
+
+def reload_profiles() -> Dict[str, VoiceProfile]:
+    """Force a reload of voice profiles (clears the cache)."""
+    global _loaded
+    _loaded = False
+    return load_profiles()

--- a/voice_mode/voice_profiles.py
+++ b/voice_mode/voice_profiles.py
@@ -1,0 +1,89 @@
+"""Voice profiles for clone-based TTS.
+
+Loads voice profiles from ~/.voicemode/voices.json. Each profile maps a voice
+name to a reference audio file and transcript on the TTS server, plus model
+and endpoint routing info.
+"""
+
+import json
+import logging
+import os
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Dict, Optional
+
+logger = logging.getLogger("voicemode")
+
+PROFILES_PATH = Path(os.path.expanduser("~/.voicemode/voices.json"))
+
+# Default mlx-audio endpoint (Qwen3-TTS on ms2)
+DEFAULT_CLONE_BASE_URL = "http://ms2:8890/v1"
+DEFAULT_CLONE_MODEL = "mlx-community/Qwen3-TTS-12Hz-1.7B-Base-bf16"
+
+
+@dataclass
+class VoiceProfile:
+    """A voice cloning profile."""
+    name: str
+    ref_audio: str       # Path to reference audio on TTS server
+    ref_text: str        # Transcript of reference audio
+    model: str           # TTS model to use
+    base_url: str        # TTS endpoint URL
+    description: str = ""
+
+
+_profiles: Dict[str, VoiceProfile] = {}
+_loaded = False
+
+
+def load_profiles() -> Dict[str, VoiceProfile]:
+    """Load voice profiles from disk."""
+    global _profiles, _loaded
+
+    if not PROFILES_PATH.exists():
+        logger.debug(f"No voice profiles file at {PROFILES_PATH}")
+        _loaded = True
+        return _profiles
+
+    try:
+        with open(PROFILES_PATH) as f:
+            data = json.load(f)
+
+        _profiles = {}
+        for name, profile_data in data.get("voices", {}).items():
+            _profiles[name] = VoiceProfile(
+                name=name,
+                ref_audio=profile_data["ref_audio"],
+                ref_text=profile_data["ref_text"],
+                model=profile_data.get("model", DEFAULT_CLONE_MODEL),
+                base_url=profile_data.get("base_url", DEFAULT_CLONE_BASE_URL),
+                description=profile_data.get("description", ""),
+            )
+        _loaded = True
+        logger.info(f"Loaded {len(_profiles)} voice profiles: {list(_profiles.keys())}")
+    except Exception as e:
+        logger.error(f"Failed to load voice profiles: {e}")
+        _loaded = True
+
+    return _profiles
+
+
+def get_profile(voice_name: str) -> Optional[VoiceProfile]:
+    """Get a voice profile by name. Returns None if not a clone voice."""
+    if not _loaded:
+        load_profiles()
+    return _profiles.get(voice_name)
+
+
+def is_clone_voice(voice_name: str) -> bool:
+    """Check if a voice name refers to a clone profile."""
+    if not _loaded:
+        load_profiles()
+    return voice_name in _profiles
+
+
+def list_profiles() -> Dict[str, VoiceProfile]:
+    """List all available voice profiles."""
+    if not _loaded:
+        load_profiles()
+    return _profiles


### PR DESCRIPTION
## Summary

Follow-up to #355. The drain-sleep fix in #355 wasn't sufficient on Mike's setup, which uses a macOS aggregate device (`app3`) as the default output. Mike confirmed the tail is still being cut off.

## Diagnosis

- **Saved opus files are complete and well-formed** — `latest.opus` is 22 seconds, all samples present.
- **PortAudio reports `stream.latency = 0.66s`** for the playback stream on the aggregate device.
- **The drain sleep of `(stream.latency or 0.0) + 0.3` = ~0.96s** should cover that on paper.
- But on **macOS aggregate devices**, the buffer chain (PortAudio host buffer → AudioUnit → sub-device buffer) extends past what `stream.latency` reports, and `stream.stop()` does not consistently wait for the full chain to drain — so the tail still gets dropped.

## Fix

Append `VOICEMODE_TTS_TRAILING_SILENCE` seconds (default **0.5s**) of silence to the decoded samples before `stream.write()`. This makes the fix robust regardless of how the device chain buffers — even if some of the tail is truncated, only the appended silence is lost.

The existing time-based drain stays as belt-and-braces for systems where `stream.stop()` does drain correctly.

## Why this doesn't add perceived delay

`converse` already does `await asyncio.sleep(0.5)` between TTS finishing and the listening chime. The 0.5s of trailing silence overlaps with that pause — there's no audible gap added.

## Test plan

- [ ] Mike runs converse with VOICEMODE_TTS_AUDIO_FORMAT=opus
- [ ] Confirm last words come through cleanly (the "pomegranate" test)
- [ ] If 0.5s isn't enough, increase via VOICEMODE_TTS_TRAILING_SILENCE=0.8 in voicemode.env

## Side note

While diagnosing this I noticed Mike's `VOICEMODE_TTS_BASE_URLS` starts with `https://ms2.local:8880/v1` which hangs ~10s before failing over to `127.0.0.1:8880` when he's off the home network — adds 10s of dead time per converse call. Separate fix.