### PR TITLE
VM-1204: fast-fail conch lock when holder PID is dead

### DIFF
--- a/tests/test_conch.py
+++ b/tests/test_conch.py
@@ -371,6 +371,147 @@ class TestConchAtomicLocking:
 
         conch.release()
 
+    def test_try_acquire_clears_dead_holder_lock(self):
+        """try_acquire() unlinks a lock owned by a dead PID and acquires.
+
+        Uses the fork-and-reap pattern: spawn a child, wait for it to exit,
+        then write a lock file with the reaped (now dead) PID. Avoids the
+        flaky "PID 999999" pattern -- high-PID systems may have it in use.
+        """
+        # Fork a child that exits immediately, then reap it so the PID is
+        # genuinely dead.
+        pid = os.fork()
+        if pid == 0:
+            # Child -- exit immediately
+            os._exit(0)
+        # Parent -- reap the child
+        os.waitpid(pid, 0)
+
+        # Sanity check: signal 0 against the reaped PID should now raise.
+        with pytest.raises(ProcessLookupError):
+            os.kill(pid, 0)
+
+        # Write a lock file with the dead PID and a fresh timestamp
+        # (so timestamp-based expiry would NOT fire).
+        Conch.LOCK_FILE.parent.mkdir(parents=True, exist_ok=True)
+        from datetime import datetime
+        data = {
+            "pid": pid,
+            "agent": "dead_agent",
+            "acquired": datetime.now().isoformat(),
+            "expires": None,
+        }
+        Conch.LOCK_FILE.write_text(json.dumps(data))
+
+        # A fresh Conch should clear the dead-holder lock and acquire.
+        new_conch = Conch(agent_name="new_agent")
+        assert new_conch.try_acquire() is True
+
+        # The lock should now be ours.
+        new_data = json.loads(Conch.LOCK_FILE.read_text())
+        assert new_data["pid"] == os.getpid()
+        assert new_data["agent"] == "new_agent"
+
+        new_conch.release()
+
+    def test_try_acquire_clears_dead_holder_lock_with_expiry_disabled(self):
+        """Dead-PID clearance works even when CONCH_LOCK_EXPIRY <= 0.
+
+        Operators may opt out of timestamp-based expiry, but a dead holder
+        is unambiguously stale and must still be cleared.
+        """
+        pid = os.fork()
+        if pid == 0:
+            os._exit(0)
+        os.waitpid(pid, 0)
+
+        Conch.LOCK_FILE.parent.mkdir(parents=True, exist_ok=True)
+        from datetime import datetime
+        data = {
+            "pid": pid,
+            "agent": "dead_agent",
+            "acquired": datetime.now().isoformat(),
+            "expires": None,
+        }
+        Conch.LOCK_FILE.write_text(json.dumps(data))
+
+        # Patch the deferred lock-expiry getter to simulate disabled expiry.
+        with patch("voice_mode.conch._get_lock_expiry", return_value=0):
+            new_conch = Conch(agent_name="new_agent")
+            assert new_conch.try_acquire() is True
+
+        new_conch.release()
+
+    def test_try_acquire_respects_live_holder_lock(self):
+        """try_acquire() returns False when a live PID holds a fresh lock."""
+        # Write a lock file with our own (live) PID and fresh timestamp.
+        # We DON'T use Conch.acquire() because that doesn't take an flock --
+        # we need a flock-protected lock to genuinely block try_acquire.
+        holder = Conch(agent_name="holder")
+        assert holder.try_acquire() is True
+
+        # Sanity: lock file has our live PID.
+        data = json.loads(Conch.LOCK_FILE.read_text())
+        assert data["pid"] == os.getpid()
+
+        # A fresh Conch should NOT acquire.
+        contender = Conch(agent_name="contender")
+        assert contender.try_acquire() is False
+
+        # Lock file is unchanged (still belongs to holder).
+        assert Conch.LOCK_FILE.exists()
+
+        holder.release()
+
+    def test_try_acquire_clears_stale_timestamp_with_live_pid(self):
+        """Existing behavior: live PID + expired timestamp still clears."""
+        # Write a lock file with our live PID but an ancient timestamp.
+        Conch.LOCK_FILE.parent.mkdir(parents=True, exist_ok=True)
+        data = {
+            "pid": os.getpid(),
+            "agent": "stuck_agent",
+            "acquired": "2000-01-01T00:00:00",  # Way past any expiry
+            "expires": None,
+        }
+        Conch.LOCK_FILE.write_text(json.dumps(data))
+
+        # A fresh Conch should clear the stale-timestamp lock and acquire.
+        new_conch = Conch(agent_name="new_agent")
+        assert new_conch.try_acquire() is True
+
+        new_data = json.loads(Conch.LOCK_FILE.read_text())
+        assert new_data["agent"] == "new_agent"
+
+        new_conch.release()
+
+    def test_check_and_clear_handles_permission_error(self):
+        """PermissionError from os.kill is treated as 'alive' -- lock preserved.
+
+        If os.kill raises PermissionError, the process exists but is owned
+        by another user. We must NOT clear the lock in that case.
+        """
+        # Write a lock file with a fresh timestamp and some PID.
+        Conch.LOCK_FILE.parent.mkdir(parents=True, exist_ok=True)
+        from datetime import datetime
+        data = {
+            "pid": 12345,
+            "agent": "other_user_agent",
+            "acquired": datetime.now().isoformat(),
+            "expires": None,
+        }
+        Conch.LOCK_FILE.write_text(json.dumps(data))
+
+        # Mock os.kill to raise PermissionError.
+        with patch("voice_mode.conch.os.kill", side_effect=PermissionError):
+            conch = Conch(agent_name="probe")
+            conch._check_and_clear_stale_lock()
+
+        # Lock file must still exist -- treated as alive.
+        assert Conch.LOCK_FILE.exists()
+        preserved = json.loads(Conch.LOCK_FILE.read_text())
+        assert preserved["pid"] == 12345
+        assert preserved["agent"] == "other_user_agent"
+
     def test_release_without_acquire_does_not_delete_lock_file(self):
         """release() on non-holder must NOT delete the lock file.
 

--- a/voice_mode/conch.py
+++ b/voice_mode/conch.py
@@ -147,44 +147,84 @@ class Conch:
             return False
 
     def _check_and_clear_stale_lock(self) -> None:
-        """Check for and clear stale locks based on timestamp.
+        """Check for and clear stale locks.
 
-        If a lock file exists and its timestamp exceeds CONCH_LOCK_EXPIRY,
-        forcibly remove it to allow new acquisitions. This handles the case
-        where a process is alive but stuck and won't release the lock.
+        Two paths:
+        1. Dead-holder fast-fail: if the recorded PID no longer exists,
+           unlink the lock immediately. This runs even when timestamp-based
+           expiry is disabled (CONCH_LOCK_EXPIRY <= 0) -- a dead holder is
+           unambiguously stale.
+        2. Timestamp-based expiry: if the lock is older than
+           CONCH_LOCK_EXPIRY seconds, forcibly remove it. This handles the
+           case where the holder is alive but stuck.
 
-        Note: This deletes the file, creating a new inode. The stuck process
+        Note: This deletes the file, creating a new inode. A stuck process
         still holds its flock on the old inode, but we can now create a fresh
         lock file.
         """
-        lock_expiry = _get_lock_expiry()
-        if lock_expiry <= 0:
-            return  # Stale lock detection disabled
-
         if not self.LOCK_FILE.exists():
             return
 
         try:
             data = json.loads(self.LOCK_FILE.read_text())
-            acquired_str = data.get("acquired")
-            if not acquired_str:
-                return
+        except (json.JSONDecodeError, OSError):
+            return
 
-            acquired_time = datetime.fromisoformat(acquired_str)
-            age_seconds = (datetime.now() - acquired_time).total_seconds()
-
-            if age_seconds > lock_expiry:
-                # Lock is stale - forcibly remove it
+        # Fast-fail on dead holder -- no need to wait for timestamp expiry.
+        pid = data.get("pid")
+        if pid is not None:
+            try:
+                os.kill(pid, 0)
+                # Process is alive -- fall through to timestamp check.
+            except ProcessLookupError:
+                # Holder is dead -- clear the lock immediately.
                 stale_agent = data.get("agent", "unknown")
-                stale_pid = data.get("pid", "unknown")
                 try:
                     self.LOCK_FILE.unlink()
-                    # Log would be nice here, but avoid import complexity
                 except OSError:
                     pass
-        except (json.JSONDecodeError, ValueError, OSError):
-            # Can't read or parse - ignore
-            pass
+                # Best-effort observability event. Safe no-op if logger unset
+                # or import fails (avoids circular-import / startup-order issues).
+                try:
+                    from voice_mode.utils.event_logger import get_event_logger
+                    event_logger = get_event_logger()
+                    if event_logger:
+                        event_logger.log_event("CONCH_DEAD_HOLDER_CLEARED", {
+                            "stale_pid": pid,
+                            "stale_agent": stale_agent,
+                        })
+                except Exception:
+                    pass
+                return
+            except PermissionError:
+                # Process exists but we can't signal it -- treat as alive.
+                pass
+            except (TypeError, OSError):
+                # PID isn't a valid int or other OS error -- skip dead-PID path,
+                # fall through to timestamp check.
+                pass
+
+        # Timestamp-based stale clearance.
+        lock_expiry = _get_lock_expiry()
+        if lock_expiry <= 0:
+            return  # Stale lock detection disabled
+
+        acquired_str = data.get("acquired")
+        if not acquired_str:
+            return
+
+        try:
+            acquired_time = datetime.fromisoformat(acquired_str)
+        except ValueError:
+            return
+
+        age_seconds = (datetime.now() - acquired_time).total_seconds()
+        if age_seconds > lock_expiry:
+            # Lock is stale - forcibly remove it
+            try:
+                self.LOCK_FILE.unlink()
+            except OSError:
+                pass
 
     def release(self) -> float:
         """Release the lock and return seconds held.


### PR DESCRIPTION
## Summary

- `Conch._check_and_clear_stale_lock()` now probes the recorded PID with `os.kill(pid, 0)`. If `ProcessLookupError` fires, the lock file is unlinked immediately -- a crashed converse holder no longer forces waiters to wait the full `CONCH_LOCK_EXPIRY` (default 300s).
- `PermissionError` from `os.kill` is treated as "alive" (the process exists, just owned by another user) -- the lock is preserved.
- Dead-PID clearance runs even when `CONCH_LOCK_EXPIRY <= 0`. A non-existent PID is unambiguously stale.
- Best-effort `CONCH_DEAD_HOLDER_CLEARED` event is logged via the existing event-logger singleton (safe no-op when the logger is unset).

Task: [VM-1204](../../.taskmaster/projects/voicemode/VM-1204_fix_fast-fail-conch-lock-when-holder-pid-is-dead/README.md) -- `~/.taskmaster/projects/voicemode/VM-1204_fix_fast-fail-conch-lock-when-holder-pid-is-dead/README.md`

Before this fix, agent A could `kill -9` mid-call and agent B's `try_acquire(wait_for_conch=true)` loop would block until `CONCH_TIMEOUT` (60s) or until the timestamp expired (300s). Now agent B clears the dead lock on the next retry tick (~0.5s).

## Test plan

- [x] `uv run pytest tests/test_conch.py -v` -- 33 passed (5 new)
- [x] `uv run pytest tests/test_converse_cancellation.py -v` -- 3 passed (no regression)
- [ ] Manual: run `voicemode converse "say hello" --listen-duration-max 600` in one shell, `kill -9` it, then run another `voicemode converse "test"` and confirm acquisition within ~0.5s instead of 60s

New tests:
- `test_try_acquire_clears_dead_holder_lock` -- fork+reap to get a genuinely-dead PID, write lock, assert acquire succeeds
- `test_try_acquire_clears_dead_holder_lock_with_expiry_disabled` -- same with `CONCH_LOCK_EXPIRY=0` patched
- `test_try_acquire_respects_live_holder_lock` -- live holder + fresh timestamp blocks contender
- `test_try_acquire_clears_stale_timestamp_with_live_pid` -- existing timestamp path still wins
- `test_check_and_clear_handles_permission_error` -- mocked `PermissionError` does NOT clear

🤖 Generated with [Claude Code](https://claude.com/claude-code)