### PR TITLE
VM-1172: fix test_get_git_commit_hash for grown abbreviation length

### DIFF
--- a/tests/test_version_detection.py
+++ b/tests/test_version_detection.py
@@ -19,13 +19,21 @@ def test_get_git_commit_hash():
     """Test getting git commit hash."""
     # Should return a hash in a real git repo
     commit = get_git_commit_hash(short=True)
-    if commit:
-        assert len(commit) == 7  # Short hash is 7 characters
-        
-    # Test full hash
     commit_full = get_git_commit_hash(short=False)
+
+    if commit:
+        # Git auto-grows the short hash as the repo grows so the abbreviation
+        # stays unambiguous. Assert a sane range and that the short form is a
+        # prefix of the full hash, rather than a fixed length.
+        assert 7 <= len(commit) <= 40
+        assert all(c in "0123456789abcdef" for c in commit)
+        if commit_full:
+            assert commit_full.startswith(commit)
+
+    # Test full hash
     if commit_full:
-        assert len(commit_full) == 40  # Full hash is 40 characters
+        assert len(commit_full) == 40  # Full hash is always 40 characters
+        assert all(c in "0123456789abcdef" for c in commit_full)
 
 
 def test_is_git_repository():


### PR DESCRIPTION
## Summary

- Fix the last failing test on master so 8.7.0 release smoke tests come back fully green
- Git auto-grows the short-hash abbreviation as the repo grows so it stays unambiguous (this repo is now 8 chars: `82fd3dfa`). The test asserted a fixed length of 7 and started failing once we crossed the boundary. Noted as a pre-existing flake in the VM-1172 handover.

## Change

Replace the fixed-length assertion with:
- a sane range (7..40)
- hex-only character check
- short hash must be a prefix of the full hash

Same hex-only check applied to the full-hash branch (length stays exactly 40).

## Test plan

- [x] `uv run pytest tests/test_version_detection.py -v` -> 6 passed
- [x] Verifies short hash is `82fd3dfa` (8 chars) on current master
- [x] Re-asserts that the short hash is a prefix of the full 40-char hash

🤖 Generated with [Claude Code](https://claude.com/claude-code)