### PR TITLE
fix(kokoro): install from mbailey/Kokoro-FastAPI fork (opus tail fix)

### DIFF
--- a/voice_mode/tools/kokoro/install.py
+++ b/voice_mode/tools/kokoro/install.py
@@ -104,11 +104,17 @@ async def kokoro_install(
     skip_deps: Union[bool, str] = False
 ) -> Dict[str, Any]:
     """
-    Install and setup remsky/kokoro-fastapi TTS service using the simple 3-step approach.
+    Install and setup mbailey/Kokoro-FastAPI TTS service using the simple 3-step approach.
 
     1. Clones the repository to ~/.voicemode/services/kokoro
     2. Uses the appropriate start script (start-gpu_mac.sh on macOS)
     3. Installs a launchagent on macOS for automatic startup
+
+    Note: voicemode installs from a fork of remsky/Kokoro-FastAPI because the
+    upstream has been unmaintained since 2026-01-04 (no commits, no PR review,
+    134 open issues). The fork tracks upstream master with one critical patch
+    cherry-picked from upstream PR #448: a fix for OGG/Opus tail truncation
+    that causes the last 1-2 seconds of audio to be silently dropped.
 
     Args:
         install_dir: Directory to install kokoro-fastapi (default: ~/.voicemode/services/kokoro)
@@ -176,7 +182,7 @@ async def kokoro_install(
         
         # Resolve version if "latest" is specified
         if version == "latest":
-            tags = get_git_tags("https://github.com/remsky/kokoro-fastapi")
+            tags = get_git_tags("https://github.com/mbailey/Kokoro-FastAPI")
             if not tags:
                 return {
                     "success": False,
@@ -284,7 +290,7 @@ async def kokoro_install(
         if not os.path.exists(install_dir):
             logger.info(f"Cloning kokoro-fastapi repository (version {version})...")
             subprocess.run([
-                "git", "clone", "https://github.com/remsky/kokoro-fastapi.git", install_dir
+                "git", "clone", "https://github.com/mbailey/Kokoro-FastAPI.git", install_dir
             ], check=True)
             # Checkout the specific version
             if not checkout_version(Path(install_dir), version):

--- a/voice_mode/utils/services/list_versions.py
+++ b/voice_mode/utils/services/list_versions.py
@@ -8,7 +8,7 @@ from pathlib import Path
 
 
 WHISPER_REPO = "https://github.com/ggerganov/whisper.cpp"
-KOKORO_REPO = "https://github.com/remsky/kokoro-fastapi"
+KOKORO_REPO = "https://github.com/mbailey/Kokoro-FastAPI"
 
 
 @mcp.tool(

--- a/voice_mode/utils/services/version_info.py
+++ b/voice_mode/utils/services/version_info.py
@@ -287,7 +287,7 @@ async def check_updates(
             # Check latest from GitHub
             import httpx
             response = httpx.get(
-                "https://api.github.com/repos/remsky/Kokoro-FastAPI/commits/main",
+                "https://api.github.com/repos/mbailey/Kokoro-FastAPI/commits/master",
                 headers={"Accept": "application/vnd.github.v3+json"},
                 timeout=5.0
             )


### PR DESCRIPTION
## Summary

Switch the kokoro installer from `remsky/Kokoro-FastAPI` to `mbailey/Kokoro-FastAPI`. The mbailey fork tracks upstream master with [PR #448](https://github.com/remsky/Kokoro-FastAPI/pull/448) cherry-picked on top — that PR fixes a known OGG/Opus tail-truncation bug ([#273](https://github.com/remsky/Kokoro-FastAPI/issues/273), [#447](https://github.com/remsky/Kokoro-FastAPI/issues/447), [#449](https://github.com/remsky/Kokoro-FastAPI/issues/449)) that drops the last 1-2 seconds of audio.

## Why fork instead of patch upstream?

`remsky/Kokoro-FastAPI` has been unmaintained since 2026-01-04: ~134 open issues, ~15 open PRs, no commits or reviews from the maintainer in months. PR #448 has been sitting open since 2026-02-14 without engagement. There is no clear successor fork — searched the active forks, none have independently picked up the opus fix. So we maintain our own.

## Changes

- `voice_mode/tools/kokoro/install.py` — clone URL and tag-fetch URL
- `voice_mode/utils/services/list_versions.py` — `KOKORO_REPO` constant
- `voice_mode/utils/services/version_info.py` — GitHub commits API URL. Also fixes a latent bug: the API queried `commits/main` but upstream's default branch is `master`, so version-check requests were silently returning 404. The fork uses `master`, and we now query `commits/master`.

## Test plan

- [ ] `voicemode kokoro install --force-reinstall` — clones from mbailey fork
- [ ] `curl -X POST http://127.0.0.1:8880/v1/audio/speech -d '...' --output test.opus` — confirm opus duration matches mp3 (within ~50ms codec rounding)
- [ ] Voice converse with kokoro voice — last word comes through cleanly

## Already verified

The local install at `~/.voicemode/services/kokoro/` was hand-patched with the same fix and confirmed working in voice testing tonight (Mike: "I heard the papaya" — confirming the end word came through, where it had been cut off prior to the patch).