### PR TITLE
VM-1166: echo user/assistant messages around converse to keep voice transcript visible

### DIFF
--- a/.claude/skills/voicemode/SKILL.md
+++ b/.claude/skills/voicemode/SKILL.md
@@ -71,6 +71,58 @@ For all parameters, see [Converse Parameters](../../docs/reference/converse-para
 4. **Let VoiceMode auto-select** - Don't hardcode providers unless user has preference
 5. **First run is slow** - Model downloads happen on first start (2-5 min), then instant
 
+## Transcript visibility
+
+Newer Claude Code releases collapse MCP tool calls in the visible transcript, so the spoken side of a `voicemode:converse` exchange disappears from the conversation record. To keep voice turns readable, echo the spoken content as visible Markdown on **both** sides of the call:
+
+- **Before** every `voicemode:converse` call where `wait_for_response=true`, write the assistant message you are about to speak as a blockquote in the same response that issues the tool call.
+- **After** the call returns with a captured user message, write that user message as a blockquote in your next response.
+
+Use this format:
+
+```
+> **voicemode (assistant):** <message arg passed to converse>
+[voicemode:converse tool call]
+> **voicemode (user):** <captured user message>
+```
+
+The bold `voicemode` label and the `(assistant)` / `(user)` qualifier keep voice turns unambiguous in a transcript that mixes typed and spoken conversation.
+
+### When to echo
+
+- **Echo only when `wait_for_response=true`** *and* the tool response contains a user message.
+- **Do not echo when `wait_for_response=false`** — speak-only narration calls have no user message to surface, so they produce no echo (in either direction).
+- **Do not echo on empty or failed transcription** — if the tool returns no user utterance (timeout, transcription failure, empty result), skip the echo line and proceed.
+
+### Worked example
+
+In the response that issues the converse call, the assistant echo precedes the tool use:
+
+```
+> **voicemode (assistant):** What would you like to work on next?
+[voicemode:converse("What would you like to work on next?") tool call]
+```
+
+In the next assistant response, after receiving the tool result, the user echo comes first:
+
+```
+> **voicemode (user):** Let's pick up the auth refactor where we left off.
+
+Sure — pulling up that branch now.
+```
+
+A future reader can reconstruct the full voice exchange from the visible blockquotes alone, without expanding any collapsed tool calls.
+
+### No double-echo
+
+If the assistant message you pass to `converse` is identical to a sentence already written as visible prose in the same response, don't also produce a separate `> **voicemode (assistant):**` line — the prose already serves the same purpose. The common case is that the visible reasoning text and the spoken `message` argument differ, and in that case both should appear.
+
+The same rule applies to the user side: if you naturally quote the user's words back in your reasoning ("You said 'X', so..."), don't also add a separate `> **voicemode (user):**` line for the same content. One visible record of each utterance is enough.
+
+### Opt-out
+
+This is a default, not a hard rule. If the user asks you to stop echoing voice turns ("stop echoing", "drop the voicemode lines", "you don't need to repeat me"), honour that for the rest of the session and resume only if they ask.
+
 ## Parallel Tool Calls (Zero Dead Air)
 
 Eliminate dead air by sending voice and action calls in the **same response**:

--- a/.claude/skills/voicemode/SKILL.md
+++ b/.claude/skills/voicemode/SKILL.md
@@ -73,12 +73,7 @@ For all parameters, see [Converse Parameters](../../docs/reference/converse-para
 
 ## Transcript visibility
 
-Newer Claude Code releases collapse MCP tool calls in the visible transcript, so the spoken side of a `voicemode:converse` exchange disappears from the conversation record. To keep voice turns readable, echo the spoken content as visible Markdown on **both** sides of the call:
-
-- **Before** every `voicemode:converse` call where `wait_for_response=true`, write the assistant message you are about to speak as a blockquote in the same response that issues the tool call.
-- **After** the call returns with a captured user message, write that user message as a blockquote in your next response.
-
-Use this format:
+Newer Claude Code collapses MCP tool calls — voice turns vanish from the visible transcript. Echo them as Markdown blockquotes on both sides of every `voicemode:converse` call where `wait_for_response=true`:
 
 ```
 > **ASSISTANT (voicemode):** <message arg passed to converse>
@@ -86,84 +81,14 @@ Use this format:
 > **USER (voicemode):** <captured user message>
 ```
 
-The capitalised speaker label (`ASSISTANT` / `USER`) is the visual anchor — your eye reads *who* first. The lowercase `(voicemode)` qualifier is metadata: it marks the turn as a voice turn, distinguishing it from typed conversation in the same transcript.
+- Speaker first in caps; `(voicemode)` is the channel tag.
+- Skip the echo when `wait_for_response=false` or transcription is empty.
+- **Assistant echo defaults to companion** — Markdown-formatted (lists, code, etc) of the *same content* you spoke.
+- **User echo defaults to verbatim** — exact words, no reformatting (rewriting risks distorting intent).
+- Don't double-echo: if a sentence already appears as visible prose in the same response, don't also blockquote it.
+- Opt-out if asked ("stop echoing", "drop the voicemode lines").
 
-### When to echo
-
-- **Echo only when `wait_for_response=true`** *and* the tool response contains a user message.
-- **Do not echo when `wait_for_response=false`** — speak-only narration calls have no user message to surface, so they produce no echo (in either direction).
-- **Do not echo on empty or failed transcription** — if the tool returns no user utterance (timeout, transcription failure, empty result), skip the echo line and proceed.
-
-### Worked example
-
-In the response that issues the converse call, the assistant echo precedes the tool use:
-
-```
-> **ASSISTANT (voicemode):** What would you like to work on next?
-[voicemode:converse("What would you like to work on next?") tool call]
-```
-
-In the next assistant response, after receiving the tool result, the user echo comes first:
-
-```
-> **USER (voicemode):** Let's pick up the auth refactor where we left off.
-
-Sure — pulling up that branch now.
-```
-
-A future reader can reconstruct the full voice exchange from the visible blockquotes alone, without expanding any collapsed tool calls.
-
-### No double-echo
-
-If the assistant message you pass to `converse` is identical to a sentence already written as visible prose in the same response, don't also produce a separate `> **ASSISTANT (voicemode):**` line — the prose already serves the same purpose. The common case is that the visible reasoning text and the spoken `message` argument differ, and in that case both should appear.
-
-The same rule applies to the user side: if you naturally quote the user's words back in your reasoning ("You said 'X', so..."), don't also add a separate `> **USER (voicemode):**` line for the same content. One visible record of each utterance is enough.
-
-### Verbatim vs companion formatting
-
-Spoken content is prose by necessity — TTS doesn't read bullet points or headings. But the visible echo is rendered Markdown, so a long spoken sentence often reads much better in the transcript as a list. Two echo modes are supported:
-
-- **Verbatim** — print the exact words spoken or heard, no reformatting. Faithful to the audio.
-- **Companion** — print a Markdown-formatted version of the same content: lists become bullets, multi-step reasoning becomes numbered steps, code references become inline code or fenced blocks, file paths get backticks, etc. Same semantic content, optimized for reading.
-
-**Defaults:**
-
-- **User echo defaults to verbatim.** Rewriting the user's words risks distorting their intent — they said what they said.
-- **Assistant echo defaults to companion.** You authored the prose, so you can faithfully render your own intent in better Markdown.
-
-**Companion mode is constrained.** Same content, better formatting — that's it. Companion must NOT:
-
-- Paraphrase or summarise to the point that meaning shifts
-- Add information that wasn't in the spoken content
-- Drop substantive content to make the echo "tidier"
-- Change the tone (e.g. casual → formal)
-
-If in doubt, fall back to verbatim. The constraint exists because companion mode is a presentation layer, not a chance to "improve" the conversation.
-
-**Worked example.** A spoken assistant message like:
-
-> "Three options for you. One, triage TM-698 children — flip the nine inbox tasks to todo. Two, flesh out TM-720 — design the rename properly: scope, order, what breaks. Three, switch tracks to CC-164 — the settle skill still needs triage."
-
-…in companion mode echoes as:
-
-```
-> **ASSISTANT (voicemode):**
-> - **(1) Triage TM-698 children** — flip the nine inbox tasks to todo
-> - **(2) Flesh out TM-720** — design the rename properly: scope, order, what breaks
-> - **(3) Switch tracks to CC-164** — the settle skill still needs triage
-```
-
-Same content, same options, same emphasis — just a list instead of run-on prose.
-
-**Per-turn / per-session overrides.** Either side can be flipped:
-
-- "Echo my last reply verbatim" → just that user echo flips, others stay default.
-- "Verbatim only from now on" → both sides flip to verbatim for the rest of the session.
-- "Skip the assistant companion" → assistant echo flips to verbatim for the session.
-
-### Opt-out
-
-This is a default, not a hard rule. If the user asks you to stop echoing voice turns ("stop echoing", "drop the voicemode lines", "you don't need to repeat me"), honour that for the rest of the session and resume only if they ask.
+Deep dive (overrides, edge cases, worked examples, companion-mode constraints): [docs/transcript-visibility.md](docs/transcript-visibility.md).
 
 ## Parallel Tool Calls (Zero Dead Air)
 

--- a/.claude/skills/voicemode/SKILL.md
+++ b/.claude/skills/voicemode/SKILL.md
@@ -81,12 +81,12 @@ Newer Claude Code releases collapse MCP tool calls in the visible transcript, so
 Use this format:
 
 ```
-> **voicemode (assistant):** <message arg passed to converse>
+> **ASSISTANT (voicemode):** <message arg passed to converse>
 [voicemode:converse tool call]
-> **voicemode (user):** <captured user message>
+> **USER (voicemode):** <captured user message>
 ```
 
-The bold `voicemode` label and the `(assistant)` / `(user)` qualifier keep voice turns unambiguous in a transcript that mixes typed and spoken conversation.
+The capitalised speaker label (`ASSISTANT` / `USER`) is the visual anchor — your eye reads *who* first. The lowercase `(voicemode)` qualifier is metadata: it marks the turn as a voice turn, distinguishing it from typed conversation in the same transcript.
 
 ### When to echo
 
@@ -99,14 +99,14 @@ The bold `voicemode` label and the `(assistant)` / `(user)` qualifier keep voice
 In the response that issues the converse call, the assistant echo precedes the tool use:
 
 ```
-> **voicemode (assistant):** What would you like to work on next?
+> **ASSISTANT (voicemode):** What would you like to work on next?
 [voicemode:converse("What would you like to work on next?") tool call]
 ```
 
 In the next assistant response, after receiving the tool result, the user echo comes first:
 
 ```
-> **voicemode (user):** Let's pick up the auth refactor where we left off.
+> **USER (voicemode):** Let's pick up the auth refactor where we left off.
 
 Sure — pulling up that branch now.
 ```
@@ -115,9 +115,9 @@ A future reader can reconstruct the full voice exchange from the visible blockqu
 
 ### No double-echo
 
-If the assistant message you pass to `converse` is identical to a sentence already written as visible prose in the same response, don't also produce a separate `> **voicemode (assistant):**` line — the prose already serves the same purpose. The common case is that the visible reasoning text and the spoken `message` argument differ, and in that case both should appear.
+If the assistant message you pass to `converse` is identical to a sentence already written as visible prose in the same response, don't also produce a separate `> **ASSISTANT (voicemode):**` line — the prose already serves the same purpose. The common case is that the visible reasoning text and the spoken `message` argument differ, and in that case both should appear.
 
-The same rule applies to the user side: if you naturally quote the user's words back in your reasoning ("You said 'X', so..."), don't also add a separate `> **voicemode (user):**` line for the same content. One visible record of each utterance is enough.
+The same rule applies to the user side: if you naturally quote the user's words back in your reasoning ("You said 'X', so..."), don't also add a separate `> **USER (voicemode):**` line for the same content. One visible record of each utterance is enough.
 
 ### Verbatim vs companion formatting
 
@@ -147,7 +147,7 @@ If in doubt, fall back to verbatim. The constraint exists because companion mode
 …in companion mode echoes as:
 
 ```
-> **voicemode (assistant):**
+> **ASSISTANT (voicemode):**
 > - **(1) Triage TM-698 children** — flip the nine inbox tasks to todo
 > - **(2) Flesh out TM-720** — design the rename properly: scope, order, what breaks
 > - **(3) Switch tracks to CC-164** — the settle skill still needs triage

--- a/.claude/skills/voicemode/SKILL.md
+++ b/.claude/skills/voicemode/SKILL.md
@@ -119,6 +119,48 @@ If the assistant message you pass to `converse` is identical to a sentence alrea
 
 The same rule applies to the user side: if you naturally quote the user's words back in your reasoning ("You said 'X', so..."), don't also add a separate `> **voicemode (user):**` line for the same content. One visible record of each utterance is enough.
 
+### Verbatim vs companion formatting
+
+Spoken content is prose by necessity — TTS doesn't read bullet points or headings. But the visible echo is rendered Markdown, so a long spoken sentence often reads much better in the transcript as a list. Two echo modes are supported:
+
+- **Verbatim** — print the exact words spoken or heard, no reformatting. Faithful to the audio.
+- **Companion** — print a Markdown-formatted version of the same content: lists become bullets, multi-step reasoning becomes numbered steps, code references become inline code or fenced blocks, file paths get backticks, etc. Same semantic content, optimized for reading.
+
+**Defaults:**
+
+- **User echo defaults to verbatim.** Rewriting the user's words risks distorting their intent — they said what they said.
+- **Assistant echo defaults to companion.** You authored the prose, so you can faithfully render your own intent in better Markdown.
+
+**Companion mode is constrained.** Same content, better formatting — that's it. Companion must NOT:
+
+- Paraphrase or summarise to the point that meaning shifts
+- Add information that wasn't in the spoken content
+- Drop substantive content to make the echo "tidier"
+- Change the tone (e.g. casual → formal)
+
+If in doubt, fall back to verbatim. The constraint exists because companion mode is a presentation layer, not a chance to "improve" the conversation.
+
+**Worked example.** A spoken assistant message like:
+
+> "Three options for you. One, triage TM-698 children — flip the nine inbox tasks to todo. Two, flesh out TM-720 — design the rename properly: scope, order, what breaks. Three, switch tracks to CC-164 — the settle skill still needs triage."
+
+…in companion mode echoes as:
+
+```
+> **voicemode (assistant):**
+> - **(1) Triage TM-698 children** — flip the nine inbox tasks to todo
+> - **(2) Flesh out TM-720** — design the rename properly: scope, order, what breaks
+> - **(3) Switch tracks to CC-164** — the settle skill still needs triage
+```
+
+Same content, same options, same emphasis — just a list instead of run-on prose.
+
+**Per-turn / per-session overrides.** Either side can be flipped:
+
+- "Echo my last reply verbatim" → just that user echo flips, others stay default.
+- "Verbatim only from now on" → both sides flip to verbatim for the rest of the session.
+- "Skip the assistant companion" → assistant echo flips to verbatim for the session.
+
 ### Opt-out
 
 This is a default, not a hard rule. If the user asks you to stop echoing voice turns ("stop echoing", "drop the voicemode lines", "you don't need to repeat me"), honour that for the rest of the session and resume only if they ask.

--- a/.claude/skills/voicemode/SKILL.md
+++ b/.claude/skills/voicemode/SKILL.md
@@ -82,9 +82,10 @@ Newer Claude Code collapses MCP tool calls — voice turns vanish from the visib
 ```
 
 - Speaker first in caps; `(voicemode)` is the channel tag.
-- Skip the echo when `wait_for_response=false` or transcription is empty.
+- **ASSISTANT echo: always**, including `wait_for_response=false` (speak-only narration still produces visible content that would otherwise vanish).
+- **USER echo: only when a user message was captured** (skip on `wait_for_response=false`, empty result, or transcription failure — there is nothing to echo).
 - **Assistant echo defaults to companion** — Markdown-formatted (lists, code, etc) of the *same content* you spoke.
-- **User echo defaults to verbatim** — exact words, no reformatting (rewriting risks distorting intent).
+- **User echo defaults to verbatim and full** — exact words, no truncation; rewriting or shortening risks distorting intent.
 - Don't double-echo: if a sentence already appears as visible prose in the same response, don't also blockquote it.
 - Opt-out if asked ("stop echoing", "drop the voicemode lines").
 

--- a/.claude/skills/voicemode/docs/transcript-visibility.md
+++ b/.claude/skills/voicemode/docs/transcript-visibility.md
@@ -10,13 +10,25 @@ The fix is a soft instruction (this skill), not a hook or output style. Hooks ca
 
 ## When to echo
 
-| Tool call shape | User message in result | Echo? |
-|---|---|---|
-| `wait_for_response=true` | yes | echo BOTH sides |
-| `wait_for_response=true` | empty / transcription failure / timeout | NO echo (don't fabricate) |
-| `wait_for_response=false` | (n/a — no listen window) | NO echo (no user message to surface) |
+The two echoes are **asymmetric** — assistant echo and user echo follow different rules:
+
+| Tool call shape | User message in result | ASSISTANT echo | USER echo |
+|---|---|---|---|
+| `wait_for_response=true` | captured | yes | yes |
+| `wait_for_response=true` | empty / transcription failure / timeout | yes | **no** (nothing to echo) |
+| `wait_for_response=false` (speak-only narration) | (n/a — no listen window) | **yes** | no |
+
+The asymmetry: the assistant always speaks something on a converse call, and the visible transcript is exactly where that content gets lost — so the assistant echo always applies. The user echo only applies when there is a captured user message; otherwise there's nothing to print and fabricating a placeholder would be misleading.
 
 The assistant echo appears in the response that issues the converse call (immediately before the tool use). The user echo appears in the next assistant response (immediately after receiving the tool result).
+
+## Truncation
+
+**Default: no truncation.** Echo the full user message, full assistant message. If the user said three sentences, all three appear in the blockquote.
+
+**Opt-in truncation.** A user can say *"truncate long echoes"* or *"keep echoes under one line"* to enable a soft cap (suggest: ~140 chars, with `…` on a single subsequent line). The cap applies for the rest of the session unless the user resets it.
+
+**Never truncate the user echo by default.** Mike's note 2026-05-03: truncating user speech in the echo is a real risk for misreading what was said. The user typed (or spoke) what they spoke; show the whole thing back unless they explicitly ask for shorter.
 
 ## Worked example
 

--- a/.claude/skills/voicemode/docs/transcript-visibility.md
+++ b/.claude/skills/voicemode/docs/transcript-visibility.md
@@ -1,0 +1,105 @@
+# Transcript visibility — deep dive
+
+The `## Transcript visibility` section in `SKILL.md` is the always-loaded summary. This file holds the detail you only need when something out of the ordinary comes up — modes, edge cases, worked examples, override phrasings.
+
+## Why this exists
+
+Newer Claude Code releases collapse MCP tool calls in the visible transcript. The spoken side of a `voicemode:converse` exchange — both the message you passed in and the user message that came back — disappears from the conversation record unless you mirror it as visible Markdown.
+
+The fix is a soft instruction (this skill), not a hook or output style. Hooks can't directly write into the transcript at the moment the user reads it; output styles are too coarse-grained for "after tool X, print Y." A skill instruction matches how the model already produces visible text after a tool call returns, and inherits the right opt-out behaviour for free.
+
+## When to echo
+
+| Tool call shape | User message in result | Echo? |
+|---|---|---|
+| `wait_for_response=true` | yes | echo BOTH sides |
+| `wait_for_response=true` | empty / transcription failure / timeout | NO echo (don't fabricate) |
+| `wait_for_response=false` | (n/a — no listen window) | NO echo (no user message to surface) |
+
+The assistant echo appears in the response that issues the converse call (immediately before the tool use). The user echo appears in the next assistant response (immediately after receiving the tool result).
+
+## Worked example
+
+In the response that issues the converse call:
+
+```markdown
+> **ASSISTANT (voicemode):** What would you like to work on next?
+[voicemode:converse("What would you like to work on next?") tool call]
+```
+
+In the next response, after the tool result:
+
+```markdown
+> **USER (voicemode):** Let's pick up the auth refactor where we left off.
+
+Sure — pulling up that branch now.
+```
+
+A future reader can reconstruct the full voice exchange from the visible blockquotes alone, without expanding any collapsed tool calls.
+
+## Verbatim vs companion modes
+
+Spoken content is prose by necessity — TTS doesn't read bullet points or headings. But the visible echo is rendered Markdown, so a long spoken sentence often reads much better in the transcript as a list.
+
+| Mode | Description | Default for |
+|---|---|---|
+| **Verbatim** | Exact words spoken or heard, no reformatting. Faithful to the audio. | **User** echo. Rewriting the user's words risks distorting their intent. |
+| **Companion** | Same content, Markdown-formatted: lists become bullets, multi-step reasoning becomes numbered steps, code references become inline code or fenced blocks, file paths get backticks, etc. | **Assistant** echo. You authored the prose and can faithfully render your own intent in better Markdown. |
+
+### Companion is constrained
+
+Same content, better formatting — that's it. Companion must NOT:
+
+- Paraphrase or summarise to the point that meaning shifts
+- Add information that wasn't in the spoken content
+- Drop substantive content to make the echo "tidier"
+- Change the tone (e.g. casual → formal)
+
+If in doubt, fall back to verbatim. The constraint exists because companion mode is a presentation layer, not a chance to "improve" the conversation.
+
+### Companion-mode worked example
+
+A spoken assistant message like:
+
+> *"Three options for you. One, triage TM-698 children — flip the nine inbox tasks to todo. Two, flesh out TM-720 — design the rename properly: scope, order, what breaks. Three, switch tracks to CC-164 — the settle skill still needs triage."*
+
+…echoes in companion mode as:
+
+```markdown
+> **ASSISTANT (voicemode):**
+> - **(1) Triage TM-698 children** — flip the nine inbox tasks to todo
+> - **(2) Flesh out TM-720** — design the rename properly: scope, order, what breaks
+> - **(3) Switch tracks to CC-164** — the settle skill still needs triage
+```
+
+Same content, same options, same emphasis — just a list instead of run-on prose.
+
+## Per-turn and per-session overrides
+
+Either side can be flipped:
+
+| User says | Effect |
+|---|---|
+| *"Echo my last reply verbatim"* | Just that user echo flips, others stay at default. |
+| *"Verbatim only from now on"* | Both sides flip to verbatim for the rest of the session. |
+| *"Skip the assistant companion"* | Assistant echo flips to verbatim for the session. |
+| *"Companion mode for me too"* | User echo flips to companion (rare — mainly when the user has spoken a long structured list and wants it formatted). |
+
+## No double-echo
+
+If the assistant message you pass to `converse` is identical to a sentence already written as visible prose in the same response, don't also produce a separate `> **ASSISTANT (voicemode):**` line — the prose already serves the same purpose.
+
+The same rule applies to the user side: if you naturally quote the user's words back in your reasoning ("You said 'X', so..."), don't also add a separate `> **USER (voicemode):**` line for the same content. One visible record of each utterance is enough.
+
+The common case is that the visible reasoning text and the spoken `message` argument differ — in that case both should appear.
+
+## Opt-out phrasings
+
+The behaviour is a default, not a hard rule. Honour any of these for the rest of the session:
+
+- *"stop echoing"*
+- *"drop the voicemode lines"*
+- *"you don't need to repeat me"*
+- *"no more transcript echoes"*
+
+Resume only if the user asks.


### PR DESCRIPTION
## Summary

- Adds a new `## Transcript visibility` H2 section to `.claude/skills/voicemode/SKILL.md` instructing the assistant to echo voice turns as visible Markdown blockquotes around `voicemode:converse` calls.
- **Both directions** by default: assistant message echoed *before* the call, captured user message echoed *after*, in the format `> **voicemode (assistant):** ...` / `> **voicemode (user):** ...`.
- Gated on `wait_for_response=true` with a captured user utterance — speak-only narration calls and empty/failed transcriptions produce no echo.
- Includes a worked example, no-double-echo guidance (don't repeat content already visible in the same response), and an explicit mid-session opt-out path.

## Why

Newer Claude Code releases collapse MCP tool calls in the visible transcript, which hides the spoken side of `voicemode:converse` exchanges. The semantically important content (the user's spoken message and the assistant's spoken reply) disappears from the visible flow. Echoing both sides as blockquotes keeps the conversation reconstructible from the transcript alone.

## Design

Decisions D1–D5 are locked in the task README under Design > Decisions (taskmaster-tasks/projects/voicemode/VM-1166_*):

- **D1** Direction: BOTH the assistant and the user message
- **D2** Format: Markdown blockquote with bold `voicemode (assistant|user):` label
- **D3** Gating: only on `wait_for_response=true` with a captured utterance
- **D4** Mechanism: skill instruction (hooks rejected — post-tool output goes to the next model turn, not the visible transcript)
- **D5** Location: new top-level `## Transcript visibility` H2 section, between Best Practices and Parallel Tool Calls

This is a soft instruction the model follows by default and the user can override mid-session ("stop echoing").

## Test plan

- [ ] Run 3–5 `voicemode:converse` exchanges with `wait_for_response=true` in a fresh Claude Code session that loads this skill; confirm both `voicemode (assistant):` and `voicemode (user):` blockquotes appear around each call.
- [ ] Run one `wait_for_response=false` (speak-only) call; confirm no echo is produced.
- [ ] Confirm no double-echo when the assistant naturally quotes the user's words in its own reasoning.
- [ ] Ask the assistant mid-session to stop echoing voice turns; confirm the next 1–2 exchanges produce no echo lines.
- [ ] Confirm the lines are clearly attributed to "voicemode" so a future reader of the transcript can tell which turns came via voice.

Validation will be documented in the task README under `validate-001`.

Refs: VM-1166

🤖 Generated with [Claude Code](https://claude.com/claude-code)