### PR TITLE
VM-1094: SuperDirt-style voice expressions + remote path translation

### DIFF
--- a/tests/test_voice_profiles.py
+++ b/tests/test_voice_profiles.py
@@ -1,0 +1,180 @@
+"""Tests for voice profile loading and SuperDirt-style voice expressions."""
+
+import importlib
+
+import pytest
+
+
+@pytest.fixture
+def voices_dir(tmp_path, monkeypatch):
+    """Build a voices/ tree with one voice (samantha) that has 3 samples."""
+    voices = tmp_path / "voices"
+    voices.mkdir()
+
+    sam = voices / "samantha"
+    sam.mkdir()
+    (sam / "default.wav").write_bytes(b"riff-default")
+    (sam / "default.txt").write_text("default transcript")
+    (sam / "angry.wav").write_bytes(b"riff-angry")
+    (sam / "angry.txt").write_text("angry transcript")
+    (sam / "happy.wav").write_bytes(b"riff-happy")
+    # No happy.txt — should fall back to default.txt
+    (sam / "description.txt").write_text("Test voice")
+
+    # Second voice with no transcript at all — exercises the warning path
+    bare = voices / "bare"
+    bare.mkdir()
+    (bare / "default.wav").write_bytes(b"riff-bare")
+
+    monkeypatch.setenv("VOICEMODE_VOICES_DIR", str(voices))
+    monkeypatch.delenv("VOICEMODE_REMOTE_VOICES_DIR", raising=False)
+    return voices
+
+
+@pytest.fixture
+def vp(voices_dir):
+    """Reload voice_profiles after env vars are set, return the module."""
+    from voice_mode import voice_profiles
+
+    importlib.reload(voice_profiles)
+    return voice_profiles
+
+
+@pytest.fixture
+def vp_remote(voices_dir, monkeypatch):
+    """Same as vp but with VOICEMODE_REMOTE_VOICES_DIR set to /remote/voices."""
+    monkeypatch.setenv("VOICEMODE_REMOTE_VOICES_DIR", "/remote/voices")
+    from voice_mode import voice_profiles
+
+    importlib.reload(voice_profiles)
+    return voice_profiles
+
+
+# ---------- parse_voice_expr ----------
+
+@pytest.mark.parametrize("expr,expected", [
+    ("samantha", ("samantha", None)),
+    ("samantha[0]", ("samantha", "[0]")),
+    ("samantha[12]", ("samantha", "[12]")),
+    ("samantha/angry.wav", ("samantha", "angry.wav")),
+    ("/abs/path/file.wav", (None, "/abs/path/file.wav")),
+    ("", (None, None)),
+])
+def test_parse_voice_expr(vp, expr, expected):
+    assert vp.parse_voice_expr(expr) == expected
+
+
+# ---------- profile loading ----------
+
+def test_load_profiles_finds_voices_with_default_wav(vp):
+    profiles = vp.load_profiles()
+    assert set(profiles.keys()) == {"samantha", "bare"}
+
+
+def test_profile_picks_up_description(vp):
+    p = vp.get_profile("samantha")
+    assert p.description == "Test voice"
+
+
+def test_voice_with_no_transcript_loads_with_empty_ref_text(vp):
+    p = vp.get_profile("bare")
+    assert p is not None
+    assert p.ref_text == ""
+
+
+# ---------- bare name resolution ----------
+
+def test_bare_name_resolves_to_default_wav(vp):
+    p = vp.get_profile("samantha")
+    assert p.ref_audio.endswith("/samantha/default.wav")
+    assert p.ref_text == "default transcript"
+
+
+# ---------- indexed selector ----------
+
+def test_indexed_selector_picks_sorted_sample(vp):
+    # Sorted: angry, default, happy
+    assert vp.get_profile("samantha[0]").ref_audio.endswith("/angry.wav")
+    assert vp.get_profile("samantha[1]").ref_audio.endswith("/default.wav")
+    assert vp.get_profile("samantha[2]").ref_audio.endswith("/happy.wav")
+
+
+def test_indexed_transcript_falls_back_to_default_txt(vp):
+    # happy.wav has no happy.txt — should use default.txt
+    p = vp.get_profile("samantha[2]")
+    assert p.ref_text == "default transcript"
+
+
+def test_indexed_with_matching_txt_uses_it(vp):
+    # angry.wav has angry.txt
+    p = vp.get_profile("samantha[0]")
+    assert p.ref_text == "angry transcript"
+
+
+def test_index_out_of_range_falls_back_to_default(vp):
+    p = vp.get_profile("samantha[99]")
+    assert p.ref_audio.endswith("/samantha/default.wav")
+
+
+# ---------- relative path selector ----------
+
+def test_relative_path_resolves_inside_voice_dir(vp):
+    p = vp.get_profile("samantha/angry.wav")
+    assert p.ref_audio.endswith("/samantha/angry.wav")
+    assert p.ref_text == "angry transcript"
+
+
+# ---------- absolute path escape hatch ----------
+
+def test_absolute_path_passes_through(vp):
+    p = vp.get_profile("/some/abs/path.wav")
+    assert p.ref_audio == "/some/abs/path.wav"
+    assert p.ref_text == ""
+    # Should be marked as a clone voice so routing works
+    assert vp.is_clone_voice("/some/abs/path.wav")
+
+
+# ---------- is_clone_voice ----------
+
+@pytest.mark.parametrize("expr", [
+    "samantha", "samantha[0]", "samantha/angry.wav", "/abs/path.wav",
+])
+def test_is_clone_voice_recognises_all_expr_forms(vp, expr):
+    assert vp.is_clone_voice(expr)
+
+
+@pytest.mark.parametrize("expr", ["af_sky", "nova", "", "unknown"])
+def test_is_clone_voice_rejects_non_clone(vp, expr):
+    assert not vp.is_clone_voice(expr)
+
+
+def test_get_profile_returns_none_for_unknown(vp):
+    assert vp.get_profile("definitely-not-a-voice") is None
+
+
+# ---------- remote path translation ----------
+
+def test_remote_path_translation_rewrites_prefix(vp_remote):
+    p = vp_remote.get_profile("samantha")
+    assert p.ref_audio == "/remote/voices/samantha/default.wav"
+
+
+def test_remote_path_translation_for_indexed(vp_remote):
+    p = vp_remote.get_profile("samantha[0]")
+    assert p.ref_audio == "/remote/voices/samantha/angry.wav"
+
+
+def test_remote_path_translation_for_relative(vp_remote):
+    p = vp_remote.get_profile("samantha/happy.wav")
+    assert p.ref_audio == "/remote/voices/samantha/happy.wav"
+
+
+def test_remote_path_translation_skips_absolute(vp_remote):
+    p = vp_remote.get_profile("/literal/path.wav")
+    assert p.ref_audio == "/literal/path.wav"
+
+
+def test_no_remote_uses_local_absolute_path(vp, voices_dir):
+    p = vp.get_profile("samantha")
+    expected = str((voices_dir / "samantha" / "default.wav").resolve())
+    assert p.ref_audio == expected

--- a/voice_mode/voice_profiles.py
+++ b/voice_mode/voice_profiles.py
@@ -1,47 +1,61 @@
 """Voice profiles for clone-based TTS.
 
-Voices come from two sources, layered:
+Voices live in ``$VOICEMODE_VOICES_DIR`` (default ``~/.voicemode/voices``).
+Each subdirectory is a voice profile. For ``<name>/`` we look for a
+``default.wav`` (or the first ``*.wav``) plus a sidecar transcript
+``default.txt`` (or matching basename). SuperDirt-style: drop a folder in,
+you get a voice. Symlink ``default.wav`` to swap which sample is active
+without renaming files.
 
-1. **Directory-based** (preferred):
-   ``$VOICEMODE_VOICES_DIR`` (default ``~/.voicemode/voices``).
-   Each subdirectory is a voice. For ``<name>/`` we look for a
-   ``default.wav`` (or the first ``*.wav``) plus a sidecar transcript
-   ``default.txt`` (or matching basename). SuperDirt-style: drop a folder
-   in, you get a voice. Symlink ``default.wav`` to swap which sample is
-   active without renaming files.
+Each profile maps a voice name to a reference audio file and transcript,
+plus model and endpoint routing info.
 
-2. **JSON-based** (legacy):
-   ``~/.voicemode/voices.json``. Loaded after the directory; entries that
-   already exist as directory profiles are not overridden, so dir wins.
+Voice expression syntax (``voice="<expr>"`` at converse time):
 
-Each profile maps a voice name to a reference audio file and transcript
-on the TTS server, plus model and endpoint routing info.
+* ``samantha``           — the voice's ``default.wav``
+* ``samantha[0]``        — the first ``*.wav`` in the dir (sorted)
+* ``samantha[2]``        — the third ``*.wav`` (SuperDirt-style indexing)
+* ``samantha/angry.wav`` — an explicit file inside the voice dir
+* ``/abs/path.wav``      — absolute path passed straight to the TTS server
+
+Remote TTS servers (e.g. mlx-audio on ms2) need the ref_audio path that
+exists on *their* filesystem, not ours. Set ``VOICEMODE_REMOTE_VOICES_DIR``
+to the path where the voices directory is mirrored on the TTS host; we
+rewrite the prefix when sending the request. If unset, the local
+absolute path is sent (only useful when the TTS server runs locally).
 """
 
-import json
 import logging
 import os
-from dataclasses import dataclass
+import re
+from dataclasses import dataclass, replace
 from pathlib import Path
-from typing import Dict, Optional
+from typing import Dict, List, Optional, Tuple
 
 logger = logging.getLogger("voicemode")
 
-PROFILES_JSON = Path(os.path.expanduser("~/.voicemode/voices.json"))
 VOICES_DIR = Path(os.path.expanduser(
     os.environ.get("VOICEMODE_VOICES_DIR", "~/.voicemode/voices")
 ))
 
+# Path on the remote TTS server where VOICES_DIR is mirrored. When set,
+# ref_audio paths sent to the server are rewritten with this prefix so
+# the server can find the file on its own filesystem.
+REMOTE_VOICES_DIR = os.environ.get("VOICEMODE_REMOTE_VOICES_DIR", "")
+
 # Default mlx-audio endpoint (Qwen3-TTS on ms2)
 DEFAULT_CLONE_BASE_URL = "http://ms2:8890/v1"
 DEFAULT_CLONE_MODEL = "mlx-community/Qwen3-TTS-12Hz-1.7B-Base-bf16"
+
+# Matches ``name[0]``, ``name[12]``. Captures (name, index).
+_INDEX_RE = re.compile(r"^([^/\[\]]+)\[(\d+)\]$")
 
 
 @dataclass
 class VoiceProfile:
     """A voice cloning profile."""
     name: str
-    ref_audio: str       # Path to reference audio on TTS server
+    ref_audio: str       # Absolute path to reference audio (server-side)
     ref_text: str        # Transcript of reference audio
     model: str           # TTS model to use
     base_url: str        # TTS endpoint URL
@@ -98,6 +112,14 @@ def _resolve_transcript(wav_path: Path) -> str:
     return ""
 
 
+def _read_description(voice_dir: Path) -> str:
+    """Read the optional ``description.txt`` sidecar."""
+    desc_path = voice_dir / "description.txt"
+    if desc_path.exists():
+        return desc_path.read_text().strip()
+    return ""
+
+
 def _load_dir_profiles() -> Dict[str, VoiceProfile]:
     """Walk VOICES_DIR and build profiles from per-voice subdirectories."""
     profiles: Dict[str, VoiceProfile] = {}
@@ -122,87 +144,187 @@ def _load_dir_profiles() -> Dict[str, VoiceProfile]:
 
         profiles[voice_dir.name] = VoiceProfile(
             name=voice_dir.name,
-            ref_audio=str(wav.resolve()),
+            ref_audio=_translate_path(wav),
             ref_text=transcript,
             model=DEFAULT_CLONE_MODEL,
             base_url=DEFAULT_CLONE_BASE_URL,
-            description="",
+            description=_read_description(voice_dir),
         )
 
     if profiles:
         logger.info(
-            f"Loaded {len(profiles)} dir profiles from {VOICES_DIR}: "
-            f"{list(profiles.keys())}"
-        )
-    return profiles
-
-
-def _load_json_profiles() -> Dict[str, VoiceProfile]:
-    """Load profiles from the legacy voices.json registry."""
-    profiles: Dict[str, VoiceProfile] = {}
-
-    if not PROFILES_JSON.exists():
-        logger.debug(f"No voice profiles file at {PROFILES_JSON}")
-        return profiles
-
-    try:
-        with open(PROFILES_JSON) as f:
-            data = json.load(f)
-    except Exception as e:
-        logger.error(f"Failed to load voice profiles JSON: {e}")
-        return profiles
-
-    for name, pd in data.get("voices", {}).items():
-        profiles[name] = VoiceProfile(
-            name=name,
-            ref_audio=pd["ref_audio"],
-            ref_text=pd["ref_text"],
-            model=pd.get("model", DEFAULT_CLONE_MODEL),
-            base_url=pd.get("base_url", DEFAULT_CLONE_BASE_URL),
-            description=pd.get("description", ""),
-        )
-
-    if profiles:
-        logger.info(
-            f"Loaded {len(profiles)} JSON profiles from {PROFILES_JSON}: "
+            f"Loaded {len(profiles)} voice profiles from {VOICES_DIR}: "
             f"{list(profiles.keys())}"
         )
     return profiles
 
 
 def load_profiles() -> Dict[str, VoiceProfile]:
-    """Load voice profiles from both directory and JSON sources.
-
-    Directory takes precedence — JSON only fills in voices not already
-    defined by a directory profile.
-    """
+    """Load voice profiles by scanning VOICES_DIR."""
     global _profiles, _loaded
-
-    dir_profiles = _load_dir_profiles()
-    json_profiles = _load_json_profiles()
-
-    # Layer JSON on top of dir, but only for keys dir didn't define
-    merged = dict(dir_profiles)
-    for name, prof in json_profiles.items():
-        merged.setdefault(name, prof)
-
-    _profiles = merged
+    _profiles = _load_dir_profiles()
     _loaded = True
     return _profiles
 
 
-def get_profile(voice_name: str) -> Optional[VoiceProfile]:
-    """Get a voice profile by name. Returns None if not a clone voice."""
-    if not _loaded:
-        load_profiles()
-    return _profiles.get(voice_name)
+def parse_voice_expr(expr: str) -> Tuple[Optional[str], Optional[str]]:
+    """Parse a voice expression into ``(voice_name, selector)``.
+
+    Selector is either ``None`` (use default), a string like ``"[N]"``
+    (indexed sample), or a relative file path inside the voice dir
+    (e.g. ``"angry.wav"``). For absolute paths the voice_name is ``None``
+    and the selector is the absolute path itself.
+
+    Examples::
+
+        parse_voice_expr("samantha")           == ("samantha", None)
+        parse_voice_expr("samantha[0]")        == ("samantha", "[0]")
+        parse_voice_expr("samantha/angry.wav") == ("samantha", "angry.wav")
+        parse_voice_expr("/abs/path.wav")      == (None, "/abs/path.wav")
+    """
+    if not expr:
+        return None, None
+    if expr.startswith("/"):
+        return None, expr
+
+    m = _INDEX_RE.match(expr)
+    if m:
+        return m.group(1), f"[{m.group(2)}]"
+
+    if "/" in expr:
+        head, _, tail = expr.partition("/")
+        return head, tail
+
+    return expr, None
 
 
-def is_clone_voice(voice_name: str) -> bool:
-    """Check if a voice name refers to a clone profile."""
+def _list_samples(voice_dir: Path) -> List[Path]:
+    """Sorted list of ``*.wav`` files inside a voice directory."""
+    return sorted(voice_dir.glob("*.wav"))
+
+
+def _translate_path(local_path: Path) -> str:
+    """Translate a local voices-dir path into the path the TTS server sees.
+
+    If ``VOICEMODE_REMOTE_VOICES_DIR`` is set and ``local_path`` lives
+    under ``VOICES_DIR``, replace the prefix. Otherwise return the local
+    absolute path (correct when the TTS server is the local machine).
+    """
+    abs_local = local_path.resolve() if local_path.exists() else local_path
+    if not REMOTE_VOICES_DIR:
+        return str(abs_local)
+
+    try:
+        rel = abs_local.relative_to(VOICES_DIR.resolve())
+    except ValueError:
+        # Path isn't under VOICES_DIR — pass through untranslated
+        return str(abs_local)
+
+    return str(Path(REMOTE_VOICES_DIR) / rel)
+
+
+def resolve_voice_expr(expr: str) -> Optional[VoiceProfile]:
+    """Resolve a voice expression to a fully-populated ``VoiceProfile``.
+
+    Returns a profile whose ``ref_audio`` is the path the TTS server
+    should look up, and whose ``ref_text`` matches the chosen sample.
+    Returns ``None`` if the expression doesn't refer to a clone voice.
+
+    For the absolute-path escape hatch (``"/abs/path.wav"``), returns a
+    minimal profile with the path passed through and an empty
+    ``ref_text`` (caller may not have a transcript for arbitrary files).
+    """
     if not _loaded:
         load_profiles()
-    return voice_name in _profiles
+
+    name, selector = parse_voice_expr(expr)
+
+    # Absolute-path escape hatch: no profile lookup, no transcript.
+    if name is None and selector and selector.startswith("/"):
+        return VoiceProfile(
+            name=expr,
+            ref_audio=selector,
+            ref_text="",
+            model=DEFAULT_CLONE_MODEL,
+            base_url=DEFAULT_CLONE_BASE_URL,
+            description="(absolute path)",
+        )
+
+    if not name:
+        return None
+
+    profile = _profiles.get(name)
+    if profile is None:
+        return None
+
+    # Bare name → use the profile as-is (already pointing at default.wav).
+    if selector is None:
+        return profile
+
+    voice_dir = VOICES_DIR / name
+
+    # Indexed sample: samantha[0]
+    if selector.startswith("[") and selector.endswith("]"):
+        try:
+            idx = int(selector[1:-1])
+        except ValueError:
+            logger.error(f"Bad sample index in voice expr {expr!r}")
+            return profile
+        samples = _list_samples(voice_dir)
+        if not samples:
+            logger.warning(f"Voice {name!r}: no .wav samples for indexing")
+            return profile
+        if idx < 0 or idx >= len(samples):
+            logger.error(
+                f"Sample index {idx} out of range for {name!r} "
+                f"({len(samples)} samples available)"
+            )
+            return profile
+        wav = samples[idx]
+        return replace(
+            profile,
+            ref_audio=_translate_path(wav),
+            ref_text=_resolve_transcript(wav),
+        )
+
+    # Explicit relative file: samantha/angry.wav
+    wav = voice_dir / selector
+    if not wav.exists():
+        logger.warning(
+            f"Voice expr {expr!r}: {wav} does not exist locally — "
+            f"sending path to server anyway in case it's mirrored."
+        )
+    return replace(
+        profile,
+        ref_audio=_translate_path(wav),
+        ref_text=_resolve_transcript(wav) if wav.exists() else "",
+    )
+
+
+def get_profile(voice_expr: str) -> Optional[VoiceProfile]:
+    """Get a voice profile resolved from a voice expression.
+
+    Equivalent to :func:`resolve_voice_expr` — kept under the original
+    name for back-compat with existing callers.
+    """
+    return resolve_voice_expr(voice_expr)
+
+
+def is_clone_voice(voice_expr: str) -> bool:
+    """Check if a voice expression refers to a clone profile.
+
+    Recognises the selector syntax: ``samantha[0]`` and
+    ``samantha/angry.wav`` are both clone voices if ``samantha`` is.
+    Absolute paths always count as clone voices.
+    """
+    if not _loaded:
+        load_profiles()
+    if not voice_expr:
+        return False
+    name, selector = parse_voice_expr(voice_expr)
+    if name is None and selector and selector.startswith("/"):
+        return True
+    return name in _profiles
 
 
 def list_profiles() -> Dict[str, VoiceProfile]:


### PR DESCRIPTION
## Summary

Unbreaks clone voices on remote mlx-audio servers after voice-lab's directory layout migration.

- Voice param becomes a SuperDirt-style **selector**: \`samantha\`, \`samantha[0]\`, \`samantha/angry.wav\`, or absolute path.
- New env var \`VOICEMODE_REMOTE_VOICES_DIR\` rewrites ref_audio paths so the remote TTS server can find files mirrored under a different prefix.
- \`voices.json\` is no longer read — voices are discovered by walking \`VOICES_DIR\` only (mirrors voice-lab VL-8).
- 30 new pytest cases covering parser, indexed selector, relative paths, abs pass-through, and remote translation.

## Why

Before this PR, when voicemode loaded a clone voice from the directory layout, \`ref_audio\` was set to the local absolute path (\`/Users/admin/.voicemode/voices/jeannie/default.wav\`). When sent to mlx-audio on ms2, the file didn't exist there — ms2 has voices at \`/Users/admin/local/mlx-audio/voices/\`. Result: every clone voice died mid-request with \`peer closed connection without sending complete message body (incomplete chunked read)\`.

The legacy \`voices.json\` worked by accident (users hand-wrote ms2 paths into it). VL-10's directory migration broke those flat paths.

## Mike's setup after this lands

\`\`\`
# ~/.voicemode/voicemode.env
VOICEMODE_REMOTE_VOICES_DIR=/Users/admin/local/mlx-audio/voices
\`\`\`

Local (MBA): \`~/.voicemode/voices/<name>/default.wav\`
Remote (ms2): \`/Users/admin/local/mlx-audio/voices/<name>/default.wav\` (mirrored manually for now)

## Test plan
- [x] 30 new pytest cases pass (\`pytest tests/test_voice_profiles.py\`)
- [x] Full suite: 785 passed, 1 pre-existing STT failure unrelated
- [ ] End-to-end: \`converse(message="...", voice="jeannie")\` against ms2 mlx-audio
- [ ] Indexed selector: \`converse(voice="samantha[0]")\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)