### PR TITLE
VM-1106: recognize mlx-audio (port 8890) in provider type detection

### DIFF
--- a/tests/test_provider_discovery.py
+++ b/tests/test_provider_discovery.py
@@ -1,0 +1,70 @@
+"""Unit tests for provider_discovery.detect_provider_type and is_local_provider."""
+
+import pytest
+
+from voice_mode.provider_discovery import detect_provider_type, is_local_provider
+
+
+class TestDetectProviderType:
+    """Cover the provider-type ladder including the mlx-audio branch (VM-1106)."""
+
+    @pytest.mark.parametrize(
+        "url,expected",
+        [
+            ("https://api.openai.com/v1", "openai"),
+            ("http://127.0.0.1:8880/v1", "kokoro"),
+            ("http://127.0.0.1:2022/v1", "whisper"),
+            ("http://127.0.0.1:8890/v1", "mlx-audio"),
+            ("http://localhost:8890", "mlx-audio"),
+        ],
+    )
+    def test_known_provider_types(self, url, expected):
+        assert detect_provider_type(url) == expected
+
+    def test_mlx_audio_substring_fallback(self):
+        # Reverse-proxied / non-default-port deployments still match via
+        # host/path substring per VM-1106 design.
+        assert detect_provider_type("http://example.com/mlx_audio/v1") == "mlx-audio"
+        assert detect_provider_type("http://example.com/mlx-audio/v1") == "mlx-audio"
+
+    def test_unknown_url_falls_through(self):
+        # Non-localhost, non-OpenAI URLs without mlx-audio markers should
+        # remain "unknown" -- this is the existing default behaviour.
+        assert detect_provider_type("https://api.example.com/v1") == "unknown"
+
+    def test_empty_base_url(self):
+        assert detect_provider_type("") == "unknown"
+
+    def test_generic_local_unchanged(self):
+        # A localhost endpoint on an unrecognised port still falls back to
+        # the generic "local" provider type (regression check).
+        assert detect_provider_type("http://127.0.0.1:9999/v1") == "local"
+
+
+class TestIsLocalProvider:
+    """is_local_provider must treat mlx-audio as local (VM-1106 AC item 6)."""
+
+    def test_mlx_audio_localhost_is_local(self):
+        assert is_local_provider("http://127.0.0.1:8890/v1") is True
+
+    def test_mlx_audio_reverse_proxy_is_local(self):
+        # Even off-localhost mlx-audio endpoints should be classified local
+        # via the provider_type allowlist.
+        assert is_local_provider("http://example.com/mlx_audio/v1") is True
+
+    @pytest.mark.parametrize(
+        "url",
+        [
+            "http://127.0.0.1:8880/v1",
+            "http://localhost:2022/v1",
+            "http://127.0.0.1:9999/v1",
+        ],
+    )
+    def test_existing_local_providers_unchanged(self, url):
+        assert is_local_provider(url) is True
+
+    def test_openai_is_not_local(self):
+        assert is_local_provider("https://api.openai.com/v1") is False
+
+    def test_empty_base_url_is_not_local(self):
+        assert is_local_provider("") is False

--- a/voice_mode/provider_discovery.py
+++ b/voice_mode/provider_discovery.py
@@ -55,7 +55,7 @@ def is_local_provider(base_url: str) -> bool:
     if not base_url:
         return False
     provider_type = detect_provider_type(base_url)
-    return provider_type in ["kokoro", "whisper", "local"] or \
+    return provider_type in ["kokoro", "whisper", "mlx-audio", "local"] or \
            "127.0.0.1" in base_url or \
            "localhost" in base_url
 

--- a/voice_mode/provider_discovery.py
+++ b/voice_mode/provider_discovery.py
@@ -14,6 +14,7 @@ import time
 from typing import Dict, List, Optional, Any
 from dataclasses import dataclass, asdict
 from datetime import datetime, timezone
+from urllib.parse import urlparse
 
 import httpx
 from openai import AsyncOpenAI
@@ -34,6 +35,8 @@ def detect_provider_type(base_url: str) -> str:
         return "kokoro"
     elif ":2022" in base_url:
         return "whisper"
+    elif urlparse(base_url).port == 8890 or "mlx_audio" in base_url or "mlx-audio" in base_url:
+        return "mlx-audio"
     elif "127.0.0.1" in base_url or "localhost" in base_url:
         # Try to infer from port if not already detected
         if base_url.endswith("/v1"):

--- a/voice_mode/provider_discovery.py
+++ b/voice_mode/provider_discovery.py
@@ -60,6 +60,15 @@ def is_local_provider(base_url: str) -> bool:
            "localhost" in base_url
 
 
+def _default_stt_models(base_url: str) -> List[str]:
+    # Display-only seed. mlx-audio rejects "whisper-1" (it expects a full HF
+    # repo id), so advertise its websocket default instead. Wire payloads are
+    # unaffected -- VM-1100 owns the per-endpoint resolver.
+    if detect_provider_type(base_url) == "mlx-audio":
+        return ["mlx-community/whisper-large-v3-turbo"]
+    return ["whisper-1"]
+
+
 @dataclass
 class EndpointInfo:
     """Information about a discovered endpoint."""
@@ -108,7 +117,7 @@ class ProviderRegistry:
                 provider_type = detect_provider_type(url)
                 self.registry["stt"][url] = EndpointInfo(
                     base_url=url,
-                    models=["whisper-1"],
+                    models=_default_stt_models(url),
                     voices=[],  # STT doesn't have voices
                     provider_type=provider_type
                 )
@@ -171,13 +180,13 @@ class ProviderRegistry:
                                 response = await http_client.get(base_url.rstrip('/v1'))
                                 if response.status_code == 200:
                                     logger.debug(f"Local whisper endpoint {base_url} is responding")
-                                    models = ["whisper-1"]  # Default model name
+                                    models = _default_stt_models(base_url)
                                 else:
                                     raise Exception(f"Whisper endpoint returned status {response.status_code}")
                         else:
                             # For OpenAI, models.list failure likely means auth issue
                             # We'll still mark it as healthy since the endpoint exists
-                            models = ["whisper-1"]  # OpenAI's whisper model
+                            models = _default_stt_models(base_url)
                             logger.debug(f"Assuming OpenAI whisper endpoint {base_url} is available")
                     except Exception as health_error:
                         logger.debug(f"STT health check failed for {base_url}: {health_error}")
@@ -185,7 +194,7 @@ class ProviderRegistry:
             
             # Ensure STT endpoints have at least the default whisper model
             if service_type == "stt" and not models:
-                models = ["whisper-1"]
+                models = _default_stt_models(base_url)
             
             # For TTS, discover voices
             voices = []

--- a/voice_mode/tools/providers.py
+++ b/voice_mode/tools/providers.py
@@ -4,7 +4,7 @@ import logging
 from typing import Optional, Union, Dict, Any
 
 from voice_mode.server import mcp
-from voice_mode.provider_discovery import provider_registry, detect_provider_type
+from voice_mode.provider_discovery import provider_registry, detect_provider_type, _default_stt_models
 from voice_mode.config import TTS_BASE_URLS, STT_BASE_URLS
 
 logger = logging.getLogger("voicemode")
@@ -64,7 +64,7 @@ async def refresh_provider_registry(
 
                     provider_registry.registry[service][url] = EndpointInfo(
                         base_url=url,
-                        models=["whisper-1"] if service == "stt" else (["tts-1", "tts-1-hd"] if "openai.com" in url else ["tts-1"]),
+                        models=_default_stt_models(url) if service == "stt" else (["tts-1", "tts-1-hd"] if "openai.com" in url else ["tts-1"]),
                         voices=[] if service == "stt" else (["alloy", "echo", "fable", "nova", "onyx", "shimmer"] if "openai.com" in url else ["af_alloy", "af_aoede", "af_bella", "af_heart", "af_jadzia", "af_jessica", "af_kore", "af_nicole", "af_nova", "af_river", "af_sarah", "af_sky", "af_v0", "af_v0bella", "af_v0irulan", "af_v0nicole", "af_v0sarah", "af_v0sky", "am_adam", "am_echo", "am_eric", "am_fenrir", "am_liam", "am_michael", "am_onyx", "am_puck", "am_santa", "am_v0adam", "am_v0gurney", "am_v0michael", "bf_alice", "bf_emma", "bf_lily", "bf_v0emma", "bf_v0isabella", "bm_daniel", "bm_fable", "bm_george", "bm_lewis", "bm_v0george", "bm_v0lewis", "ef_dora", "em_alex", "em_santa", "ff_siwis", "hf_alpha", "hf_beta", "hm_omega", "hm_psi", "if_sara", "im_nicola", "jf_alpha", "jf_gongitsune", "jf_nezumi", "jf_tebukuro", "jm_kumo", "pf_dora", "pm_alex", "pm_santa", "zf_xiaobei", "zf_xiaoni", "zf_xiaoxiao", "zf_xiaoyi", "zm_yunjian", "zm_yunxi", "zm_yunxia", "zm_yunyang"]),
                         provider_type=detect_provider_type(url),
                         last_check=datetime.utcnow().isoformat() + "Z"


### PR DESCRIPTION
## Summary

Adds `mlx-audio` as a recognized provider type in `provider_discovery.py` so the resolver in VM-1100 can branch on it cleanly. Until this lands, mlx-audio endpoints get classified as generic `local` (not wrong, but not specific).

- `detect_provider_type()` now returns `"mlx-audio"` for port 8890 or URLs containing `mlx_audio`/`mlx-audio`
- `is_local_provider()` treats `mlx-audio` as local (matches `kokoro`, `whisper`, `local`)
- Display-only seed sites (`provider_discovery.py:108,171,177,185` and `tools/providers.py:67`) seed mlx-audio endpoints with `mlx-community/whisper-large-v3-turbo` instead of `whisper-1`
- 16 unit tests in `tests/test_provider_discovery.py` covering all five provider types + edge cases

Independent of VM-1100 (the actual STT model resolver) — that one will consume this detection once it lands.

## Test plan
- [x] `pytest tests/test_provider_discovery.py` — 16/16 pass
- [ ] Manual: confirm `voicemode status` labels port 8890 endpoint as `mlx-audio`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>