### PR TITLE
fix(VM-1128): restore mlx-audio STT response_format patch (over-removed in VM-1126)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -119,6 +119,7 @@ include = [
   "voice_mode/data/**/*.ffmeta",
   "voice_mode/data/**/*.sha256",
   "voice_mode/data/**/*.bash",
+  "voice_mode/data/**/*.patch",
 ]
 # artifacts overrides .gitignore for VCS-ignored files that should be packaged
 artifacts = [

--- a/tests/test_mlx_audio_install.py
+++ b/tests/test_mlx_audio_install.py
@@ -295,24 +295,54 @@ class TestMlxAudioConfigEnvVars:
 
 
 # ============================================================================
-# Bundled patch resource (removed VM-1126)
+# Bundled patch resource (restored VM-1128)
 # ============================================================================
-# voice_mode/data/patches/mlx_audio_server.patch was deleted because both
-# fixes it carried (MLX Metal serialisation lock + OpenAI-style STT
-# response_format) were upstreamed in mlx-audio 0.4.3. The patch file no
-# longer exists, so there is nothing to assert about it here.
+# voice_mode/data/patches/mlx_audio_server.patch ships the OpenAI-style STT
+# response_format handling that mlx-audio 0.4.3 still does NOT provide.
+# (VM-1126 incorrectly removed it on the assumption that all fixes were
+# upstreamed; only the inference lock was. VM-1128 restores the
+# response_format half against the 0.4.3 endpoint shape.)
 
 
-class TestNoBundledPatchShips:
-    """Belt-and-braces: the patches directory must NOT come back."""
+class TestBundledPatchShips:
+    """The patch file and its sentinel must exist and be wired through."""
 
-    def test_patches_dir_absent(self):
-        patches_dir = (
-            Path(__file__).parent.parent / "voice_mode" / "data" / "patches"
+    def test_patch_file_exists(self):
+        from voice_mode.tools.mlx_audio.install import _PATCH_RESOURCE
+        assert _PATCH_RESOURCE.exists(), (
+            f"Bundled patch missing at {_PATCH_RESOURCE}. "
+            "Wheel/sdist will ship without STT response_format support."
         )
-        assert not patches_dir.exists(), (
-            f"voice_mode/data/patches/ has come back at {patches_dir}. "
-            "Bundling another mlx-audio patch invites the same staleness "
-            "that broke installs against mlx-audio 0.4.3 -- prefer pinning "
-            "a fixed upstream version instead. See VM-1126."
+
+    def test_patch_sentinel_present_in_patch(self):
+        """The sentinel must literally appear in the patch -- otherwise
+        applying the patch can never satisfy the post-patch sanity check."""
+        from voice_mode.tools.mlx_audio.install import (
+            _PATCH_RESOURCE,
+            PATCH_SENTINEL,
+        )
+        text = _PATCH_RESOURCE.read_text(encoding="utf-8")
+        assert PATCH_SENTINEL in text, (
+            f"Sentinel {PATCH_SENTINEL!r} not found in patch content. "
+            "Either the sentinel constant or the patch comment has drifted."
+        )
+
+    def test_patch_targets_response_format(self):
+        """Smoke test: patch should add response_format form param and the
+        text/json/verbose_json branching block."""
+        from voice_mode.tools.mlx_audio.install import _PATCH_RESOURCE
+        text = _PATCH_RESOURCE.read_text(encoding="utf-8")
+        assert "response_format: str = Form" in text
+        assert "PlainTextResponse" in text
+        assert "JSONResponse" in text
+
+    def test_pyproject_includes_patches_glob(self):
+        """The wheel target must include *.patch under data/ or the patch
+        file silently won't ship to PyPI."""
+        pyproject = (
+            Path(__file__).parent.parent / "pyproject.toml"
+        ).read_text(encoding="utf-8")
+        assert "voice_mode/data/**/*.patch" in pyproject, (
+            "pyproject.toml [tool.hatch.build.targets.wheel].include is "
+            "missing the *.patch glob -- the bundled patch will not ship."
         )

--- a/voice_mode/data/patches/mlx_audio_server.patch
+++ b/voice_mode/data/patches/mlx_audio_server.patch
@@ -1,0 +1,82 @@
+--- a/server.py
++++ b/server.py
+@@ -38,7 +38,7 @@
+     WebSocketDisconnect,
+ )
+ from fastapi.middleware.cors import CORSMiddleware
+-from fastapi.responses import StreamingResponse
++from fastapi.responses import JSONResponse, PlainTextResponse, StreamingResponse
+ from pydantic import BaseModel
+ 
+ from mlx_audio.audio_io import read as audio_read
+@@ -928,6 +928,7 @@
+     context: Optional[str] = Form(None),
+     prefill_step_size: int = Form(2048),
+     text: Optional[str] = Form(None),
++    response_format: str = Form("json"),
+ ):
+     """Transcribe audio using an STT model in OpenAI format."""
+     payload = TranscriptionRequest(
+@@ -959,7 +960,62 @@
+         normalized_kwargs=payload.model_dump(exclude={"model"}, exclude_none=True),
+         stream=payload.stream,
+     )
++
++    # voicemode-patch: honor OpenAI-style response_format. mlx-audio's native
++    # transport is application/x-ndjson with whisper's full segment/timing
++    # payload (incl. trailing silence-hallucination segments). For
++    # text/json/verbose_json we collect, parse, drop the silence segments,
++    # and return the OpenAI Audio API shape. Default ("ndjson") preserves
++    # the legacy behaviour for any client relying on it.
++    if response_format in ("text", "json", "verbose_json"):
++        full = None
++        accumulated = ""
++        try:
++            while True:
++                chunk = await _next_inference_chunk(handle)
++                if chunk.kind == "done":
++                    break
++                if chunk.kind == "error":
++                    raise chunk.error
++                line = chunk.payload
++                if isinstance(line, bytes):
++                    line = line.decode("utf-8", errors="replace")
++                for raw in str(line).splitlines():
++                    raw = raw.strip()
++                    if not raw:
++                        continue
++                    try:
++                        obj = json.loads(raw)
++                    except Exception:
++                        continue
++                    if isinstance(obj, dict) and ("segments" in obj or "language" in obj):
++                        full = obj
++                    elif isinstance(obj, dict) and "text" in obj:
++                        accumulated += obj.get("text") or ""
++        finally:
++            handle.cancel()
++
++        if full is None:
++            full = {"text": accumulated}
++
++        # Whisper hallucinates empty / "." / "..." segments on trailing
++        # silence. Strip them so callers don't drown in noise.
++        segs = full.get("segments") or []
++        filtered = [
++            s for s in segs
++            if (s.get("text") or "").strip() not in ("", ".", "...")
++        ]
++        if filtered:
++            full = {**full, "segments": filtered}
++            full["text"] = "".join(s.get("text", "") for s in filtered)
+ 
++        if response_format == "text":
++            return PlainTextResponse((full.get("text") or "").strip())
++        if response_format == "json":
++            return JSONResponse({"text": (full.get("text") or "").strip()})
++        # verbose_json: full payload with segments + language, silence-cleaned
++        return JSONResponse(full)
++
+     return StreamingResponse(
+         _stream_inference_results(handle, request),
+         media_type="application/x-ndjson",

--- a/voice_mode/tools/mlx_audio/install.py
+++ b/voice_mode/tools/mlx_audio/install.py
@@ -16,11 +16,17 @@ The install pipeline is:
    is hardcoded in :data:`MLX_AUDIO_EXTRAS` and is the minimum surface
    needed to make the upstream server.py serve Kokoro TTS, Qwen3-TTS
    clone-voice, and Whisper STT under the OpenAI-compatible API. The
-   ``>=0.4.3`` floor exists because earlier releases of mlx-audio needed
-   a bundled patch for MLX Metal thread-safety + OpenAI-style STT
-   ``response_format``; both fixes are upstream from 0.4.3 on, and
-   voicemode no longer ships a patch.
-3. Render the launchd plist calling ``~/.local/bin/mlx_audio.server``
+   ``>=0.4.3`` floor exists because that's the first release that absorbed
+   the MLX Metal thread-safety serialisation lock. (See VM-1108.)
+3. Apply the bundled ``mlx_audio_server.patch`` to add OpenAI-style STT
+   ``response_format`` (``text`` / ``json`` / ``verbose_json``) handling.
+   Upstream mlx-audio 0.4.3 returns whisper's full ndjson stream regardless
+   of what the client requests; the patch reshapes ``text`` / ``json`` /
+   ``verbose_json`` into the OpenAI Audio API shape and strips whisper's
+   trailing silence-hallucination segments. (See VM-1128 -- this fix used
+   to be intertwined with the inference-lock patch and was incorrectly
+   removed alongside it in VM-1126.)
+4. Render the launchd plist calling ``~/.local/bin/mlx_audio.server``
    directly. (Apple-Silicon-only -- no systemd unit ships.)
 """
 
@@ -42,10 +48,28 @@ logger = logging.getLogger("voicemode")
 
 MLX_AUDIO_DEFAULT_PORT = 8890
 # Pinned ``>=0.4.3`` because that's the first upstream release that absorbed
-# the MLX Metal serialisation lock + OpenAI-compatible STT ``response_format``
-# fixes voicemode previously shipped as a bundled patch. See VM-1126.
+# the MLX Metal serialisation lock fix voicemode previously shipped as part
+# of a bundled patch. See VM-1126. The OpenAI-style STT ``response_format``
+# half of the original patch was NOT upstreamed -- voicemode still bundles
+# a minimal patch to add it. See VM-1128.
 MLX_AUDIO_PIP_PACKAGE = "mlx-audio>=0.4.3"
 MLX_AUDIO_ENTRY_POINT = "mlx_audio.server"
+
+# Sentinel string that proves the bundled patch has already been applied
+# to the installed server.py. Picked because the comment line is unique to
+# the patch and unlikely to appear in any unpatched mlx-audio release.
+PATCH_SENTINEL = "voicemode-patch: honor OpenAI-style response_format"
+
+# Path of the bundled patch relative to the installed package root.
+_PATCH_RESOURCE = (
+    Path(__file__).resolve().parent.parent.parent
+    / "data"
+    / "patches"
+    / "mlx_audio_server.patch"
+)
+
+# Backup filename written next to the patched server.py.
+_BACKUP_NAME = "server.py.pre-voicemode.bak"
 
 # Extras the bundled server.py + voicemode client need at runtime. These were
 # captured from Mike's working install on 2026-04-27. Order matters only for
@@ -143,6 +167,160 @@ def _build_install_cmd(force_reinstall: bool) -> List[str]:
     if force_reinstall:
         cmd.append("--reinstall")
     return cmd
+
+
+def _find_installed_server_py() -> Optional[Path]:
+    """Locate the ``server.py`` shipped by the just-installed mlx-audio.
+
+    ``uv tool install mlx-audio`` puts the package under
+    ``~/.local/share/uv/tools/mlx-audio/lib/python<X.Y>/site-packages/mlx_audio/``.
+    The Python version isn't pinned by us (uv picks one), so we glob for it.
+    Returns ``None`` if no candidate exists.
+    """
+    base = Path.home() / ".local" / "share" / "uv" / "tools" / "mlx-audio" / "lib"
+    if not base.exists():
+        return None
+    candidates = sorted(base.glob("python*/site-packages/mlx_audio/server.py"))
+    return candidates[0] if candidates else None
+
+
+def _query_installed_version() -> Optional[str]:
+    """Best-effort: read mlx-audio's installed version from inside its venv.
+
+    Uses ``importlib.metadata`` via ``uv tool run`` rather than parsing
+    ``uv tool list`` stdout (which is fragile across uv releases). Returns
+    ``None`` on any failure -- callers should treat it as "unknown version"
+    rather than aborting the install/patch flow.
+    """
+    try:
+        completed = subprocess.run(
+            [
+                "uv",
+                "tool",
+                "run",
+                "--from",
+                MLX_AUDIO_PIP_PACKAGE,
+                "python",
+                "-c",
+                "import importlib.metadata as m; "
+                f"print(m.version('{MLX_AUDIO_PIP_PACKAGE}'))",
+            ],
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+    except (FileNotFoundError, OSError, subprocess.TimeoutExpired):
+        return None
+    if completed.returncode != 0:
+        return None
+    version = (
+        completed.stdout.strip().splitlines()[-1] if completed.stdout.strip() else ""
+    )
+    if not version or not version[0].isdigit():
+        return None
+    return version
+
+
+def _apply_server_patch(server_py: Path) -> Dict[str, Any]:
+    """Apply the bundled patch to ``server.py``, idempotently.
+
+    1. If ``server.py`` already contains :data:`PATCH_SENTINEL`, treat it as
+       already-patched and return success without touching anything.
+    2. Else, save a one-shot backup as ``server.py.pre-voicemode.bak`` (only
+       if no backup exists yet) and run ``patch -p1`` from the package root.
+    3. On failure, surface a clear error pointing at both the bundled patch
+       and the installed mlx-audio version (best-effort) so the operator can
+       refresh the patch against upstream.
+    """
+    result: Dict[str, Any] = {
+        "patch_path": str(_PATCH_RESOURCE),
+        "server_py": str(server_py),
+    }
+
+    if not _PATCH_RESOURCE.exists():
+        result["success"] = False
+        result["error"] = (
+            f"Bundled patch is missing at {_PATCH_RESOURCE}. "
+            "This is a packaging bug -- reinstall voicemode."
+        )
+        return result
+
+    try:
+        current = server_py.read_text(encoding="utf-8", errors="replace")
+    except OSError as exc:
+        result["success"] = False
+        result["error"] = f"Could not read {server_py}: {exc}"
+        return result
+
+    if PATCH_SENTINEL in current:
+        result["success"] = True
+        result["already_patched"] = True
+        result["message"] = "mlx-audio server.py already patched (sentinel present)"
+        logger.info(result["message"])
+        return result
+
+    package_root = server_py.parent  # .../site-packages/mlx_audio/
+    backup_path = package_root / _BACKUP_NAME
+
+    if not backup_path.exists():
+        try:
+            shutil.copy2(server_py, backup_path)
+            logger.info("Saved backup: %s", backup_path)
+        except OSError as exc:
+            result["success"] = False
+            result["error"] = f"Could not write backup {backup_path}: {exc}"
+            return result
+    result["backup_path"] = str(backup_path)
+
+    # Apply with ``patch -p1`` from the package root. ``-p1`` strips the
+    # leading "a/" / "b/" path prefix from the diff so it matches the
+    # installed file regardless of its absolute location.
+    try:
+        completed = subprocess.run(
+            ["patch", "-p1", "--forward", "-i", str(_PATCH_RESOURCE)],
+            cwd=str(package_root),
+            capture_output=True,
+            text=True,
+        )
+    except FileNotFoundError as exc:
+        result["success"] = False
+        result["error"] = (
+            f"`patch` binary not found ({exc}). On macOS install Xcode "
+            "command-line tools: xcode-select --install"
+        )
+        return result
+
+    if completed.returncode != 0:
+        version = _query_installed_version()
+        result["success"] = False
+        result["error"] = (
+            f"Failed to apply {_PATCH_RESOURCE} to {server_py} "
+            f"(mlx-audio version: {version or 'unknown'}). "
+            "The upstream server.py may have drifted. Refresh the patch "
+            "against the installed file and retry. "
+            f"patch stdout: {completed.stdout.strip()!r} "
+            f"patch stderr: {completed.stderr.strip()!r}"
+        )
+        return result
+
+    # Sanity check: the sentinel should now be present.
+    try:
+        post = server_py.read_text(encoding="utf-8", errors="replace")
+    except OSError:
+        post = ""
+    if PATCH_SENTINEL not in post:
+        result["success"] = False
+        result["error"] = (
+            f"`patch` reported success but {PATCH_SENTINEL!r} is not in "
+            f"{server_py}. Refusing to silently ship a half-applied patch."
+        )
+        return result
+
+    result["success"] = True
+    result["already_patched"] = False
+    result["message"] = "mlx-audio server.py patched successfully"
+    logger.info(result["message"])
+    return result
 
 
 async def _update_mlx_audio_service_files(
@@ -275,12 +453,33 @@ async def mlx_audio_install(
             ),
         }
 
+    server_py = _find_installed_server_py()
+    if server_py is None:
+        return {
+            "success": False,
+            "error": (
+                "Could not locate installed mlx_audio/server.py under "
+                "~/.local/share/uv/tools/mlx-audio/. uv tool layout may have "
+                "changed -- inspect `uv tool list` and refresh the locator."
+            ),
+        }
+
+    patch_result = _apply_server_patch(server_py)
+    if not patch_result.get("success"):
+        return {
+            "success": False,
+            "error": f"Patch step failed: {patch_result.get('error')}",
+            "install_path": str(install_path),
+            "patch": patch_result,
+        }
+
     service_result = await _update_mlx_audio_service_files(auto_enable_bool)
     if not service_result.get("success"):
         return {
             "success": False,
             "error": f"service file update failed: {service_result.get('error')}",
             "install_path": str(install_path),
+            "patch": patch_result,
         }
 
     bind_host = "0.0.0.0" if bind_lan_bool else "127.0.0.1"
@@ -293,6 +492,7 @@ async def mlx_audio_install(
         "host": bind_host,
         "port": port_int,
         "auto_enabled": service_result.get("enabled", False),
+        "patch": patch_result,
         "extras": list(MLX_AUDIO_EXTRAS),
         "message": (
             f"mlx-audio installed via uv tool install. "


### PR DESCRIPTION
## Summary

VM-1126 (PR #366) deleted `voice_mode/data/patches/mlx_audio_server.patch` on the assumption mlx-audio 0.4.3 had upstreamed both fixes it carried. The MLX Metal serialisation lock was indeed upstreamed, but the **OpenAI-style STT `response_format` handling was not.** Upstream 0.4.3's `/v1/audio/transcriptions` endpoint:

- has **no** `response_format` form parameter
- unconditionally returns `application/x-ndjson` with whisper's full segment payload, including trailing silence-hallucination segments

Clients sending `response_format=text` (e.g. voicemode's `simple_failover.py`) get the verbose stream regardless. The voice-loop STT path then surfaces hundreds of empty segments instead of the transcribed text.

This PR restores the response_format half of the patch, rewritten against 0.4.3's refactored endpoint (`inference_broker` / `_stream_inference_results` / `_next_inference_chunk`). The `_inference_lock` half is **not** restored -- that's still legitimately upstream.

## What's in the new patch

- Adds `response_format: str = Form(\"json\")` form parameter.
- For `text` / `json` / `verbose_json`: drain chunks via `_next_inference_chunk`, parse the ndjson lines, drop whisper's empty / \".\" / \"...\" silence segments, return `PlainTextResponse` or `JSONResponse` in the OpenAI Audio API shape.
- Default (`ndjson`) preserves legacy streaming behaviour for any client still relying on it.

## Install machinery

Restored in `voice_mode/tools/mlx_audio/install.py`:

- `_find_installed_server_py()`, `_query_installed_version()`, `_apply_server_patch()` with sentinel-based idempotency.
- New `PATCH_SENTINEL = \"voicemode-patch: honor OpenAI-style response_format\"` -- can't collide with the old VM-1108 sentinel (`asyncio.Lock()`, which is now legitimately in upstream 0.4.3).

## Packaging

- `pyproject.toml` `[tool.hatch.build.targets.wheel].include` now lists `voice_mode/data/**/*.patch` so the patch ships in the wheel.
- sdist already captures `/voice_mode` wholesale.

## Tests

- Removed `TestNoBundledPatchShips` (the VM-1126 guard).
- Added `TestBundledPatchShips`: file exists, sentinel literally appears in the patch (otherwise post-apply sanity check is unsatisfiable), patch targets response_format, pyproject ships `*.patch`.
- All 32 `tests/test_mlx_audio_install.py` tests pass.

## Test plan

- [x] `patch -p1 --forward` applies cleanly against installed server.py
- [x] `_apply_server_patch` idempotent (sentinel detection on second run)
- [x] Restart mlx-audio → `response_format=text` returns plain text body (\"Coming Master!\")
- [x] `response_format=json` returns `{\"text\": \"...\"}`
- [x] `response_format=verbose_json` returns full payload with silence segments stripped
- [x] All `tests/test_mlx_audio_install.py` pass (32 / 32)
- [ ] Reviewer: confirm no client elsewhere expects raw ndjson by default

## Follow-up

- Submit upstream PR to mlx-audio for proper OpenAI `response_format` support so we can eventually drop this patch (separate task).

Refs VM-1126.