### PR TITLE
fix(VM-1138): isolate provider tests from user voicemode.env

### DIFF
--- a/tests/test_provider_resilience.py
+++ b/tests/test_provider_resilience.py
@@ -5,7 +5,38 @@ import asyncio
 from unittest.mock import patch
 
 from voice_mode import config
+from voice_mode import provider_discovery
 from voice_mode.provider_discovery import ProviderRegistry, is_local_provider, detect_provider_type
+
+
+# Documented defaults — tests assert against these literal URLs / providers, so
+# pin them here regardless of what the developer has in ~/.voicemode/voicemode.env.
+# See VM-1138.
+DEFAULT_TTS_BASE_URLS = [
+    "http://127.0.0.1:8880/v1",      # Kokoro (local TTS)
+    "https://api.openai.com/v1",     # OpenAI (remote)
+]
+DEFAULT_STT_BASE_URLS = [
+    "http://127.0.0.1:2022/v1",      # Whisper (local STT)
+    "https://api.openai.com/v1",     # OpenAI (remote)
+]
+
+
+@pytest.fixture(autouse=True)
+def pin_provider_urls(monkeypatch):
+    """Pin TTS/STT base URLs to documented defaults so tests are isolated from
+    the user's ~/.voicemode/voicemode.env. Without this, tests asserting on
+    'http://127.0.0.1:8880/v1' or provider 'whisper' fail when the user has
+    overridden the URL list (e.g. mlx-audio at 8890 first).
+
+    Both `config` and `provider_discovery` carry their own bound names because
+    `provider_discovery` does `from .config import TTS_BASE_URLS, STT_BASE_URLS`
+    at module load — patch both.
+    """
+    monkeypatch.setattr(config, "TTS_BASE_URLS", list(DEFAULT_TTS_BASE_URLS))
+    monkeypatch.setattr(config, "STT_BASE_URLS", list(DEFAULT_STT_BASE_URLS))
+    monkeypatch.setattr(provider_discovery, "TTS_BASE_URLS", list(DEFAULT_TTS_BASE_URLS))
+    monkeypatch.setattr(provider_discovery, "STT_BASE_URLS", list(DEFAULT_STT_BASE_URLS))
 
 
 class TestProviderResilience:

--- a/tests/test_provider_resilience_simple.py
+++ b/tests/test_provider_resilience_simple.py
@@ -12,7 +12,29 @@ sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 # Ensure ALWAYS_TRY_LOCAL is enabled for the test
 os.environ['VOICEMODE_ALWAYS_TRY_LOCAL'] = 'true'
 
+from voice_mode import config
+from voice_mode import provider_discovery
 from voice_mode.provider_discovery import ProviderRegistry, is_local_provider, detect_provider_type
+
+
+# Documented defaults — pin so tests are isolated from user voicemode.env. See VM-1138.
+DEFAULT_TTS_BASE_URLS = [
+    "http://127.0.0.1:8880/v1",
+    "https://api.openai.com/v1",
+]
+DEFAULT_STT_BASE_URLS = [
+    "http://127.0.0.1:2022/v1",
+    "https://api.openai.com/v1",
+]
+
+
+@pytest.fixture(autouse=True)
+def pin_provider_urls(monkeypatch):
+    """Isolate from user ~/.voicemode/voicemode.env. See VM-1138."""
+    monkeypatch.setattr(config, "TTS_BASE_URLS", list(DEFAULT_TTS_BASE_URLS))
+    monkeypatch.setattr(config, "STT_BASE_URLS", list(DEFAULT_STT_BASE_URLS))
+    monkeypatch.setattr(provider_discovery, "TTS_BASE_URLS", list(DEFAULT_TTS_BASE_URLS))
+    monkeypatch.setattr(provider_discovery, "STT_BASE_URLS", list(DEFAULT_STT_BASE_URLS))
 
 
 @pytest.mark.asyncio

--- a/tests/test_stt_error_handling.py
+++ b/tests/test_stt_error_handling.py
@@ -12,6 +12,18 @@ from voice_mode.simple_failover import simple_stt_failover
 TEST_STT_BASE_URLS = ["http://127.0.0.1:2022/v1", "https://api.openai.com/v1"]
 
 
+@pytest.fixture(autouse=True)
+def pin_stt_base_urls(monkeypatch):
+    """Pin simple_failover.STT_BASE_URLS to TEST_STT_BASE_URLS so tests are
+    isolated from the user's ~/.voicemode/voicemode.env (which may put
+    mlx-audio first or omit OpenAI entirely). See VM-1138.
+
+    `simple_failover` does `from .config import STT_BASE_URLS` at module load,
+    so it carries its own bound name — patch the failover module, not config.
+    """
+    monkeypatch.setattr("voice_mode.simple_failover.STT_BASE_URLS", list(TEST_STT_BASE_URLS))
+
+
 class TestSTTErrorHandling:
     """Test STT error handling and structured response generation"""
 


### PR DESCRIPTION
## Summary

7 provider/STT tests fail when a developer's `~/.voicemode/voicemode.env` overrides the default `VOICEMODE_TTS_BASE_URLS` / `VOICEMODE_STT_BASE_URLS` (which is increasingly common as VoiceMode moves to mlx-audio on port 8890 as the recommended local backend).

`config.py` reads these env vars **at import time** into module-level lists, so the user's config leaks into the test process before any fixture can clean it up. CI passes only because GitHub runners have no `voicemode.env`.

This PR adds autouse pytest fixtures to the 3 affected test files that pin the URL lists to the documented defaults, regardless of user config.

## Failing tests fixed

```
tests/test_provider_resilience.py::TestProviderResilience::test_mark_failed_records_error
tests/test_provider_resilience.py::TestProviderResilience::test_error_tracking_for_all_providers
tests/test_provider_resilience.py::TestProviderResilience::test_get_endpoints_returns_all
tests/test_provider_resilience_simple.py::test_provider_resilience
tests/test_stt_error_handling.py::TestSTTErrorHandling::test_whisper_error_as_json_text
tests/test_stt_error_handling.py::TestSTTErrorHandling::test_successful_transcription
tests/test_stt_error_handling.py::TestSTTErrorHandling::test_mixed_results_prefer_successful
```

## Approach

- `test_provider_resilience.py` and `test_provider_resilience_simple.py`: monkeypatch both `config.{TTS,STT}_BASE_URLS` and `provider_discovery.{TTS,STT}_BASE_URLS`. The latter does `from .config import TTS_BASE_URLS, STT_BASE_URLS` at module load, so it carries its own bound name and patching `config` alone isn't enough.
- `test_stt_error_handling.py`: monkeypatch `simple_failover.STT_BASE_URLS`. Matches the `with patch('voice_mode.simple_failover.STT_BASE_URLS', TEST_STT_BASE_URLS):` pattern that other tests in the file already use; the failing tests just didn't apply it.

No product code changes. The bug is in the tests, not the runtime.

## Test plan

- [x] All 7 previously-failing tests pass with `~/.voicemode/voicemode.env` putting mlx-audio (port 8890) first
- [x] All 17 tests in the 3 affected files pass with clean env (CI parity)
- [x] Full test suite green: `931 passed, 58 skipped` (was `924 passed, 7 failed, 58 skipped`)
- [x] No product code changes outside `tests/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)