### PR TITLE
VM-1172: fix test imports after Impressions rename

### DIFF
--- a/tests/test_clone_clip_length.py
+++ b/tests/test_clone_clip_length.py
@@ -6,7 +6,7 @@ from unittest.mock import patch
 
 import pytest
 
-from voice_mode.tools.clone.profiles import (
+from voice_mode.tools.impressions.profiles import (
     TRIM_HINT,
     _probe_duration_seconds,
     _validate_clip_length,
@@ -28,8 +28,8 @@ def tmp_voicemode(tmp_path, monkeypatch):
     voices_json = tmp_path / "voices.json"
     voices_dir = tmp_path / "voices"
     voices_dir.mkdir()
-    monkeypatch.setattr("voice_mode.tools.clone.profiles.VOICES_JSON", voices_json)
-    monkeypatch.setattr("voice_mode.tools.clone.profiles.VOICES_DIR", voices_dir)
+    monkeypatch.setattr("voice_mode.tools.impressions.profiles.VOICES_JSON", voices_json)
+    monkeypatch.setattr("voice_mode.tools.impressions.profiles.VOICES_DIR", voices_dir)
     return {"voices_json": voices_json, "voices_dir": voices_dir}
 
 
@@ -87,7 +87,7 @@ def test_validate_rejects_just_over_upper_boundary(tmp_path):
 def test_probe_falls_back_to_wave_when_ffprobe_missing(tmp_path):
     wav = _write_wav(tmp_path / "wave.wav", 5.0)
     with patch(
-        "voice_mode.tools.clone.profiles.subprocess.run",
+        "voice_mode.tools.impressions.profiles.subprocess.run",
         side_effect=FileNotFoundError("ffprobe not found"),
     ):
         duration = _probe_duration_seconds(wav)
@@ -98,7 +98,7 @@ def test_probe_non_wav_without_ffprobe_raises(tmp_path):
     mp3 = tmp_path / "x.mp3"
     mp3.write_bytes(b"\x00" * 100)
     with patch(
-        "voice_mode.tools.clone.profiles.subprocess.run",
+        "voice_mode.tools.impressions.profiles.subprocess.run",
         side_effect=FileNotFoundError("ffprobe not found"),
     ):
         with pytest.raises(RuntimeError) as exc:
@@ -129,7 +129,7 @@ async def test_clone_add_rejects_long_clip(tmp_voicemode, tmp_path):
 async def test_clone_add_passes_gate_for_7s_clip(tmp_voicemode, tmp_path):
     ok = _write_wav(tmp_path / "ok.wav", 7.0)
     with patch(
-        "voice_mode.tools.clone.profiles._transcribe_audio",
+        "voice_mode.tools.impressions.profiles._transcribe_audio",
         return_value="hello world",
     ):
         result = await clone_add("testfoo", str(ok))

--- a/tests/test_clone_layout.py
+++ b/tests/test_clone_layout.py
@@ -8,7 +8,7 @@ from unittest.mock import patch
 import pytest
 import yaml
 
-from voice_mode.tools.clone.profiles import (
+from voice_mode.tools.impressions.profiles import (
     NORMALISED_FORMAT_DESC,
     clone_add,
 )
@@ -29,10 +29,10 @@ def tmp_voicemode(tmp_path, monkeypatch):
     voices_dir = tmp_path / "voices"
     voices_dir.mkdir()
     monkeypatch.setattr(
-        "voice_mode.tools.clone.profiles.VOICES_JSON", voices_json
+        "voice_mode.tools.impressions.profiles.VOICES_JSON", voices_json
     )
     monkeypatch.setattr(
-        "voice_mode.tools.clone.profiles.VOICES_DIR", voices_dir
+        "voice_mode.tools.impressions.profiles.VOICES_DIR", voices_dir
     )
     return {"voices_json": voices_json, "voices_dir": voices_dir}
 
@@ -59,10 +59,10 @@ def _patch_normalise(voices_dir: Path):
 async def test_clone_add_creates_per_voice_directory(tmp_voicemode, stub_wav):
     voices_dir = tmp_voicemode["voices_dir"]
     with patch(
-        "voice_mode.tools.clone.profiles._normalise_audio",
+        "voice_mode.tools.impressions.profiles._normalise_audio",
         side_effect=_patch_normalise(voices_dir),
     ), patch(
-        "voice_mode.tools.clone.profiles._transcribe_audio",
+        "voice_mode.tools.impressions.profiles._transcribe_audio",
         return_value="hello world",
     ):
         result = await clone_add("testfoo", str(stub_wav))
@@ -78,10 +78,10 @@ async def test_clone_add_creates_per_voice_directory(tmp_voicemode, stub_wav):
 async def test_voice_md_has_required_keys(tmp_voicemode, stub_wav):
     voices_dir = tmp_voicemode["voices_dir"]
     with patch(
-        "voice_mode.tools.clone.profiles._normalise_audio",
+        "voice_mode.tools.impressions.profiles._normalise_audio",
         side_effect=_patch_normalise(voices_dir),
     ), patch(
-        "voice_mode.tools.clone.profiles._transcribe_audio",
+        "voice_mode.tools.impressions.profiles._transcribe_audio",
         return_value="this is the transcript",
     ):
         await clone_add("testfoo", str(stub_wav))
@@ -106,10 +106,10 @@ async def test_voice_md_has_required_keys(tmp_voicemode, stub_wav):
 async def test_voices_json_points_at_per_voice_default_wav(tmp_voicemode, stub_wav):
     voices_dir = tmp_voicemode["voices_dir"]
     with patch(
-        "voice_mode.tools.clone.profiles._normalise_audio",
+        "voice_mode.tools.impressions.profiles._normalise_audio",
         side_effect=_patch_normalise(voices_dir),
     ), patch(
-        "voice_mode.tools.clone.profiles._transcribe_audio",
+        "voice_mode.tools.impressions.profiles._transcribe_audio",
         return_value="hello world",
     ):
         await clone_add("testfoo", str(stub_wav))
@@ -129,10 +129,10 @@ async def test_clone_add_refuses_when_voice_dir_already_populated(
     (existing / "default.wav").write_bytes(b"existing")
 
     with patch(
-        "voice_mode.tools.clone.profiles._normalise_audio",
+        "voice_mode.tools.impressions.profiles._normalise_audio",
         side_effect=_patch_normalise(voices_dir),
     ), patch(
-        "voice_mode.tools.clone.profiles._transcribe_audio",
+        "voice_mode.tools.impressions.profiles._transcribe_audio",
         return_value="hello world",
     ):
         result = await clone_add("testfoo", str(stub_wav))
@@ -149,10 +149,10 @@ async def test_clone_add_does_not_remove_legacy_flat_wav(tmp_voicemode, stub_wav
     legacy.write_bytes(b"legacy")
 
     with patch(
-        "voice_mode.tools.clone.profiles._normalise_audio",
+        "voice_mode.tools.impressions.profiles._normalise_audio",
         side_effect=_patch_normalise(voices_dir),
     ), patch(
-        "voice_mode.tools.clone.profiles._transcribe_audio",
+        "voice_mode.tools.impressions.profiles._transcribe_audio",
         return_value="hello world",
     ):
         result = await clone_add("testfoo", str(stub_wav))
@@ -179,10 +179,10 @@ async def test_clone_add_preserves_other_voices_json_entries(
     tmp_voicemode["voices_json"].write_text(json.dumps(pre_existing))
 
     with patch(
-        "voice_mode.tools.clone.profiles._normalise_audio",
+        "voice_mode.tools.impressions.profiles._normalise_audio",
         side_effect=_patch_normalise(voices_dir),
     ), patch(
-        "voice_mode.tools.clone.profiles._transcribe_audio",
+        "voice_mode.tools.impressions.profiles._transcribe_audio",
         return_value="hello world",
     ):
         await clone_add("testfoo", str(stub_wav))
@@ -197,10 +197,10 @@ async def test_clone_add_preserves_other_voices_json_entries(
 async def test_success_message_includes_layout_paths(tmp_voicemode, stub_wav):
     voices_dir = tmp_voicemode["voices_dir"]
     with patch(
-        "voice_mode.tools.clone.profiles._normalise_audio",
+        "voice_mode.tools.impressions.profiles._normalise_audio",
         side_effect=_patch_normalise(voices_dir),
     ), patch(
-        "voice_mode.tools.clone.profiles._transcribe_audio",
+        "voice_mode.tools.impressions.profiles._transcribe_audio",
         return_value="hello world transcript here",
     ):
         result = await clone_add("testfoo", str(stub_wav))

--- a/tests/test_clone_normalise.py
+++ b/tests/test_clone_normalise.py
@@ -6,7 +6,7 @@ from unittest.mock import patch
 
 import pytest
 
-from voice_mode.tools.clone.profiles import _normalise_audio
+from voice_mode.tools.impressions.profiles import _normalise_audio
 
 
 EXPECTED_FFMPEG_ARGS = [
@@ -31,7 +31,7 @@ def test_normalise_invokes_ffmpeg_with_expected_arg_vector():
     dest = Path("/tmp/out.wav")
     fake_result = SimpleNamespace(returncode=0, stderr="", stdout="")
     with patch(
-        "voice_mode.tools.clone.profiles.subprocess.run",
+        "voice_mode.tools.impressions.profiles.subprocess.run",
         return_value=fake_result,
     ) as mock_run:
         _normalise_audio(src, dest)
@@ -49,7 +49,7 @@ def test_normalise_raises_runtimeerror_on_nonzero_exit_with_stderr():
     stderr_payload = "\n".join(f"line {i}" for i in range(30))
     fake_result = SimpleNamespace(returncode=1, stderr=stderr_payload, stdout="")
     with patch(
-        "voice_mode.tools.clone.profiles.subprocess.run",
+        "voice_mode.tools.impressions.profiles.subprocess.run",
         return_value=fake_result,
     ):
         with pytest.raises(RuntimeError) as exc:
@@ -67,7 +67,7 @@ def test_normalise_raises_filenotfound_when_ffmpeg_missing():
     src = Path("/tmp/in.wav")
     dest = Path("/tmp/out.wav")
     with patch(
-        "voice_mode.tools.clone.profiles.subprocess.run",
+        "voice_mode.tools.impressions.profiles.subprocess.run",
         side_effect=FileNotFoundError("No such file: ffmpeg"),
     ):
         with pytest.raises(FileNotFoundError) as exc:

--- a/tests/test_clone_transcribe.py
+++ b/tests/test_clone_transcribe.py
@@ -14,7 +14,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-from voice_mode.tools.clone.profiles import (
+from voice_mode.tools.impressions.profiles import (
     _normalise_transcription_url,
     _transcribe_audio,
 )
@@ -58,7 +58,7 @@ def test_failover_success_uses_second_url(sample_audio, monkeypatch):
         return _ok_response("Hello world")
 
     with patch(
-        "voice_mode.tools.clone.profiles.urllib.request.urlopen",
+        "voice_mode.tools.impressions.profiles.urllib.request.urlopen",
         side_effect=fake_urlopen,
     ):
         result = _transcribe_audio(sample_audio)
@@ -79,7 +79,7 @@ def test_all_urls_fail_lists_each_in_error(sample_audio, monkeypatch):
     )
 
     with patch(
-        "voice_mode.tools.clone.profiles.urllib.request.urlopen",
+        "voice_mode.tools.impressions.profiles.urllib.request.urlopen",
         side_effect=urllib.error.URLError("nope"),
     ):
         with pytest.raises(ConnectionError) as exc_info:


### PR DESCRIPTION
## Summary

- Fix `make test` collection errors on master (4 test files importing the old `voice_mode.tools.clone.profiles` path)
- Mechanical find/replace to the new `voice_mode.tools.impressions.profiles` path that VM-1174 created
- Required to unblock 8.7.0 release smoke testing (VM-1172)

## Why this happened

VM-1182 and VM-1184 (clone-add fixes) landed alongside VM-1174 (Impressions rename). The test files from those sibling branches imported the pre-rename module path and weren't rebased onto the rename, so when both sets of branches merged into master, `make test` broke at collection.

## Test plan

- [x] `make test` -- 944 passed, 60 skipped, 1 pre-existing flake (`test_get_git_commit_hash`, asserts 7-char hash; repo now uses 8)
- [x] No new failures introduced
- [x] No remaining stale references to `voice_mode.tools.clone` anywhere in the repo

🤖 Generated with [Claude Code](https://claude.com/claude-code)