### PR TITLE
VM-1100: STT model config + provider-aware resolver

### DIFF
--- a/tests/manual/test_stt_failover_chain.py
+++ b/tests/manual/test_stt_failover_chain.py
@@ -1,0 +1,155 @@
+"""Manual smoke test: full STT failover chain with VOICEMODE_STT_MODEL set.
+
+Implements the manual smoke described in VM-1100 test-004. Instead of
+requiring an interactive `voicemode converse` session, this script drives
+``simple_stt_failover()`` directly against running services and asserts which
+endpoint succeeds for each scenario in the failover chain.
+
+Scenarios:
+    A. All three URLs alive            -> mlx-audio (8890) handles the request.
+    B. mlx-audio "down" (bad URL)      -> whisper.cpp (2022) handles it.
+    C. Both local "down" (bad URLs)    -> OpenAI handles it; we verify the
+       outbound model kwarg is 'whisper-1' via a patched AsyncOpenAI client
+       (avoiding real credit consumption).
+
+Prerequisites:
+    - mlx-audio listening on http://127.0.0.1:8890/v1
+    - whisper.cpp listening on http://127.0.0.1:2022/v1
+    - A WAV sample at WAV_PATH (defaults to a recent one in ~/.voicemode/audio/).
+
+Run:
+    cd worktree && uv run python -m tests.manual.test_stt_failover_chain
+"""
+
+import asyncio
+import os
+import sys
+from pathlib import Path
+from unittest.mock import AsyncMock, patch
+
+WAV_PATH = Path.home() / ".voicemode" / "audio" / "no_speech_20260427_013641.wav"
+
+OPENAI_URL = "https://api.openai.com/v1"
+MLX_AUDIO_URL = "http://127.0.0.1:8890/v1"
+WHISPER_CPP_URL = "http://127.0.0.1:2022/v1"
+DEAD_URL_FOR_MLX = "http://127.0.0.1:18890/v1"
+DEAD_URL_FOR_WHISPER_CPP = "http://127.0.0.1:12022/v1"
+
+STT_MODEL = "mlx-community/whisper-large-v3-turbo"
+
+
+def _set_env_for_chain(stt_base_urls: str) -> None:
+    os.environ["VOICEMODE_STT_MODEL"] = STT_MODEL
+    os.environ["VOICEMODE_STT_BASE_URLS"] = stt_base_urls
+
+
+def _reload_config_into(*modules):
+    """Re-read STT_MODEL / STT_BASE_URLS / STT_MODELS in voice_mode.config and
+    re-bind the names imported into each downstream module."""
+    import voice_mode.config as cfg
+    cfg.reload_configuration()
+    for mod in modules:
+        mod.STT_BASE_URLS = cfg.STT_BASE_URLS
+        if hasattr(mod, "STT_MODEL"):
+            mod.STT_MODEL = cfg.STT_MODEL
+        if hasattr(mod, "STT_MODELS"):
+            mod.STT_MODELS = cfg.STT_MODELS
+
+
+async def scenario_a_full_chain():
+    print("\n=== Scenario A: full chain alive (expect mlx-audio handles) ===")
+    _set_env_for_chain(f"{MLX_AUDIO_URL},{WHISPER_CPP_URL},{OPENAI_URL}")
+
+    from voice_mode import simple_failover, providers
+    _reload_config_into(simple_failover, providers)
+
+    with open(WAV_PATH, "rb") as audio_file:
+        result = await simple_failover.simple_stt_failover(audio_file=audio_file)
+
+    print(f"  Result: {result}")
+    assert result is not None and "text" in result, f"expected success, got {result}"
+    assert result["endpoint"] == MLX_AUDIO_URL, (
+        f"expected mlx-audio to handle, got endpoint={result['endpoint']}"
+    )
+    print(f"  OK: mlx-audio handled the request, transcribed {result['text']!r}")
+
+
+async def scenario_b_mlx_down():
+    print("\n=== Scenario B: mlx-audio down (expect whisper.cpp handles) ===")
+    _set_env_for_chain(f"{DEAD_URL_FOR_MLX},{WHISPER_CPP_URL},{OPENAI_URL}")
+
+    from voice_mode import simple_failover, providers
+    _reload_config_into(simple_failover, providers)
+
+    with open(WAV_PATH, "rb") as audio_file:
+        result = await simple_failover.simple_stt_failover(audio_file=audio_file)
+
+    print(f"  Result: {result}")
+    assert result is not None and "text" in result, f"expected success, got {result}"
+    assert result["endpoint"] == WHISPER_CPP_URL, (
+        f"expected whisper.cpp to handle, got endpoint={result['endpoint']}"
+    )
+    print(f"  OK: whisper.cpp handled the request, transcribed {result['text']!r}")
+
+
+async def scenario_c_both_local_down():
+    print("\n=== Scenario C: both local down (expect OpenAI handles, model='whisper-1') ===")
+    _set_env_for_chain(f"{DEAD_URL_FOR_MLX},{DEAD_URL_FOR_WHISPER_CPP},{OPENAI_URL}")
+
+    from voice_mode import simple_failover, providers
+    _reload_config_into(simple_failover, providers)
+
+    captured = {}
+    real_aoai = simple_failover.AsyncOpenAI
+
+    def fake_aoai_factory(*args, base_url=None, **kwargs):
+        """Only stub the OpenAI endpoint; for dead local URLs, return a real
+        AsyncOpenAI client so the connection genuinely fails and triggers
+        failover."""
+        if base_url == OPENAI_URL:
+            instance = AsyncMock()
+
+            async def fake_create(**create_kwargs):
+                captured.update(create_kwargs)
+                captured["__base_url__"] = base_url
+                return "ok-from-openai-mock"
+
+            instance.audio.transcriptions.create = AsyncMock(side_effect=fake_create)
+            return instance
+        return real_aoai(*args, base_url=base_url, **kwargs)
+
+    with patch("voice_mode.simple_failover.AsyncOpenAI", side_effect=fake_aoai_factory):
+        with open(WAV_PATH, "rb") as audio_file:
+            result = await simple_failover.simple_stt_failover(audio_file=audio_file)
+
+    print(f"  Result: {result}")
+    print(f"  Captured kwargs: model={captured.get('model')!r}")
+    assert result is not None and result.get("text") == "ok-from-openai-mock", (
+        f"expected the mocked OpenAI call to succeed, got {result}"
+    )
+    assert result["endpoint"] == OPENAI_URL, (
+        f"expected openai endpoint, got {result['endpoint']}"
+    )
+    assert captured.get("model") == "whisper-1", (
+        f"expected outbound model='whisper-1' (OpenAI override), got {captured.get('model')!r}"
+    )
+    print("  OK: OpenAI received the call with model='whisper-1' (override applied).")
+
+
+async def main():
+    if not WAV_PATH.exists():
+        print(f"ERROR: missing WAV sample at {WAV_PATH}", file=sys.stderr)
+        sys.exit(2)
+
+    print(f"Audio sample: {WAV_PATH} ({WAV_PATH.stat().st_size / 1024:.1f} KB)")
+    print(f"VOICEMODE_STT_MODEL = {STT_MODEL}")
+
+    await scenario_a_full_chain()
+    await scenario_b_mlx_down()
+    await scenario_c_both_local_down()
+
+    print("\nAll three failover-chain scenarios passed.")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/tests/test_provider_selection.py
+++ b/tests/test_provider_selection.py
@@ -5,7 +5,11 @@ from unittest.mock import Mock, patch, AsyncMock
 from datetime import datetime, timezone
 
 from voice_mode.provider_discovery import ProviderRegistry, EndpointInfo, detect_provider_type
-from voice_mode.providers import get_tts_client_and_voice, _select_model_for_endpoint
+from voice_mode.providers import (
+    get_tts_client_and_voice,
+    _select_model_for_endpoint,
+    _select_stt_model_for_endpoint,
+)
 
 
 class TestProviderTypeDetection:
@@ -204,3 +208,111 @@ class TestModelSelection:
         
         # No models at all, fallback to tts-1
         assert _select_model_for_endpoint(endpoint) == "tts-1"
+
+
+class TestSttModelSelection:
+    """Tests for _select_stt_model_for_endpoint resolver branches."""
+
+    def _make_endpoint(self, base_url: str, provider_type: str) -> EndpointInfo:
+        return EndpointInfo(
+            base_url=base_url,
+            models=[],
+            voices=[],
+            provider_type=provider_type,
+            last_check="",
+            last_error=None,
+        )
+
+    def test_openai_override_returns_whisper_1_regardless_of_requested(self):
+        """Branch 1: provider_type == 'openai' always returns 'whisper-1',
+        even when caller passes a different model and STT_MODELS configures
+        a positional override."""
+        endpoint = self._make_endpoint("https://api.openai.com/v1", "openai")
+        with patch(
+            "voice_mode.providers.STT_BASE_URLS",
+            ["https://api.openai.com/v1"],
+        ), patch(
+            "voice_mode.providers.STT_MODELS",
+            ["mlx-community/whisper-large-v3-turbo"],
+        ), patch("voice_mode.providers.STT_MODEL", "global-default"):
+            assert _select_stt_model_for_endpoint(endpoint) == "whisper-1"
+            assert (
+                _select_stt_model_for_endpoint(endpoint, "caller-passed")
+                == "whisper-1"
+            )
+
+    def test_caller_passed_wins_for_non_openai(self):
+        """Branch 2: caller-passed requested_model is honored for non-OpenAI
+        providers (whisper.cpp, mlx-audio, openai-compatible, unknown)."""
+        for provider_type in (
+            "whisper",
+            "mlx-audio",
+            "openai-compatible",
+            "unknown-provider",
+        ):
+            endpoint = self._make_endpoint(
+                "http://127.0.0.1:2022/v1", provider_type
+            )
+            with patch(
+                "voice_mode.providers.STT_BASE_URLS",
+                ["http://127.0.0.1:2022/v1"],
+            ), patch(
+                "voice_mode.providers.STT_MODELS", ["positional-model"]
+            ), patch("voice_mode.providers.STT_MODEL", "global-default"):
+                assert (
+                    _select_stt_model_for_endpoint(endpoint, "caller-model")
+                    == "caller-model"
+                ), f"caller-passed should win for provider_type={provider_type}"
+
+    def test_positional_stt_models_used_when_caller_passed_is_none(self):
+        """Branch 3: when caller-passed is None and the endpoint URL is in
+        STT_BASE_URLS at index N, return STT_MODELS[N] if non-empty."""
+        urls = [
+            "http://127.0.0.1:8890/v1",
+            "http://127.0.0.1:2022/v1",
+            "https://api.openai.com/v1",
+        ]
+        models = [
+            "mlx-community/whisper-large-v3-turbo",
+            "custom-cpp-model",
+            "whisper-1",
+        ]
+        with patch("voice_mode.providers.STT_BASE_URLS", urls), patch(
+            "voice_mode.providers.STT_MODELS", models
+        ), patch("voice_mode.providers.STT_MODEL", "global-default"):
+            mlx = self._make_endpoint(urls[0], "mlx-audio")
+            cpp = self._make_endpoint(urls[1], "whisper")
+            assert (
+                _select_stt_model_for_endpoint(mlx)
+                == "mlx-community/whisper-large-v3-turbo"
+            )
+            assert _select_stt_model_for_endpoint(cpp) == "custom-cpp-model"
+
+    def test_global_stt_model_fallback_when_no_positional(self):
+        """Branch 4: fallback to global STT_MODEL when caller-passed is None
+        and no positional STT_MODELS entry applies (URL not in STT_BASE_URLS,
+        index out of range, or positional entry empty)."""
+        with patch(
+            "voice_mode.providers.STT_BASE_URLS",
+            ["http://127.0.0.1:2022/v1"],
+        ), patch("voice_mode.providers.STT_MODELS", []), patch(
+            "voice_mode.providers.STT_MODEL", "global-default"
+        ):
+            # URL not in STT_BASE_URLS
+            unknown = self._make_endpoint(
+                "http://10.0.0.5:9999/v1", "unknown-provider"
+            )
+            assert _select_stt_model_for_endpoint(unknown) == "global-default"
+            # URL in STT_BASE_URLS but STT_MODELS empty (idx out of range)
+            cpp = self._make_endpoint("http://127.0.0.1:2022/v1", "whisper")
+            assert _select_stt_model_for_endpoint(cpp) == "global-default"
+
+        # Positional entry exists but is empty -> falls back to global
+        with patch(
+            "voice_mode.providers.STT_BASE_URLS",
+            ["http://127.0.0.1:2022/v1"],
+        ), patch("voice_mode.providers.STT_MODELS", [""]), patch(
+            "voice_mode.providers.STT_MODEL", "global-default"
+        ):
+            cpp = self._make_endpoint("http://127.0.0.1:2022/v1", "whisper")
+            assert _select_stt_model_for_endpoint(cpp) == "global-default"

--- a/tests/test_stt_config.py
+++ b/tests/test_stt_config.py
@@ -1,0 +1,81 @@
+"""Tests for STT_MODEL / STT_MODELS config and reload_configuration() round-trip.
+
+Covers VM-1100 acceptance criteria:
+  - `from voice_mode.config import STT_MODEL, STT_MODELS` succeeds.
+  - reload_configuration() picks up changes to VOICEMODE_STT_MODEL /
+    VOICEMODE_STT_MODELS without a process restart.
+"""
+
+import os
+
+import pytest
+
+
+def test_import_stt_model_and_stt_models():
+    """Smoke test: STT_MODEL and STT_MODELS are importable from voice_mode.config."""
+    from voice_mode.config import STT_MODEL, STT_MODELS
+
+    assert isinstance(STT_MODEL, str)
+    assert isinstance(STT_MODELS, list)
+
+
+@pytest.fixture
+def isolated_reload(monkeypatch):
+    """Yield a reload_configuration callable that does not read voicemode.env files.
+
+    The real reload_configuration() calls load_voicemode_env() which reads
+    ~/.voicemode/voicemode.env. We patch that to a no-op so tests only see
+    values set in os.environ.
+    """
+    import voice_mode.config as cfg
+
+    monkeypatch.setattr(cfg, "load_voicemode_env", lambda: None)
+    monkeypatch.delenv("VOICEMODE_STT_MODEL", raising=False)
+    monkeypatch.delenv("VOICEMODE_STT_MODELS", raising=False)
+    yield cfg
+
+
+def test_reload_picks_up_stt_model_change(isolated_reload, monkeypatch):
+    """Mutating VOICEMODE_STT_MODEL and calling reload_configuration() updates STT_MODEL."""
+    cfg = isolated_reload
+
+    monkeypatch.setenv("VOICEMODE_STT_MODEL", "mlx-community/whisper-large-v3-turbo")
+    cfg.reload_configuration()
+    assert cfg.STT_MODEL == "mlx-community/whisper-large-v3-turbo"
+
+    monkeypatch.setenv("VOICEMODE_STT_MODEL", "whisper-1")
+    cfg.reload_configuration()
+    assert cfg.STT_MODEL == "whisper-1"
+
+
+def test_reload_picks_up_stt_models_comma_list(isolated_reload, monkeypatch):
+    """VOICEMODE_STT_MODELS as comma-separated list is parsed on reload."""
+    cfg = isolated_reload
+
+    monkeypatch.setenv(
+        "VOICEMODE_STT_MODELS",
+        "mlx-community/whisper-large-v3-turbo,custom-cpp-model,whisper-1",
+    )
+    cfg.reload_configuration()
+    assert cfg.STT_MODELS == [
+        "mlx-community/whisper-large-v3-turbo",
+        "custom-cpp-model",
+        "whisper-1",
+    ]
+
+    # Whitespace around entries is stripped, empty entries dropped (parse_comma_list).
+    monkeypatch.setenv("VOICEMODE_STT_MODELS", " a , b ,, c ")
+    cfg.reload_configuration()
+    assert cfg.STT_MODELS == ["a", "b", "c"]
+
+
+def test_defaults_when_env_unset(isolated_reload):
+    """With VOICEMODE_STT_MODEL[S] absent, defaults are 'whisper-1' and []."""
+    cfg = isolated_reload
+
+    assert "VOICEMODE_STT_MODEL" not in os.environ
+    assert "VOICEMODE_STT_MODELS" not in os.environ
+
+    cfg.reload_configuration()
+    assert cfg.STT_MODEL == "whisper-1"
+    assert cfg.STT_MODELS == []

--- a/tests/test_stt_failover_wire_model.py
+++ b/tests/test_stt_failover_wire_model.py
@@ -1,0 +1,86 @@
+"""Tests for the wire-level model kwarg in simple_stt_failover().
+
+Covers VM-1100 acceptance criterion: the `model` field of the outbound
+client.audio.transcriptions.create(...) request must be the per-endpoint
+resolved model, not a hardcoded literal.
+
+  - mlx-audio endpoint (8890) -> global VOICEMODE_STT_MODEL
+  - OpenAI endpoint -> always 'whisper-1' (provider_type override)
+  - whisper.cpp endpoint (2022) -> global STT_MODEL (passed but ignored
+    by whisper.cpp at the wire; the value must still appear in kwargs)
+"""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from voice_mode.simple_failover import simple_stt_failover
+
+
+def _make_audio_file():
+    """Return a MagicMock standing in for an open audio file."""
+    return MagicMock()
+
+
+async def _capture_kwargs_for_url(base_url: str, stt_model: str, stt_models=None):
+    """Run simple_stt_failover with a single STT endpoint and capture the
+    kwargs passed to client.audio.transcriptions.create."""
+    if stt_models is None:
+        stt_models = []
+
+    captured = {}
+
+    async def fake_create(**kwargs):
+        captured.update(kwargs)
+        return "ok"
+
+    with patch(
+        "voice_mode.simple_failover.STT_BASE_URLS", [base_url]
+    ), patch(
+        "voice_mode.providers.STT_BASE_URLS", [base_url]
+    ), patch(
+        "voice_mode.providers.STT_MODEL", stt_model
+    ), patch(
+        "voice_mode.providers.STT_MODELS", stt_models
+    ), patch(
+        "voice_mode.simple_failover.AsyncOpenAI"
+    ) as MockClient:
+        mock_client = MockClient.return_value
+        mock_client.audio.transcriptions.create = AsyncMock(side_effect=fake_create)
+        await simple_stt_failover(_make_audio_file())
+
+    return captured
+
+
+class TestSttFailoverWireModel:
+    """Verify the resolved model lands in transcription_kwargs at the wire."""
+
+    @pytest.mark.asyncio
+    async def test_mlx_audio_endpoint_uses_global_stt_model(self):
+        """An mlx-audio endpoint with VOICEMODE_STT_MODEL set should send
+        that model in the outbound request body."""
+        kwargs = await _capture_kwargs_for_url(
+            base_url="http://127.0.0.1:8890/v1",
+            stt_model="mlx-community/whisper-large-v3-turbo",
+        )
+        assert kwargs["model"] == "mlx-community/whisper-large-v3-turbo"
+
+    @pytest.mark.asyncio
+    async def test_openai_endpoint_overrides_to_whisper_1(self):
+        """An OpenAI endpoint always sends model='whisper-1', regardless of
+        what VOICEMODE_STT_MODEL is configured to."""
+        kwargs = await _capture_kwargs_for_url(
+            base_url="https://api.openai.com/v1",
+            stt_model="mlx-community/whisper-large-v3-turbo",
+        )
+        assert kwargs["model"] == "whisper-1"
+
+    @pytest.mark.asyncio
+    async def test_whisper_cpp_endpoint_passes_configured_stt_model(self):
+        """whisper.cpp ignores the model field at the wire, but the resolved
+        global STT_MODEL must still be present in transcription_kwargs."""
+        kwargs = await _capture_kwargs_for_url(
+            base_url="http://127.0.0.1:2022/v1",
+            stt_model="custom-cpp-model",
+        )
+        assert kwargs["model"] == "custom-cpp-model"

--- a/voice_mode/config.py
+++ b/voice_mode/config.py
@@ -547,6 +547,8 @@ TTS_BASE_URLS = parse_comma_list("VOICEMODE_TTS_BASE_URLS", "http://127.0.0.1:88
 STT_BASE_URLS = parse_comma_list("VOICEMODE_STT_BASE_URLS", "http://127.0.0.1:2022/v1,https://api.openai.com/v1")
 TTS_VOICES = parse_comma_list("VOICEMODE_VOICES", "af_sky,alloy")
 TTS_MODELS = parse_comma_list("VOICEMODE_TTS_MODELS", "tts-1,tts-1-hd,gpt-4o-mini-tts")
+STT_MODEL = os.getenv("VOICEMODE_STT_MODEL", "whisper-1")
+STT_MODELS = parse_comma_list("VOICEMODE_STT_MODELS", "")
 
 # STT prompt for vocabulary biasing (helps with specialized terminology)
 # See: https://platform.openai.com/docs/guides/speech-to-text#prompting

--- a/voice_mode/config.py
+++ b/voice_mode/config.py
@@ -601,12 +601,14 @@ def reload_configuration():
     load_voicemode_env()
     
     # Update global configuration variables
-    global TTS_VOICES, TTS_MODELS, TTS_BASE_URLS, STT_BASE_URLS
+    global TTS_VOICES, TTS_MODELS, TTS_BASE_URLS, STT_BASE_URLS, STT_MODEL, STT_MODELS
     TTS_BASE_URLS = parse_comma_list("VOICEMODE_TTS_BASE_URLS", "http://127.0.0.1:8880/v1,https://api.openai.com/v1")
     STT_BASE_URLS = parse_comma_list("VOICEMODE_STT_BASE_URLS", "http://127.0.0.1:2022/v1,https://api.openai.com/v1")
     TTS_VOICES = parse_comma_list("VOICEMODE_VOICES", "af_sky,alloy")
     TTS_MODELS = parse_comma_list("VOICEMODE_TTS_MODELS", "tts-1,tts-1-hd,gpt-4o-mini-tts")
-    
+    STT_MODEL = os.getenv("VOICEMODE_STT_MODEL", "whisper-1")
+    STT_MODELS = parse_comma_list("VOICEMODE_STT_MODELS", "")
+
     logger.info("Configuration reloaded successfully")
 
 # Legacy variables have been removed - use the new list-based configuration:

--- a/voice_mode/providers.py
+++ b/voice_mode/providers.py
@@ -9,7 +9,7 @@ import logging
 from typing import Dict, Optional, List, Any, Tuple
 from openai import AsyncOpenAI
 
-from .config import TTS_VOICES, TTS_MODELS, TTS_BASE_URLS, OPENAI_API_KEY, get_voice_preferences
+from .config import TTS_VOICES, TTS_MODELS, TTS_BASE_URLS, STT_BASE_URLS, STT_MODEL, STT_MODELS, OPENAI_API_KEY, get_voice_preferences
 from .provider_discovery import provider_registry, EndpointInfo, is_local_provider
 
 logger = logging.getLogger("voicemode")
@@ -235,18 +235,45 @@ def _select_model_for_endpoint(endpoint_info: EndpointInfo, requested_model: Opt
     # If specific model requested and supported, use it
     if requested_model and requested_model in endpoint_info.models:
         return requested_model
-    
+
     # Try to find a preferred model
     for model in TTS_MODELS:
         if model in endpoint_info.models:
             return model
-    
+
     # Otherwise use first available model
     if endpoint_info.models:
         return endpoint_info.models[0]
-    
+
     # Fallback
     return "tts-1"
+
+
+def _select_stt_model_for_endpoint(endpoint_info: EndpointInfo, requested_model: Optional[str] = None) -> str:
+    """Select the STT model name to send to an endpoint.
+
+    Resolution order:
+      1. provider_type == "openai" -> always "whisper-1" (OpenAI's only STT model id)
+      2. caller-passed requested_model wins
+      3. positional STT_MODELS entry matching this endpoint's index in STT_BASE_URLS
+      4. global STT_MODEL fallback
+
+    Note: the OpenAI override keys off endpoint_info.provider_type. If an
+    OpenAI-compatible endpoint ever sets provider_type="openai" this branch
+    would be too broad -- revisit when VM-1106-style provider detection lands.
+    """
+    if endpoint_info.provider_type == "openai":
+        return "whisper-1"
+
+    if requested_model is not None:
+        return requested_model
+
+    if endpoint_info.base_url in STT_BASE_URLS:
+        idx = STT_BASE_URLS.index(endpoint_info.base_url)
+        if idx < len(STT_MODELS) and STT_MODELS[idx]:
+            return STT_MODELS[idx]
+
+    return STT_MODEL
 
 
 # Compatibility functions for existing code

--- a/voice_mode/providers.py
+++ b/voice_mode/providers.py
@@ -183,7 +183,7 @@ async def get_stt_client(
         if not endpoint_info:
             raise ValueError(f"Requested base URL {base_url} is not configured")
 
-        selected_model = model or "whisper-1"  # Default STT model
+        selected_model = _select_stt_model_for_endpoint(endpoint_info, model)
 
         # Disable retries for local endpoints - they either work or don't
         max_retries = 0 if is_local_provider(base_url) else 2
@@ -201,7 +201,7 @@ async def get_stt_client(
         raise ValueError("No STT endpoints available")
 
     endpoint_info = endpoints[0]
-    selected_model = model or "whisper-1"
+    selected_model = _select_stt_model_for_endpoint(endpoint_info, model)
     
     api_key = OPENAI_API_KEY if endpoint_info.provider_type == "openai" else (OPENAI_API_KEY or "dummy-key-for-local")
     # Disable retries for local endpoints - they either work or don't

--- a/voice_mode/simple_failover.py
+++ b/voice_mode/simple_failover.py
@@ -12,7 +12,8 @@ from .openai_error_parser import OpenAIErrorParser
 from .provider_discovery import is_local_provider
 
 from .config import TTS_BASE_URLS, STT_BASE_URLS, OPENAI_API_KEY, STT_PROMPT, WHISPER_LANGUAGE
-from .provider_discovery import detect_provider_type
+from .provider_discovery import detect_provider_type, EndpointInfo
+from .providers import _select_stt_model_for_endpoint
 
 logger = logging.getLogger("voicemode")
 
@@ -157,7 +158,7 @@ async def simple_tts_failover(
 
 async def simple_stt_failover(
     audio_file,
-    model: str = "whisper-1",
+    model: Optional[str] = None,
     **kwargs
 ) -> Optional[Dict[str, Any]]:
     """
@@ -224,11 +225,21 @@ async def simple_stt_failover(
                 max_retries=max_retries
             )
 
+            # Resolve the per-endpoint STT model: OpenAI override -> caller-passed
+            # -> positional STT_MODELS -> global STT_MODEL.
+            endpoint_info = EndpointInfo(
+                base_url=base_url,
+                models=[],
+                voices=[],
+                provider_type=provider_type,
+            )
+            resolved_model = _select_stt_model_for_endpoint(endpoint_info, model)
+
             # Try STT with this endpoint - track timing
             request_start = time.perf_counter()
             # Build transcription kwargs with optional prompt for vocabulary biasing
             transcription_kwargs = {
-                "model": model,
+                "model": resolved_model,
                 "file": audio_file,
                 "response_format": "text"
             }

--- a/voice_mode/tools/converse.py
+++ b/voice_mode/tools/converse.py
@@ -692,7 +692,6 @@ async def speech_to_text(
             with open(tmp_path, 'rb') as audio_file:
                 result = await simple_stt_failover(
                     audio_file=audio_file,
-                    model="whisper-1"
                 )
         finally:
             # Clean up temp file (we keep the WAV)
@@ -713,7 +712,6 @@ async def speech_to_text(
             with open(tmp_path, 'rb') as audio_file:
                 result = await simple_stt_failover(
                     audio_file=audio_file,
-                    model="whisper-1"
                 )
         finally:
             # Clean up temp file


### PR DESCRIPTION
## Summary

Makes `VOICEMODE_STT_MODEL` actually work. Until this lands, the env var sits in `voicemode.env` doing nothing — STT model is hardcoded to `whisper-1` in 10 places, which breaks mlx-audio (it tries to download `whisper-1` from HuggingFace and 401s).

Provider-aware resolver — for OpenAI endpoints we keep forcing `whisper-1` (back-compat); for everything else we use `VOICEMODE_STT_MODEL` (default `"whisper-1"`) or per-endpoint `VOICEMODE_STT_MODELS` (mirroring the TTS pattern).

- `voice_mode/config.py`: add `STT_MODEL`, `STT_MODELS` env vars and register both in `reload_configuration()`
- `voice_mode/providers.py`: new `_select_stt_model_for_endpoint()` resolver (provider-aware: OpenAI → `whisper-1`, otherwise per-endpoint or global default)
- `voice_mode/simple_failover.py`: drop hardcoded `whisper-1` default; resolve model per-endpoint at the wire chokepoint before `client.audio.transcriptions.create`
- `voice_mode/tools/converse.py`: drop hardcoded `model="whisper-1"` at the two STT call sites (lines 695, 716)
- 3 new test files + extension to `tests/test_provider_selection.py`

Spawned from research task VM-1098. Sibling tasks VM-1102 (transcription module + CLI), VM-1104 (docs), VM-1106 (mlx-audio detection — already in PR #362).

## Test plan
- [x] `uv run pytest tests/test_provider_selection.py tests/test_stt_config.py tests/test_stt_failover_wire_model.py` — 24/25 pass (1 pre-existing OpenAI API key env issue, also fails on master)
- [x] `make test` regression — 8 failures, all verified pre-existing by reverting VM-1100 changes and re-running. No new regressions introduced by this PR.
- [x] `grep whisper-1 voice_mode/simple_failover.py` — zero matches
- [x] `grep 'model="whisper-1"' voice_mode/tools/converse.py` — zero matches
- [ ] Manual: with `VOICEMODE_STT_MODEL=mlx-community/whisper-large-v3-turbo` and STT base URL set to mlx-audio (8890), `voicemode converse` succeeds via mlx-audio (no whisper.cpp fallback needed)
- [ ] Manual: stop mlx-audio, confirm fallback to whisper.cpp still works
- [ ] Manual: with all local services stopped, confirm OpenAI fallback works using `whisper-1`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>