### PR TITLE
feat(voices): VL-26 impl-001 — recursive walk + leaf-name keying + collision detection

### DIFF
--- a/tests/test_voice_profiles.py
+++ b/tests/test_voice_profiles.py
@@ -178,3 +178,203 @@ def test_no_remote_uses_local_absolute_path(vp, voices_dir):
     p = vp.get_profile("samantha")
     expected = str((voices_dir / "samantha" / "default.wav").resolve())
     assert p.ref_audio == expected
+
+
+# ---------- recursive walk: grouped voice layouts (VL-26 impl-001) ----------
+
+def _make_voice(parent, name, wav_bytes=b"riff", txt="transcript"):
+    """Helper: drop a default.wav + default.txt voice dir under parent."""
+    d = parent / name
+    d.mkdir(parents=True)
+    (d / "default.wav").write_bytes(wav_bytes)
+    (d / "default.txt").write_text(txt)
+    return d
+
+
+@pytest.fixture
+def grouped_voices_dir(tmp_path, monkeypatch):
+    """Mixed-depth tree:
+
+        voices/
+          alan/default.wav                  (flat top-level)
+          bobs-burgers/
+            bob/default.wav                 (1-level group)
+            linda/default.wav
+          star-trek/
+            tng/
+              picard/default.wav            (3 levels deep)
+    """
+    voices = tmp_path / "voices"
+    voices.mkdir()
+    _make_voice(voices, "alan")
+    _make_voice(voices, "bobs-burgers/bob")
+    _make_voice(voices, "bobs-burgers/linda")
+    _make_voice(voices, "star-trek/tng/picard")
+
+    monkeypatch.setenv("VOICEMODE_VOICES_DIR", str(voices))
+    monkeypatch.delenv("VOICEMODE_REMOTE_VOICES_DIR", raising=False)
+    return voices
+
+
+@pytest.fixture
+def vp_grouped(grouped_voices_dir):
+    import importlib
+
+    from voice_mode import voice_profiles
+
+    importlib.reload(voice_profiles)
+    return voice_profiles
+
+
+def test_grouped_voice_keyed_by_leaf_name(vp_grouped):
+    profiles = vp_grouped.load_profiles()
+    assert "bob" in profiles
+    assert "linda" in profiles
+    assert profiles["bob"].ref_audio.endswith("/bobs-burgers/bob/default.wav")
+
+
+def test_three_deep_nested_voice_loads(vp_grouped, grouped_voices_dir):
+    profiles = vp_grouped.load_profiles()
+    assert "picard" in profiles
+    assert profiles["picard"].ref_audio.endswith(
+        "/star-trek/tng/picard/default.wav"
+    )
+
+
+def test_flat_and_nested_coexist(vp_grouped):
+    profiles = vp_grouped.load_profiles()
+    assert set(profiles.keys()) == {"alan", "bob", "linda", "picard"}
+
+
+def test_voice_dir_field_records_resolved_path(vp_grouped, grouped_voices_dir):
+    profiles = vp_grouped.load_profiles()
+    assert profiles["alan"].voice_dir == str(grouped_voices_dir / "alan")
+    assert profiles["bob"].voice_dir == str(
+        grouped_voices_dir / "bobs-burgers" / "bob"
+    )
+    assert profiles["picard"].voice_dir == str(
+        grouped_voices_dir / "star-trek" / "tng" / "picard"
+    )
+
+
+def test_indexed_selector_works_for_grouped_voice(tmp_path, monkeypatch):
+    voices = tmp_path / "voices"
+    voices.mkdir()
+    bob_dir = voices / "bobs-burgers" / "bob"
+    bob_dir.mkdir(parents=True)
+    (bob_dir / "default.wav").write_bytes(b"d")
+    (bob_dir / "default.txt").write_text("default")
+    (bob_dir / "angry.wav").write_bytes(b"a")
+    (bob_dir / "angry.txt").write_text("angry")
+
+    monkeypatch.setenv("VOICEMODE_VOICES_DIR", str(voices))
+    monkeypatch.delenv("VOICEMODE_REMOTE_VOICES_DIR", raising=False)
+
+    import importlib
+
+    from voice_mode import voice_profiles
+
+    importlib.reload(voice_profiles)
+
+    p = voice_profiles.get_profile("bob[0]")
+    assert p.ref_audio.endswith("/bobs-burgers/bob/angry.wav")
+    assert p.ref_text == "angry"
+
+
+# ---------- collision detection ----------
+
+def test_collision_drops_both_candidates(tmp_path, monkeypatch, caplog):
+    voices = tmp_path / "voices"
+    voices.mkdir()
+    _make_voice(voices, "bobs-burgers/bob")
+    _make_voice(voices, "the-simpsons/bob")
+    _make_voice(voices, "alan")  # should still load
+
+    monkeypatch.setenv("VOICEMODE_VOICES_DIR", str(voices))
+    monkeypatch.delenv("VOICEMODE_REMOTE_VOICES_DIR", raising=False)
+
+    import importlib
+    import logging
+
+    from voice_mode import voice_profiles
+
+    importlib.reload(voice_profiles)
+
+    with caplog.at_level(logging.ERROR, logger="voicemode"):
+        profiles = voice_profiles.load_profiles()
+
+    assert "bob" not in profiles
+    assert "alan" in profiles
+    assert any(
+        "collision" in rec.message.lower() and "bob" in rec.message
+        for rec in caplog.records
+    )
+
+
+def test_collision_three_way_drops_all(tmp_path, monkeypatch, caplog):
+    voices = tmp_path / "voices"
+    voices.mkdir()
+    _make_voice(voices, "show-a/bob")
+    _make_voice(voices, "show-b/bob")
+    _make_voice(voices, "show-c/bob")
+
+    monkeypatch.setenv("VOICEMODE_VOICES_DIR", str(voices))
+    monkeypatch.delenv("VOICEMODE_REMOTE_VOICES_DIR", raising=False)
+
+    import importlib
+    import logging
+
+    from voice_mode import voice_profiles
+
+    importlib.reload(voice_profiles)
+
+    with caplog.at_level(logging.ERROR, logger="voicemode"):
+        profiles = voice_profiles.load_profiles()
+
+    assert "bob" not in profiles
+    error_records = [
+        r for r in caplog.records
+        if r.levelno >= logging.ERROR and "bob" in r.message
+    ]
+    assert len(error_records) == 1, (
+        "Expected a single ERROR listing all three colliding paths"
+    )
+    msg = error_records[0].message
+    assert "show-a/bob" in msg
+    assert "show-b/bob" in msg
+    assert "show-c/bob" in msg
+
+
+# ---------- voice-with-subdir-ignored ----------
+
+def test_subdirs_of_voice_dir_are_not_walked(tmp_path, monkeypatch):
+    """A dir that qualifies as a voice short-circuits: its subdirs are not
+    treated as candidate voices, even if they look like voice dirs."""
+    voices = tmp_path / "voices"
+    voices.mkdir()
+
+    # Top-level voice with a 'samples/' subdir that itself contains
+    # something that would otherwise look like a voice (default.wav).
+    sam = voices / "samantha"
+    sam.mkdir()
+    (sam / "default.wav").write_bytes(b"d")
+    (sam / "default.txt").write_text("default")
+
+    samples = sam / "samples"
+    samples.mkdir()
+    (samples / "default.wav").write_bytes(b"d")  # tempting!
+    (samples / "default.txt").write_text("inner")
+
+    monkeypatch.setenv("VOICEMODE_VOICES_DIR", str(voices))
+    monkeypatch.delenv("VOICEMODE_REMOTE_VOICES_DIR", raising=False)
+
+    import importlib
+
+    from voice_mode import voice_profiles
+
+    importlib.reload(voice_profiles)
+
+    profiles = voice_profiles.load_profiles()
+    assert set(profiles.keys()) == {"samantha"}
+    # 'samples' must NOT have been registered as its own voice
+    assert "samples" not in profiles

--- a/voice_mode/voice_profiles.py
+++ b/voice_mode/voice_profiles.py
@@ -70,6 +70,7 @@ class VoiceProfile:
     model: str           # TTS model to use
     base_url: str        # TTS endpoint URL
     description: str = ""
+    voice_dir: str = ""  # Absolute path to the voice's own directory
 
 
 _profiles: Dict[str, VoiceProfile] = {}
@@ -130,36 +131,72 @@ def _read_description(voice_dir: Path) -> str:
     return ""
 
 
+def _build_profile(voice_dir: Path, wav: Path) -> VoiceProfile:
+    """Construct a VoiceProfile for a directory that qualifies as a voice."""
+    transcript = _resolve_transcript(wav)
+    if not transcript:
+        logger.warning(
+            f"Voice {voice_dir.name!r}: no transcript found "
+            f"(expected {wav.with_suffix('.txt').name} or default.txt). "
+            f"ref_text will be empty."
+        )
+
+    return VoiceProfile(
+        name=voice_dir.name,
+        ref_audio=_translate_path(wav),
+        ref_text=transcript,
+        model=DEFAULT_CLONE_MODEL,
+        base_url=DEFAULT_CLONE_BASE_URL,
+        description=_read_description(voice_dir),
+        voice_dir=str(voice_dir),
+    )
+
+
 def _load_dir_profiles() -> Dict[str, VoiceProfile]:
-    """Walk VOICES_DIR and build profiles from per-voice subdirectories."""
+    """Walk VOICES_DIR recursively and build profiles for each voice dir.
+
+    A directory containing a resolvable WAV (see :func:`_resolve_default_wav`)
+    is a voice; otherwise it's a group and we descend into it. Subdirectories
+    of a voice dir are NOT walked further — voices and groups are disjoint.
+
+    Voices are keyed by leaf directory name. If two directories anywhere in
+    the tree share the same leaf name we treat it as a load-time
+    configuration error: log a single ERROR listing every conflicting path
+    and drop ALL conflicting candidates from the registry so neither
+    resolves silently.
+    """
     profiles: Dict[str, VoiceProfile] = {}
+    seen: Dict[str, Path] = {}
+    conflicts: Dict[str, List[Path]] = {}
 
     if not VOICES_DIR.exists() or not VOICES_DIR.is_dir():
         logger.debug(f"Voices directory not found at {VOICES_DIR}")
         return profiles
 
-    for voice_dir in sorted(p for p in VOICES_DIR.iterdir() if p.is_dir()):
-        wav = _resolve_default_wav(voice_dir)
-        if wav is None:
-            logger.debug(f"Skipping {voice_dir.name!r}: no .wav files")
-            continue
+    def walk(dir_path: Path) -> None:
+        wav = _resolve_default_wav(dir_path)
+        if wav is not None:
+            leaf = dir_path.name
+            if leaf in seen:
+                conflicts.setdefault(leaf, [seen[leaf]]).append(dir_path)
+                return
+            seen[leaf] = dir_path
+            profiles[leaf] = _build_profile(dir_path, wav)
+            return  # do NOT descend into a voice dir
 
-        transcript = _resolve_transcript(wav)
-        if not transcript:
-            logger.warning(
-                f"Voice {voice_dir.name!r}: no transcript found "
-                f"(expected {wav.with_suffix('.txt').name} or default.txt). "
-                f"ref_text will be empty."
-            )
+        for child in sorted(p for p in dir_path.iterdir() if p.is_dir()):
+            walk(child)
 
-        profiles[voice_dir.name] = VoiceProfile(
-            name=voice_dir.name,
-            ref_audio=_translate_path(wav),
-            ref_text=transcript,
-            model=DEFAULT_CLONE_MODEL,
-            base_url=DEFAULT_CLONE_BASE_URL,
-            description=_read_description(voice_dir),
+    for top in sorted(p for p in VOICES_DIR.iterdir() if p.is_dir()):
+        walk(top)
+
+    for leaf, paths in conflicts.items():
+        rel_paths = [str(p.relative_to(VOICES_DIR)) for p in paths]
+        logger.error(
+            f"Voice name collision: leaf {leaf!r} appears at {rel_paths}. "
+            f"Dropping ALL candidates — rename to disambiguate."
         )
+        profiles.pop(leaf, None)
 
     if profiles:
         logger.info(
@@ -271,7 +308,7 @@ def resolve_voice_expr(expr: str) -> Optional[VoiceProfile]:
     if selector is None:
         return profile
 
-    voice_dir = VOICES_DIR / name
+    voice_dir = Path(profile.voice_dir) if profile.voice_dir else VOICES_DIR / name
 
     # Indexed sample: samantha[0]
     if selector.startswith("[") and selector.endswith("]"):


### PR DESCRIPTION
## Summary
Implements VL-26 impl-001: arbitrary-depth voice directory layout in `_load_dir_profiles()`.

- Recursive walk: any dir with a resolvable WAV is a voice (and is NOT descended into); otherwise it's a group
- Profiles keyed by **leaf dirname** (`bobs-burgers/bob` → `bob`)
- Duplicate leaf names anywhere in the tree are tracked across the walk; ALL conflicting candidates are dropped from the registry with a single ERROR log per leaf listing every conflicting relative path
- `VoiceProfile` gains a `voice_dir` field so `resolve_voice_expr()` can do indexed/relative-file selection on nested voices without re-deriving the path from `VOICES_DIR + name` (which no longer holds)

## Design
Spec locked in `taskmaster-tasks` at [VL-26 design-001 / design-notes.md](https://github.com/mbailey/taskmaster-tasks/blob/master/projects/voice-lab/VL-26_feat_group-voices-by-familyshow-arbitrary-depth-directory-layout/harness/design-notes.md).

Notable decisions:
- Multi-level paths use **joined relative path** as the group string (e.g. `star-trek/tng/picard` → group `star-trek/tng`)
- Wav fallback (`default.wav` → first `*.wav`) is unchanged
- Subdirs of a voice dir are NOT walked further (e.g. `samantha/samples/` is invisible to the loader)

## Followups in this VL-26 task
- impl-002: derive group, append `(from <group>)` suffix to description
- impl-003: migrate Bob's Burgers cluster as worked example
- validate-001 + docs-001
- `bin/sayas` (Bash) needs the same recursive treatment — covered in voice-lab side of VL-26

## Test plan
- [x] Full voicemode test suite: **937 passed, 60 skipped (pre-existing)**
- New tests cover: grouped voice keyed by leaf, 3-deep nested voice loads, flat+nested coexist, voice_dir field recorded, indexed selector works for grouped voice, 2-way + 3-way collision drops all candidates with a single ERROR log, voice subdirs are not walked further

## Note on branch hygiene
Worker spawned via `tm task work VL-26` initially committed to local `master` -- VL-26 task lives under voice-lab project but the loader change is in voicemode (separate repo), and the harness doesn't yet handle cross-repo worktrees. Foreman moved the commit onto this branch and reset master back to `origin/master`. Gap filed as a separate taskmaster task.