### PR TITLE
chore: gitignore /voices convenience symlink

### DIFF
--- a/.claude/skills/voicemode/SKILL.md
+++ b/.claude/skills/voicemode/SKILL.md
@@ -23,13 +23,13 @@ Natural voice conversations with Claude Code using speech-to-text (STT) and text
 
 ## When to Use MCP vs CLI
 
-| Task | Use | Why |
-|------|-----|-----|
+| Task                | Use                      | Why                             |
+| ------------------- | ------------------------ | ------------------------------- |
 | Voice conversations | MCP `voicemode:converse` | Faster - server already running |
-| Service start/stop | MCP `voicemode:service` | Works within Claude Code |
-| Installation | CLI `voice-mode-install` | One-time setup |
-| Configuration | CLI `voicemode config` | Edit settings directly |
-| Diagnostics | CLI `voicemode diag` | Administrative tasks |
+| Service start/stop  | MCP `voicemode:service`  | Works within Claude Code        |
+| Installation        | CLI `voice-mode-install` | One-time setup                  |
+| Configuration       | CLI `voicemode config`   | Edit settings directly          |
+| Diagnostics         | CLI `voicemode diag`     | Administrative tasks            |
 
 ## Usage
 
@@ -46,11 +46,20 @@ voicemode:converse("Searching the codebase now...", wait_for_response=False)
 For most conversations, just pass your message - defaults handle everything else.
 Use default converse tool parameters unless there's a good reason not to. Timing parameters (`listen_duration_max`, `listen_duration_min`) use smart defaults with silence detection - don't override unless the user requests it or you see a clear need. Defaults are configurable by the user via `~/.voicemode/voicemode.env`.
 
-| Parameter | Default | Description |
-|-----------|---------|-------------|
-| `message` | required | Text to speak |
-| `wait_for_response` | true | Listen after speaking |
-| `voice` | auto | TTS voice |
+| Parameter           | Default  | Description                                                          |
+| ------------------- | -------- | -------------------------------------------------------------------- |
+| `message`           | required | Text to speak                                                        |
+| `wait_for_response` | true     | Listen after speaking                                                |
+| `voice`             | auto     | TTS voice -- **must be lowercase** (e.g. `af_river`, not `AF_River`) |
+
+**Voice name rule:** If you specify a `voice`, it MUST be lowercase with
+underscores. Kokoro rejects capitalized names like `AF_River` with a 400
+error. Valid examples: `af_river`, `af_sky`, `bm_daniel`, `bf_emma`.
+The prefix encodes language+gender: `af_` = American female, `am_` =
+American male, `bf_` = British female, `bm_` = British male.
+
+When in doubt, omit `voice` entirely -- auto-select picks a working
+default.
 
 For all parameters, see [Converse Parameters](../../docs/reference/converse-parameters.md).
 
@@ -91,12 +100,12 @@ voicemode:converse("Here's what I found: ...", wait_for_response=True)
 
 ### When to Use Parallel vs Sequential
 
-| Scenario | Approach | Why |
-|----------|----------|-----|
-| Announce + do work | **Parallel** | No dependency between speech and action |
-| Announce + spawn agent | **Parallel** | Agent runs in background anyway |
-| Check result then report | **Sequential** | Need result before speaking |
-| Listen for response | **Sequential** | `wait_for_response=True` blocks until user finishes |
+| Scenario                 | Approach       | Why                                                 |
+| ------------------------ | -------------- | --------------------------------------------------- |
+| Announce + do work       | **Parallel**   | No dependency between speech and action             |
+| Announce + spawn agent   | **Parallel**   | Agent runs in background anyway                     |
+| Check result then report | **Sequential** | Need result before speaking                         |
+| Listen for response      | **Sequential** | `wait_for_response=True` blocks until user finishes |
 
 ### Key Rules
 
@@ -112,10 +121,13 @@ When the user asks you to wait or give them time:
 **Short pauses (up to 60 seconds):** If the user says something ending with "wait" (e.g., "hang on", "give me a sec", "wait"), VoiceMode automatically pauses for 60 seconds then resumes listening. This is built-in.
 
 **Longer pauses (2+ minutes):** Use `bash sleep N` where N is seconds. For example, if the user says "give me 5 minutes":
+
 ```bash
 sleep 300  # Wait 5 minutes
 ```
+
 Then call converse again when the wait is over:
+
 ```python
 voicemode:converse("Five minutes is up. Ready when you are.")
 ```
@@ -137,18 +149,21 @@ fi
 ```
 
 **Requirements:**
+
 - Audio saving must be enabled via one of:
   - `VOICEMODE_SAVE_AUDIO=true` in `~/.voicemode/voicemode.env`
   - `VOICEMODE_SAVE_ALL=true` (saves all audio and transcriptions)
   - `VOICEMODE_DEBUG=true` (enables debug mode with audio saving)
 
 **How it works:**
+
 - VoiceMode saves all STT recordings to `~/.voicemode/audio/` with timestamps
 - The `latest-STT.wav` symlink always points to the most recent recording
 - If the STT API fails, the recording is still saved for manual recovery
 - This lets you recover the user's speech without asking them to repeat
 
 **When to use:**
+
 - STT service timeout or connection failure
 - Transcription returned empty but user definitely spoke
 - Need to verify what was actually said vs. what was transcribed
@@ -188,10 +203,10 @@ voicemode:service("kokoro", "start")
 voicemode:service("whisper", "logs", lines=50)
 ```
 
-| Service | Port | Purpose |
-|---------|------|---------|
-| whisper | 2022 | Speech-to-text |
-| kokoro | 8880 | Text-to-speech |
+| Service   | Port | Purpose         |
+| --------- | ---- | --------------- |
+| whisper   | 2022 | Speech-to-text  |
+| kokoro    | 8880 | Text-to-speech  |
 | voicemode | 8765 | HTTP/SSE server |
 
 **Actions:** status, start, stop, restart, logs, enable, disable
@@ -268,6 +283,7 @@ voicemode dj mfp play 49            # Music For Programming
 Transfer voice conversations between Claude Code agents for multi-agent workflows.
 
 **Use cases:**
+
 - Personal assistant routing to project-specific foremen
 - Foremen delegating to workers for focused tasks
 - Returning control when work is complete
@@ -285,6 +301,7 @@ spawn_agent(path="/path", prompt="Load voicemode skill, use converse to greet us
 ```
 
 **Hand-back:**
+
 ```python
 voicemode:converse("Transferring you back to the assistant.", wait_for_response=False)
 # Stop conversing, exit or go idle
@@ -316,6 +333,7 @@ Off by default. Silent no-op outside tmux.
 ### Detailed Documentation
 
 See [Call Routing](../../../docs/guides/agents/call-routing/) for comprehensive guides:
+
 - [Handoff Pattern](../../../docs/guides/agents/call-routing/handoff.md) - Complete hand-off and hand-back process
 - [Voice Proxy](../../../docs/guides/agents/call-routing/proxy.md) - Relay pattern for agents without voice
 - [Call Routing Overview](../../../docs/guides/agents/call-routing/README.md) - All routing patterns
@@ -349,6 +367,7 @@ tailscale serve reset
 ### Endpoints
 
 After setup, endpoints are available at:
+
 - **TTS:** `https://<hostname>.<tailnet>.ts.net/v1/audio/speech`
 - **STT:** `https://<hostname>.<tailnet>.ts.net/v1/audio/transcriptions`
 
@@ -362,6 +381,7 @@ After setup, endpoints are available at:
 ### Use with VoiceMode Connect
 
 In the VoiceMode Connect web app settings (app.voicemode.dev/settings), set:
+
 - **TTS Endpoint**: `https://<hostname>.<tailnet>.ts.net`
 - **STT Endpoint**: `https://<hostname>.<tailnet>.ts.net`
 
@@ -371,19 +391,19 @@ Audio feedback tones that play during Claude Code tool use. Toggle with `voicemo
 
 ## Documentation Index
 
-| Topic | Link |
-|-------|------|
+| Topic               | Link                                                          |
+| ------------------- | ------------------------------------------------------------- |
 | Converse Parameters | [All Parameters](../../docs/reference/converse-parameters.md) |
-| Installation | [Getting Started](../../docs/tutorials/getting-started.md) |
-| Configuration | [Configuration Guide](../../docs/guides/configuration.md) |
-| Claude Code Plugin | [Plugin Guide](../../docs/guides/claude-code-plugin.md) |
-| Whisper STT | [Whisper Setup](../../docs/guides/whisper-setup.md) |
-| Kokoro TTS | [Kokoro Setup](../../docs/guides/kokoro-setup.md) |
-| Pronunciation | [Pronunciation Guide](../../docs/guides/pronunciation.md) |
-| Troubleshooting | [Troubleshooting](../../docs/troubleshooting/index.md) |
-| Soundfonts | [Soundfonts Guide](../../docs/guides/soundfonts.md) |
-| CLI Reference | [CLI Docs](../../docs/reference/cli.md) |
-| DJ Mode | [Background Music](docs/dj-mode/README.md) |
+| Installation        | [Getting Started](../../docs/tutorials/getting-started.md)    |
+| Configuration       | [Configuration Guide](../../docs/guides/configuration.md)     |
+| Claude Code Plugin  | [Plugin Guide](../../docs/guides/claude-code-plugin.md)       |
+| Whisper STT         | [Whisper Setup](../../docs/guides/whisper-setup.md)           |
+| Kokoro TTS          | [Kokoro Setup](../../docs/guides/kokoro-setup.md)             |
+| Pronunciation       | [Pronunciation Guide](../../docs/guides/pronunciation.md)     |
+| Troubleshooting     | [Troubleshooting](../../docs/troubleshooting/index.md)        |
+| Soundfonts          | [Soundfonts Guide](../../docs/guides/soundfonts.md)           |
+| CLI Reference       | [CLI Docs](../../docs/reference/cli.md)                       |
+| DJ Mode             | [Background Music](docs/dj-mode/README.md)                    |
 
 ## Related Skills
 

--- a/.claude/skills/voicemode/SKILL.md
+++ b/.claude/skills/voicemode/SKILL.md
@@ -64,46 +64,33 @@ For all parameters, see [Converse Parameters](../../docs/reference/converse-para
 
 ## Parallel Tool Calls (Zero Dead Air)
 
-When performing actions during a voice conversation, use parallel tool calls to eliminate dead air. Send the voice message and the action in the **same turn** so they execute concurrently.
+Eliminate dead air by sending voice and action calls in the **same response**:
 
-### Pattern: Speak + Act in Parallel
-
-```python
-# FAST: One turn — voice and action fire simultaneously
-# Turn 1: speak (fire-and-forget) + do the work (all parallel)
+```
+# FAST: speak + act in parallel (all fire concurrently)
 voicemode:converse("Checking that now.", wait_for_response=False)
-bash("git status")
+Bash("git status")
 Agent(prompt="Research X", run_in_background=True)
 
-# Turn 2: speak the results (with listening)
-voicemode:converse("Here's what I found: ...", wait_for_response=True)
-```
-
-```python
-# SLOW: Two turns — unnecessary sequential delay
-# Turn 1: speak
+# SLOW: sequential — unnecessary delay between speech and action
 voicemode:converse("Checking that now.", wait_for_response=False)
-# Turn 2: do the work
-bash("git status")
-# Turn 3: speak results
-voicemode:converse("Here's what I found: ...", wait_for_response=True)
+# ... waits for TTS to finish ...
+Bash("git status")
 ```
 
-### When to Use Parallel vs Sequential
+Then report results in the next response:
+```
+voicemode:converse("Here's what I found: ...", wait_for_response=True)
+```
 
 | Scenario | Approach | Why |
 |----------|----------|-----|
 | Announce + do work | **Parallel** | No dependency between speech and action |
 | Announce + spawn agent | **Parallel** | Agent runs in background anyway |
 | Check result then report | **Sequential** | Need result before speaking |
-| Listen for response | **Sequential** | `wait_for_response=True` blocks until user finishes |
+| Listen for response | **Sequential** | `wait_for_response=True` blocks until user speaks |
 
-### Key Rules
-
-- **All tool types can be parallel**: MCP, Bash, Agent, Read — mix freely in one turn
-- **Wall-clock time = longest call**, not the sum of all calls
-- **Use `wait_for_response=False`** for the speak call when combining with other tools
-- **Great for demos**: Audience hears continuous speech with no awkward silences
+**Key insight:** Wall-clock time = longest call, not the sum. All tool types (MCP, Bash, Agent, Read) can be mixed in one response.
 
 ## Handling Pauses and Wait Requests
 

--- a/.claude/skills/voicemode/SKILL.md
+++ b/.claude/skills/voicemode/SKILL.md
@@ -353,6 +353,20 @@ In the VoiceMode Connect web app settings (app.voicemode.dev/settings), set:
 
 Audio feedback tones that play during Claude Code tool use. Toggle with `voicemode soundfonts on/off`. See [Soundfonts Guide](../../docs/guides/soundfonts.md).
 
+## Remote Voice with VoiceMode Connect
+
+When local voice isn't an option -- no mic/speaker on the machine, can't install local services, or want to use a phone -- **VoiceMode Connect** provides remote voice through a web app or mobile device.
+
+**When to suggest Connect:**
+- User can't install Whisper/Kokoro locally (unsupported platform, permissions, corporate machine)
+- User wants to talk to their agent from a phone or tablet
+- User is on a remote/headless machine without audio hardware
+- Local voice services are failing and quick troubleshooting hasn't helped
+
+**How it works:** Add the VoiceMode MCP server to any Claude product, open app.voicemode.dev on a phone or browser, and talk. No local TTS/STT installation needed -- the client device handles audio.
+
+**Setup:** See the [VoiceMode Connect skill](../voicemode-connect/SKILL.md) for MCP configuration and getting started.
+
 ## Documentation Index
 
 | Topic | Link |

--- a/.gitignore
+++ b/.gitignore
@@ -124,3 +124,6 @@ models/
 # Coverage reports (duplicates removed - already in Python section)
 coverage.xml
 voicemode-install-feedback.md
+
+# Local convenience symlink to voice-lab voices dir (per-developer, not shipped)
+/voices


### PR DESCRIPTION
## Summary

Mike keeps a local `voices` symlink at the repo root pointing at `voice-lab/voices` for quick browsing during voicemode development. It's not part of the shipped repo (voice profiles live in voice-lab and are read at runtime from `~/.voicemode/voices/`), but it kept showing up as untracked in `git status`.

This adds `/voices` to `.gitignore` so the symlink stays invisible to git.

## Test plan

- [x] `git check-ignore -v voices` confirms `.gitignore:129:/voices` matches
- [x] `git status` no longer shows `?? voices`