### PR TITLE
VM-1208: list available voices over MCP for streamable HTTP clients

### DIFF
--- a/.claude/skills/voicemode/SKILL.md
+++ b/.claude/skills/voicemode/SKILL.md
@@ -61,6 +61,13 @@ American male, `bf_` = British female, `bm_` = British male.
 When in doubt, omit `voice` entirely -- auto-select picks a working
 default.
 
+**Voice discovery for apps and agents:** read the `voice://voices` MCP
+resource for a structured JSON list of available voices (with
+`voice://voices/{provider}` for per-backend filtering). The
+`voice_registry` tool returns the same data as prose for the LLM
+mid-conversation. Both share the underlying enumerator so they never
+drift. See [voices resource reference](../../docs/reference/voices-resource.md).
+
 For all parameters, see [Converse Parameters](../../docs/reference/converse-parameters.md).
 
 ## Best Practices

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **`voice://voices` and `voice://voices/{provider}` MCP resources for structured TTS voice discovery (VM-1208)** — Streamable HTTP MCP clients (iOS app, web client, other agents) can now enumerate available TTS voices as JSON instead of scraping prose from the `voice_registry` tool. Both resources advertise `mime_type=application/json`, share an enumerator with the `voice_registry` tool (so the JSON resource and the LLM-facing prose can never disagree), and include impressions only for local callers (toggleable via `VOICEMODE_EXPOSE_LOCAL_VOICES_REMOTE`). 60-second in-process TTL on `/audio/voices` probes; OpenAI voices come from a hand-maintained constant. As a side-effect the `voice_registry` tool now reports `Voices: none detected` for offline endpoints instead of the legacy 67-voice phantom fallback. See [`voice://voices` reference](docs/reference/voices-resource.md).
+
 #### Impressions (preview / experimental) (VM-1174)
 
 VoiceMode can now do **impressions** -- speak in any voice from a short reference clip via local Qwen3-TTS on top of mlx-audio. Drop a 5-9 second WAV at `~/.voicemode/voices/<name>/default.wav`, then call `voicemode:converse(..., voice="<name>")` or `voicemode converse --voice <name>`. The model imitates the timbre and cadence of the clip; same technical path the unreleased "voice cloning" framing pointed at, with active "do an impression" framing instead.

--- a/docs/concepts/architecture.md
+++ b/docs/concepts/architecture.md
@@ -75,6 +75,20 @@ Multi-layered configuration system (`config.py`):
 3. **User Config**: `~/.voicemode/voicemode.env`
 4. **Defaults**: Built-in sensible defaults
 
+### Resources
+
+MCP resources expose structured server state to clients (apps, agents,
+the LLM-facing tool layer). Auto-imported from `voice_mode/resources/`.
+
+- **`voice://voices`** and **`voice://voices/{provider}`** — JSON voice
+  discovery for streamable HTTP clients. Shares an enumerator with the
+  `voice_registry` tool so the JSON resource and the LLM-facing prose
+  can never disagree on the voice list. See the
+  [`voice://voices` reference](../reference/voices-resource.md).
+- **`voice://config/*`** — Effective configuration values.
+- **`audio://files/*`**, **`whisper://models`**, etc. — Other resource
+  families exposed for client access.
+
 ## Voice Services
 
 ### Whisper (Speech-to-Text)

--- a/docs/guides/serve-configuration.md
+++ b/docs/guides/serve-configuration.md
@@ -451,8 +451,26 @@ export VOICEMODE_SERVE_HOST=127.0.0.1
 
 CLI options take precedence over environment variables.
 
+## Voice Discovery for HTTP Clients
+
+Streamable HTTP MCP clients (iOS app, web client, other agents) can
+enumerate the TTS voices a connected server can produce by reading the
+`voice://voices` MCP resource (with `voice://voices/{provider}` for
+per-backend filtering). The response is structured JSON, so apps don't
+have to scrape prose from `voice_registry`.
+
+Impressions/clones are filtered out for remote callers by default —
+see the resource's
+[Privacy section](../reference/voices-resource.md#privacy) for the
+`VOICEMODE_EXPOSE_LOCAL_VOICES_REMOTE` env var and notes on running
+behind a co-located reverse proxy.
+
+Full schema, freshness model, and example responses:
+[`voice://voices` reference](../reference/voices-resource.md).
+
 ## See Also
 
+- [`voice://voices` Resource](../reference/voices-resource.md) - Structured voice discovery for HTTP clients
 - [CLI Reference](../reference/cli.md) - Complete serve command documentation
 - [Configuration Guide](configuration.md) - VoiceMode configuration options
 - [Claude Code Plugin](claude-code-plugin.md) - Plugin installation for Claude Code

--- a/docs/reference/voices-resource.md
+++ b/docs/reference/voices-resource.md
@@ -1,0 +1,288 @@
+# `voice://voices` Resource Reference
+
+Structured TTS voice discovery for MCP clients. Apps and agents read
+this resource — typically over streamable HTTP — to populate voice
+pickers and route `converse` calls to a real voice without hardcoding
+per-provider lists or scraping prose from the `voice_registry` tool.
+
+The matching `voice_registry` MCP tool stays in place for the LLM
+mid-conversation; both surfaces share the same enumerator
+(`voice_mode/voices.py::enumerate_voices`) so they never drift.
+
+## Quick Reference
+
+| URI                              | Returns                                        |
+| -------------------------------- | ---------------------------------------------- |
+| `voice://voices`                 | Full voice list                                |
+| `voice://voices/{provider}`      | Same envelope, filtered to one provider        |
+
+- MIME type: `application/json` (advertised on `resources/list`)
+- Read with: `resources/read voice://voices` (and `voice://voices/{provider}`)
+- Available over both stdio and streamable HTTP transports
+
+## URIs
+
+### `voice://voices`
+
+Returns the full voice list the connected server can produce — every
+configured TTS endpoint that responded plus, for local callers, any
+impressions/clones from `VOICES_DIR`.
+
+### `voice://voices/{provider}`
+
+Same envelope, with `voices[]` narrowed to entries whose `provider`
+field matches the path segment. The envelope is well-formed even when
+the provider is unknown (the list is just empty). Useful for clients
+that already know which backend they want to draw voices from (e.g.
+`voice://voices/kokoro` for the local Kokoro picker).
+
+> **Picking a valid `{provider}` value.** Read `voice://voices` first
+> and collect the distinct `voices[].provider` strings. The current set
+> is `openai`, `kokoro`, `mlx-audio`, `local`, `unknown` — but the
+> resource is the source of truth for what your specific server is
+> actually configured for.
+
+## JSON Schema
+
+```json
+{
+  "schema_version": 1,
+  "generated_at": "2026-05-10T16:42:00Z",
+  "voices": [
+    {
+      "id": "kokoro:af_river",
+      "voice": "af_river",
+      "name": "af_river",
+      "provider": "kokoro",
+      "language": null,
+      "gender": null,
+      "preview_url": null
+    }
+  ]
+}
+```
+
+### Envelope
+
+| Field            | Type    | Notes                                                                                            |
+| ---------------- | ------- | ------------------------------------------------------------------------------------------------ |
+| `schema_version` | integer | `1` in v1. Bumped on a breaking schema change.                                                   |
+| `generated_at`   | string  | ISO 8601 UTC with `Z` suffix. Computed at call time, not cache-fill time. See [Freshness](#freshness-and-cadence). |
+| `voices`         | array   | Voice entries. May be empty.                                                                     |
+
+### Voice entry
+
+| Field         | Type             | Notes                                                                                                |
+| ------------- | ---------------- | ---------------------------------------------------------------------------------------------------- |
+| `id`          | string           | Globally unique, scoped as `{provider}:{voice}`. Stable across reads with unchanged server config.   |
+| `voice`       | string           | Raw value to pass to `converse(voice=...)`.                                                          |
+| `name`        | string           | Human-readable display label. In v1 this falls back to `voice` when no friendlier label is known.    |
+| `provider`    | string           | Opaque short name (`openai`, `kokoro`, `mlx-audio`, `local`, `unknown`). **Never a URL** (AC4).      |
+| `language`    | string \| null   | BCP-47 where known; `null` if not tracked.                                                           |
+| `gender`      | string \| null   | `"male"` \| `"female"` \| `"neutral"` \| `null`.                                                     |
+| `preview_url` | null             | Reserved for future use. Always `null` in v1.                                                        |
+
+**No `provider_url`, no `base_url`, no endpoint URLs anywhere in the
+body.** Server-internal endpoints (`http://127.0.0.1:8880/v1`) leak
+deployment topology and are useless to a remote client. Endpoint
+diagnostics live in the `voice_registry` tool's prose output, which is
+the right surface for the LLM mid-conversation.
+
+## Example Responses
+
+### Stdio caller (impressions visible)
+
+`resources/read voice://voices` from a local stdio caller with
+`TTS_BASE_URLS=https://api.openai.com/v1,http://127.0.0.1:8880/v1`
+and one impression `samantha` under `~/.voicemode/voices/`:
+
+```json
+{
+  "schema_version": 1,
+  "generated_at": "2026-05-10T16:42:00Z",
+  "voices": [
+    { "id": "openai:alloy",   "voice": "alloy",   "name": "alloy",   "provider": "openai", "language": null, "gender": null, "preview_url": null },
+    { "id": "openai:ash",     "voice": "ash",     "name": "ash",     "provider": "openai", "language": null, "gender": null, "preview_url": null },
+    { "id": "openai:ballad",  "voice": "ballad",  "name": "ballad",  "provider": "openai", "language": null, "gender": null, "preview_url": null },
+    { "id": "openai:coral",   "voice": "coral",   "name": "coral",   "provider": "openai", "language": null, "gender": null, "preview_url": null },
+    { "id": "openai:echo",    "voice": "echo",    "name": "echo",    "provider": "openai", "language": null, "gender": null, "preview_url": null },
+    { "id": "openai:fable",   "voice": "fable",   "name": "fable",   "provider": "openai", "language": null, "gender": null, "preview_url": null },
+    { "id": "openai:nova",    "voice": "nova",    "name": "nova",    "provider": "openai", "language": null, "gender": null, "preview_url": null },
+    { "id": "openai:onyx",    "voice": "onyx",    "name": "onyx",    "provider": "openai", "language": null, "gender": null, "preview_url": null },
+    { "id": "openai:sage",    "voice": "sage",    "name": "sage",    "provider": "openai", "language": null, "gender": null, "preview_url": null },
+    { "id": "openai:shimmer", "voice": "shimmer", "name": "shimmer", "provider": "openai", "language": null, "gender": null, "preview_url": null },
+    { "id": "openai:verse",   "voice": "verse",   "name": "verse",   "provider": "openai", "language": null, "gender": null, "preview_url": null },
+    { "id": "kokoro:af_river", "voice": "af_river", "name": "af_river", "provider": "kokoro", "language": null, "gender": null, "preview_url": null },
+    { "id": "mlx-audio:samantha", "voice": "samantha", "name": "samantha", "provider": "mlx-audio", "language": null, "gender": null, "preview_url": null }
+  ]
+}
+```
+
+### Remote streamable HTTP caller (impressions hidden)
+
+Same server, same configuration, but the caller is a remote client over
+streamable HTTP. The impression is filtered out (see [Privacy](#privacy)):
+
+```json
+{
+  "schema_version": 1,
+  "generated_at": "2026-05-10T16:42:01Z",
+  "voices": [
+    { "id": "openai:alloy", "voice": "alloy", "name": "alloy", "provider": "openai", "language": null, "gender": null, "preview_url": null }
+    // ... other openai + kokoro voices, no mlx-audio:samantha
+  ]
+}
+```
+
+### Per-provider filter
+
+`resources/read voice://voices/openai`:
+
+```json
+{
+  "schema_version": 1,
+  "generated_at": "2026-05-10T16:42:02Z",
+  "voices": [
+    { "id": "openai:alloy",   "voice": "alloy",   "name": "alloy",   "provider": "openai", "language": null, "gender": null, "preview_url": null },
+    { "id": "openai:ash",     "voice": "ash",     "name": "ash",     "provider": "openai", "language": null, "gender": null, "preview_url": null }
+    // ... remaining openai voices only
+  ]
+}
+```
+
+An unknown `{provider}` returns `"voices": []` with the rest of the
+envelope intact.
+
+## Privacy
+
+Impressions/clones are personal voice data and are **omitted from
+remote responses by default**. The resolution order, hardened against
+malformed peer information:
+
+1. `VOICEMODE_EXPOSE_LOCAL_VOICES_REMOTE` truthy → include impressions.
+2. No active HTTP request (stdio / in-memory transport) → include
+   impressions.
+3. HTTP request with a loopback peer (`127/8`, `::1`, IPv4-mapped
+   loopback `::ffff:127.0.0.1`) → include impressions.
+4. Anything else — `None` client, empty host string, unparseable IP, or
+   a public peer → omit impressions (safe default).
+
+The check looks at the connection peer reported by uvicorn via
+`fastmcp.server.dependencies.get_http_request()`, not at request
+headers, so an HTTP client cannot lie its way into "local". The
+predicate is implemented in `voice_mode/resources/voices.py`.
+
+> **`stdio` vs in-memory test transports.** The stdio path is detected
+> by the same `RuntimeError` that `FastMCPTransport` (the in-memory
+> test transport) raises when it is asked for an HTTP request. So both
+> behave identically for the privacy predicate — there is no third
+> "local-but-HTTP" branch.
+
+### `VOICEMODE_EXPOSE_LOCAL_VOICES_REMOTE`
+
+| Truthy values             | Falsy values (anything else, including unset) |
+| ------------------------- | --------------------------------------------- |
+| `1`, `true`, `yes`, `on`  | `0`, `false`, `no`, `off`, `""`, unset        |
+
+Case-insensitive; surrounding whitespace is stripped. When set truthy,
+impressions are included for every read regardless of transport or peer
+address.
+
+> **When to set this.** Use it when running VoiceMode behind a
+> co-located reverse proxy on the same host: every connection arrives
+> from `127.0.0.1`, so the loopback test would over-report "local" and
+> include impressions to remote callers. Either configure your proxy
+> to forward the real peer (uvicorn `--proxy-headers`,
+> `X-Forwarded-For` / `Forwarded`) — VoiceMode does not currently honour
+> these headers, so the safer alternative is to leave the env var unset
+> (or explicitly `false`) and accept that impressions stay hidden. Set
+> the env var truthy only when you actively want every caller treated
+> as local.
+
+## Freshness and Cadence
+
+The enumerator caches results in-process for **60 seconds**, with two
+independent cache slots keyed by whether impressions are included
+(`include_local_only=True` for local callers, `False` for remote). Each
+read inside the TTL window returns the cached list with a fresh
+`generated_at` timestamp computed at call time.
+
+| Provider source                    | Subject to TTL?              | Notes                                                                 |
+| ---------------------------------- | ---------------------------- | --------------------------------------------------------------------- |
+| OpenAI                             | No (hardcoded constant)      | `OPENAI_TTS_VOICES` lives in `voice_mode/voices.py`. Never network-probed. |
+| Kokoro / mlx-audio / local / unknown | Yes (60 s)                  | Live `GET {base_url}/audio/voices` with a 5 s per-endpoint timeout.   |
+| Whisper                            | Skipped entirely             | STT-only; not in the TTS enumerator.                                  |
+| Impressions (`VOICES_DIR`)         | Yes (60 s, local callers only) | Filesystem scan via `voice_profiles.list_profiles()`.                |
+
+**Implications:**
+
+- A user installing or restarting Kokoro / mlx-audio sees the new voice
+  list within ~60 seconds.
+- A user adding a new impression sees it within ~60 seconds of the next
+  local read (no file-watcher in v1).
+- OpenAI voices change only when the maintainer hand-edits
+  `OPENAI_TTS_VOICES` (see [Maintenance](#maintenance)).
+- Polling more often than once per minute returns cached data; trading
+  freshness for snappy picker UX is the explicit design choice.
+
+There is no `cadence_seconds` field on the wire; this section is the
+canonical statement of the enumerator's freshness model (per AC7).
+
+### Failure semantics
+
+If a `/audio/voices` probe fails for any reason, the enumerator skips
+that endpoint silently and logs a `WARNING` (or `ERROR` for malformed
+JSON). The response is always a partial list — one broken endpoint does
+not break the picker. Recovery is automatic on the next read after the
+TTL expires.
+
+## How `voice_registry` Tool Sources Its Voice List
+
+The `voice_registry` MCP tool — the prose-shaped surface for the LLM
+mid-conversation — now sources its voice list via
+`enumerate_voices(include_local_only=False)` rather than the legacy
+`provider_registry` cache. Same enumerator backing both surfaces means
+the JSON resource and the LLM prose can never disagree on the voice
+list.
+
+The visible side-effect of the refactor: when an endpoint is offline,
+the tool now reports `Voices: none detected` instead of the legacy
+67-voice phantom list `provider_registry` shipped as a hardcoded
+fallback. This is deliberate — the tool now reflects what the endpoint
+can actually produce right now, not what the package once shipped with.
+
+## Maintenance
+
+### OpenAI voice list
+
+`OPENAI_TTS_VOICES` in `voice_mode/voices.py` is hand-maintained.
+OpenAI does not expose `/audio/voices`, so there is nothing to probe.
+Update the constant and the `Last verified:` comment when OpenAI
+publishes a new voice. As of `2026-05-10` the list is:
+
+```
+alloy, ash, ballad, coral, echo, fable, nova, onyx, sage, shimmer, verse
+```
+
+The original six (`alloy`, `echo`, `fable`, `nova`, `onyx`, `shimmer`)
+work with `tts-1` and `tts-1-hd`. `ballad` and `verse` were added with
+`gpt-4o-mini-tts`.
+
+### Adding a provider
+
+`detect_provider_type()` in `voice_mode/provider_discovery.py`
+classifies a `TTS_BASE_URL` into one of `openai`, `kokoro`,
+`mlx-audio`, `whisper`, `local`, `unknown`. Anything matching
+`local` / `unknown` falls through to a best-effort `GET /audio/voices`
+probe. To onboard a new provider with a different voice-list shape,
+add a branch to `_voices_for_endpoint()` in `voice_mode/voices.py`.
+
+## See Also
+
+- [Remote Access (serve)](../guides/serve-configuration.md) — How to
+  run VoiceMode over streamable HTTP so remote clients can read this
+  resource.
+- [Selecting Voices](../guides/selecting-voices.md) — Picker UX
+  guidance for end users.
+- [Architecture](../concepts/architecture.md) — Where the resource fits
+  in the broader server architecture.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -100,6 +100,7 @@ nav:
     - Service Commands: reference/cli/service-commands.md
     - Converse Parameters: reference/converse-parameters.md
     - Environment Variables: reference/environment.md
+    - Voices Resource: reference/voices-resource.md
   - Development:
     - Local Development: tutorials/development-setup.md
     - Tool Loading Architecture: reference/tool-loading-architecture.md

--- a/tests/test_diagnostics.py
+++ b/tests/test_diagnostics.py
@@ -78,46 +78,65 @@ class TestDiagnosticTools:
 
     @pytest.mark.asyncio
     async def test_voice_registry(self):
-        """Test voice_registry returns provider information."""
-        mock_registry = {
-            "tts": {
-                "http://127.0.0.1:8880/v1": {
-                    "healthy": True,
-                    "models": ["tts-1"],
-                    "voices": ["af_sky", "am_adam"],
-                    "response_time_ms": 150.0,
-                    "last_check": "2024-01-01T12:00:00"
-                }
-            },
-            "stt": {
-                "http://127.0.0.1:2022/v1": {
-                    "healthy": True,
-                    "models": ["whisper-1"],
-                    "response_time_ms": 200.0,
-                    "last_check": "2024-01-01T12:00:00"
-                }
-            }
-        }
-        
-        with patch("voice_mode.tools.voice_registry.provider_registry") as mock_registry_instance:
-            mock_registry_instance.initialize = AsyncMock()
-            mock_registry_instance.get_registry_for_llm.return_value = mock_registry
-            
+        """Test voice_registry returns provider information.
+
+        After VM-1208 impl-003 the tool sources its voice list from the
+        shared ``enumerate_voices`` enumerator, not ``provider_registry``.
+        We patch the enumerator to return a controlled fake list; the
+        endpoint URLs come from ``TTS_BASE_URLS`` / ``STT_BASE_URLS`` via
+        config, which we also patch for hermeticity.
+        """
+        async def fake_enumerate(*, include_local_only):
+            return [
+                {
+                    "id": "kokoro:af_sky",
+                    "voice": "af_sky",
+                    "name": "af_sky",
+                    "provider": "kokoro",
+                    "language": None,
+                    "gender": None,
+                    "preview_url": None,
+                },
+                {
+                    "id": "kokoro:am_adam",
+                    "voice": "am_adam",
+                    "name": "am_adam",
+                    "provider": "kokoro",
+                    "language": None,
+                    "gender": None,
+                    "preview_url": None,
+                },
+            ]
+
+        with patch(
+            "voice_mode.tools.voice_registry.enumerate_voices",
+            side_effect=fake_enumerate,
+        ), patch(
+            "voice_mode.tools.voice_registry.TTS_BASE_URLS",
+            ["http://127.0.0.1:8880/v1"],
+        ), patch(
+            "voice_mode.tools.voice_registry.STT_BASE_URLS",
+            ["http://127.0.0.1:2022/v1"],
+        ):
             result = await voice_registry.fn()
-            
+
             # Should return formatted string
             assert isinstance(result, str)
-            
+
             # Should include TTS providers
             assert "TTS" in result or "Text-to-Speech" in result
             assert "8880" in result  # Port number
-            
+
             # Should include STT providers
             assert "STT" in result or "Speech-to-Text" in result
             assert "2022" in result  # Port number
-            
+
             # Should show health status
-            assert "healthy" in result.lower() or "✅" in result or "available" in result.lower()
+            assert "✅" in result or "healthy" in result.lower() or "available" in result.lower()
+
+            # Voices from the shared enumerator should appear in the prose
+            assert "af_sky" in result
+            assert "am_adam" in result
 
     @pytest.mark.asyncio
     async def test_check_audio_dependencies_linux(self):

--- a/tests/test_voices_enumerator.py
+++ b/tests/test_voices_enumerator.py
@@ -1,0 +1,403 @@
+"""Tests for ``voice_mode/voices.py`` — the ``enumerate_voices()`` helper.
+
+Covers AC11 cases (empty / single / multi / no-voices / unhealthy /
+cross-provider id collision / stdio-vs-remote impression filtering) plus
+the same-provider impression-vs-builtin collision that research-001's
+peer review flagged as a missing test case.
+
+``asyncio_mode = "auto"`` in ``pyproject.toml`` means async test
+functions run automatically — no ``@pytest.mark.asyncio`` needed.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import httpx
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _reset_voice_cache():
+    """Clear the in-process enumerate_voices cache between tests."""
+    from voice_mode import voices
+
+    voices._reset_cache()
+    yield
+    voices._reset_cache()
+
+
+@pytest.fixture
+def voices_mod():
+    from voice_mode import voices
+
+    return voices
+
+
+def _entry_ids(entries):
+    return [e["id"] for e in entries]
+
+
+def _fake_profile(name):
+    p = MagicMock()
+    p.name = name
+    return p
+
+
+# ---------- shape & basic enumeration --------------------------------------
+
+
+async def test_empty_tts_base_urls_no_impressions(voices_mod, monkeypatch):
+    monkeypatch.setattr(voices_mod, "TTS_BASE_URLS", [])
+    monkeypatch.setattr(voices_mod, "list_profiles", lambda: {})
+
+    result = await voices_mod.enumerate_voices(include_local_only=True)
+
+    assert result == []
+
+
+async def test_single_kokoro_provider(voices_mod, monkeypatch):
+    monkeypatch.setattr(voices_mod, "TTS_BASE_URLS", ["http://127.0.0.1:8880/v1"])
+    monkeypatch.setattr(voices_mod, "list_profiles", lambda: {})
+    monkeypatch.setattr(
+        voices_mod, "_fetch_audio_voices",
+        AsyncMock(return_value=["af_beta", "af_alpha"]),
+    )
+
+    result = await voices_mod.enumerate_voices(include_local_only=False)
+
+    assert _entry_ids(result) == ["kokoro:af_alpha", "kokoro:af_beta"]
+    for e in result:
+        assert e["provider"] == "kokoro"
+        assert e["language"] is None
+        assert e["gender"] is None
+        assert e["preview_url"] is None
+        assert e["name"] == e["voice"]
+
+
+async def test_multiple_providers_in_config_order(voices_mod, monkeypatch):
+    """TTS_BASE_URLS order is the outer order; alphabetical within each provider."""
+    monkeypatch.setattr(voices_mod, "TTS_BASE_URLS", [
+        "http://127.0.0.1:8880/v1",       # kokoro
+        "https://api.openai.com/v1",      # openai
+    ])
+    monkeypatch.setattr(voices_mod, "list_profiles", lambda: {})
+    monkeypatch.setattr(
+        voices_mod, "_fetch_audio_voices",
+        AsyncMock(return_value=["af_beta", "af_alpha"]),
+    )
+
+    result = await voices_mod.enumerate_voices(include_local_only=False)
+    ids = _entry_ids(result)
+
+    assert ids[:2] == ["kokoro:af_alpha", "kokoro:af_beta"]
+    openai_part = [i.split(":", 1)[1] for i in ids if i.startswith("openai:")]
+    assert openai_part == sorted(voices_mod.OPENAI_TTS_VOICES, key=str.casefold)
+    # Together: kokoro entries first, openai entries after.
+    assert ids.index("kokoro:af_beta") < ids.index("openai:alloy")
+
+
+async def test_provider_with_no_voices(voices_mod, monkeypatch):
+    """An empty /audio/voices response simply yields no entries for that provider."""
+    monkeypatch.setattr(voices_mod, "TTS_BASE_URLS", [
+        "http://127.0.0.1:8880/v1",
+        "https://api.openai.com/v1",
+    ])
+    monkeypatch.setattr(voices_mod, "list_profiles", lambda: {})
+    monkeypatch.setattr(
+        voices_mod, "_fetch_audio_voices",
+        AsyncMock(return_value=[]),
+    )
+
+    ids = _entry_ids(await voices_mod.enumerate_voices(include_local_only=False))
+
+    assert all(not i.startswith("kokoro:") for i in ids)
+    assert any(i.startswith("openai:") for i in ids)
+
+
+async def test_provider_unhealthy_silently_skipped(voices_mod, monkeypatch, caplog):
+    """ConnectError on one endpoint must not block the rest (AC6)."""
+    monkeypatch.setattr(voices_mod, "TTS_BASE_URLS", [
+        "http://127.0.0.1:8880/v1",
+        "https://api.openai.com/v1",
+    ])
+    monkeypatch.setattr(voices_mod, "list_profiles", lambda: {})
+    monkeypatch.setattr(
+        voices_mod, "_fetch_audio_voices",
+        AsyncMock(side_effect=httpx.ConnectError("refused")),
+    )
+
+    with caplog.at_level("WARNING", logger="voicemode"):
+        ids = _entry_ids(await voices_mod.enumerate_voices(include_local_only=False))
+
+    assert all(not i.startswith("kokoro:") for i in ids)
+    assert "openai:alloy" in ids   # openai is hardcoded, exempt from probe
+    assert any("voice probe failed" in r.message for r in caplog.records)
+
+
+async def test_id_collision_cross_provider(voices_mod, monkeypatch):
+    """Same voice name from openai and kokoro — both appear with distinct ids (AC5)."""
+    monkeypatch.setattr(voices_mod, "TTS_BASE_URLS", [
+        "https://api.openai.com/v1",
+        "http://127.0.0.1:8880/v1",
+    ])
+    monkeypatch.setattr(voices_mod, "list_profiles", lambda: {})
+    monkeypatch.setattr(
+        voices_mod, "_fetch_audio_voices",
+        AsyncMock(return_value=["nova"]),
+    )
+
+    ids = _entry_ids(await voices_mod.enumerate_voices(include_local_only=False))
+
+    assert "openai:nova" in ids
+    assert "kokoro:nova" in ids
+    assert ids.count("openai:nova") == 1
+    assert ids.count("kokoro:nova") == 1
+
+
+# ---------- impressions / include_local_only -------------------------------
+
+
+async def test_include_local_only_false_omits_impressions(voices_mod, monkeypatch):
+    """AC8: impressions hidden over remote HTTP by default."""
+    monkeypatch.setattr(voices_mod, "TTS_BASE_URLS", [])
+    monkeypatch.setattr(
+        voices_mod, "list_profiles",
+        lambda: {"samantha": _fake_profile("samantha")},
+    )
+
+    result = await voices_mod.enumerate_voices(include_local_only=False)
+
+    assert result == []
+
+
+async def test_include_local_only_true_returns_impressions(voices_mod, monkeypatch):
+    """AC8: impressions included over stdio (or env-var override)."""
+    monkeypatch.setattr(voices_mod, "TTS_BASE_URLS", [])
+    monkeypatch.setattr(
+        voices_mod, "list_profiles",
+        lambda: {
+            "samantha": _fake_profile("samantha"),
+            "marvin": _fake_profile("marvin"),
+        },
+    )
+
+    ids = _entry_ids(await voices_mod.enumerate_voices(include_local_only=True))
+
+    # Alphabetical (case-insensitive) within the voice_profiles block.
+    assert ids == ["mlx-audio:marvin", "mlx-audio:samantha"]
+
+
+async def test_same_provider_collision_impression_wins(voices_mod, monkeypatch):
+    """mlx-audio /audio/voices and impressions both expose 'samantha' (research-001 review).
+
+    Per design §6 the impression wins (richer metadata), and per §7 the
+    voice_profiles block comes after the HTTP block — so the impression
+    appears once, in the trailing position.
+    """
+    monkeypatch.setattr(voices_mod, "TTS_BASE_URLS", ["http://ms2:8890/v1"])
+    monkeypatch.setattr(
+        voices_mod, "list_profiles",
+        lambda: {"samantha": _fake_profile("samantha")},
+    )
+    monkeypatch.setattr(
+        voices_mod, "_fetch_audio_voices",
+        AsyncMock(return_value=["samantha", "yvonne"]),
+    )
+
+    ids = _entry_ids(await voices_mod.enumerate_voices(include_local_only=True))
+
+    assert ids.count("mlx-audio:samantha") == 1   # AC5: id unique within response
+    assert ids == ["mlx-audio:yvonne", "mlx-audio:samantha"]
+
+
+# ---------- cache behaviour (design §4) ------------------------------------
+
+
+async def test_cache_within_ttl_reuses_result(voices_mod, monkeypatch):
+    monkeypatch.setattr(voices_mod, "TTS_BASE_URLS", ["http://127.0.0.1:8880/v1"])
+    monkeypatch.setattr(voices_mod, "list_profiles", lambda: {})
+    fetch = AsyncMock(return_value=["af_alpha"])
+    monkeypatch.setattr(voices_mod, "_fetch_audio_voices", fetch)
+
+    a = await voices_mod.enumerate_voices(include_local_only=False)
+    b = await voices_mod.enumerate_voices(include_local_only=False)
+
+    assert _entry_ids(a) == _entry_ids(b)
+    assert fetch.await_count == 1
+
+
+async def test_cache_separates_local_only_keys(voices_mod, monkeypatch):
+    """Two cache entries — stdio caller's reply does not poison HTTP caller's reply."""
+    monkeypatch.setattr(voices_mod, "TTS_BASE_URLS", [])
+    monkeypatch.setattr(
+        voices_mod, "list_profiles",
+        lambda: {"samantha": _fake_profile("samantha")},
+    )
+
+    remote = await voices_mod.enumerate_voices(include_local_only=False)
+    local = await voices_mod.enumerate_voices(include_local_only=True)
+
+    assert remote == []
+    assert _entry_ids(local) == ["mlx-audio:samantha"]
+
+
+async def test_returned_list_is_isolated_from_cache(voices_mod, monkeypatch):
+    monkeypatch.setattr(voices_mod, "TTS_BASE_URLS", [])
+    monkeypatch.setattr(
+        voices_mod, "list_profiles",
+        lambda: {"samantha": _fake_profile("samantha")},
+    )
+
+    a = await voices_mod.enumerate_voices(include_local_only=True)
+    a.clear()
+    b = await voices_mod.enumerate_voices(include_local_only=True)
+
+    assert _entry_ids(b) == ["mlx-audio:samantha"]
+
+
+def test_reset_cache_seam(voices_mod):
+    voices_mod._cache[True] = (0.0, [{"id": "stale:x"}])
+    voices_mod._reset_cache()
+
+    assert voices_mod._cache == {}
+
+
+# ---------- failure modes (design §5) --------------------------------------
+
+
+async def test_malformed_json_logs_error_and_skips(voices_mod, monkeypatch, caplog):
+    monkeypatch.setattr(voices_mod, "TTS_BASE_URLS", ["http://127.0.0.1:8880/v1"])
+    monkeypatch.setattr(voices_mod, "list_profiles", lambda: {})
+    monkeypatch.setattr(
+        voices_mod, "_fetch_audio_voices",
+        AsyncMock(side_effect=ValueError("expected JSON object")),
+    )
+
+    with caplog.at_level("ERROR", logger="voicemode"):
+        result = await voices_mod.enumerate_voices(include_local_only=False)
+
+    assert result == []
+    assert any("malformed JSON" in r.message for r in caplog.records)
+
+
+async def test_timeout_skipped_with_warning(voices_mod, monkeypatch, caplog):
+    monkeypatch.setattr(voices_mod, "TTS_BASE_URLS", ["http://127.0.0.1:8880/v1"])
+    monkeypatch.setattr(voices_mod, "list_profiles", lambda: {})
+    monkeypatch.setattr(
+        voices_mod, "_fetch_audio_voices",
+        AsyncMock(side_effect=httpx.ReadTimeout("slow")),
+    )
+
+    with caplog.at_level("WARNING", logger="voicemode"):
+        result = await voices_mod.enumerate_voices(include_local_only=False)
+
+    assert result == []
+    assert any("timeout" in r.message.lower() for r in caplog.records)
+
+
+async def test_http_status_error_skipped_with_warning(voices_mod, monkeypatch, caplog):
+    monkeypatch.setattr(voices_mod, "TTS_BASE_URLS", ["http://127.0.0.1:8880/v1"])
+    monkeypatch.setattr(voices_mod, "list_profiles", lambda: {})
+    request = httpx.Request("GET", "http://127.0.0.1:8880/v1/audio/voices")
+    response = httpx.Response(503, request=request)
+    monkeypatch.setattr(
+        voices_mod, "_fetch_audio_voices",
+        AsyncMock(side_effect=httpx.HTTPStatusError(
+            "503", request=request, response=response,
+        )),
+    )
+
+    with caplog.at_level("WARNING", logger="voicemode"):
+        result = await voices_mod.enumerate_voices(include_local_only=False)
+
+    assert result == []
+    assert any("HTTP 503" in r.message for r in caplog.records)
+
+
+async def test_whisper_endpoint_skipped_without_probe(voices_mod, monkeypatch):
+    """detect_provider_type returns 'whisper' for ':2022' URLs — STT-only, no probe."""
+    monkeypatch.setattr(voices_mod, "TTS_BASE_URLS", [
+        "http://127.0.0.1:2022/v1",
+        "https://api.openai.com/v1",
+    ])
+    monkeypatch.setattr(voices_mod, "list_profiles", lambda: {})
+    fetch = AsyncMock(side_effect=AssertionError("whisper must not be probed"))
+    monkeypatch.setattr(voices_mod, "_fetch_audio_voices", fetch)
+
+    ids = _entry_ids(await voices_mod.enumerate_voices(include_local_only=False))
+
+    assert all(not i.startswith("whisper:") for i in ids)
+    assert "openai:alloy" in ids
+
+
+async def test_list_profiles_failure_does_not_break_enumeration(
+    voices_mod, monkeypatch, caplog,
+):
+    def boom():
+        raise RuntimeError("voice_profiles broke")
+    monkeypatch.setattr(voices_mod, "TTS_BASE_URLS", [])
+    monkeypatch.setattr(voices_mod, "list_profiles", boom)
+
+    with caplog.at_level("ERROR", logger="voicemode"):
+        result = await voices_mod.enumerate_voices(include_local_only=True)
+
+    assert result == []
+    assert any("list_profiles" in r.message for r in caplog.records)
+
+
+# ---------- _fetch_audio_voices parsing ------------------------------------
+
+
+class _FakeResponse:
+    def __init__(self, payload):
+        self._payload = payload
+
+    def raise_for_status(self):
+        return None
+
+    def json(self):
+        return self._payload
+
+
+class _FakeAsyncClient:
+    def __init__(self, payload, **_kwargs):
+        self._payload = payload
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *_a):
+        return None
+
+    async def get(self, _url):
+        return _FakeResponse(self._payload)
+
+
+def _patch_async_client(monkeypatch, voices_mod, payload):
+    def factory(**kwargs):
+        return _FakeAsyncClient(payload, **kwargs)
+    monkeypatch.setattr(voices_mod.httpx, "AsyncClient", factory)
+
+
+async def test_fetch_audio_voices_parses_dict_voices_form(voices_mod, monkeypatch):
+    _patch_async_client(monkeypatch, voices_mod, {"voices": ["alpha", {"id": "beta"}]})
+
+    out = await voices_mod._fetch_audio_voices("http://x/v1")
+
+    assert out == ["alpha", "beta"]
+
+
+async def test_fetch_audio_voices_parses_bare_list_form(voices_mod, monkeypatch):
+    _patch_async_client(monkeypatch, voices_mod, ["alpha", "beta"])
+
+    out = await voices_mod._fetch_audio_voices("http://x/v1")
+
+    assert out == ["alpha", "beta"]
+
+
+async def test_fetch_audio_voices_rejects_unexpected_shape(voices_mod, monkeypatch):
+    _patch_async_client(monkeypatch, voices_mod, 42)
+
+    with pytest.raises(ValueError):
+        await voices_mod._fetch_audio_voices("http://x/v1")

--- a/tests/test_voices_resource.py
+++ b/tests/test_voices_resource.py
@@ -1,0 +1,324 @@
+"""Tests for ``voice_mode/resources/voices.py``.
+
+Covers the privacy filter (``_is_local_request`` — every branch of the
+spike-002 hardened spec) and the two resource handlers
+(``voice://voices`` and ``voice://voices/{provider}``).
+
+``asyncio_mode = "auto"`` in pyproject means async test functions run
+without an explicit decorator.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from unittest.mock import MagicMock
+
+import pytest
+
+from voice_mode.resources.voices import (
+    _is_local_request,
+    list_voices,
+    list_voices_for_provider,
+)
+
+
+# ---------- _is_local_request: every branch of the hardened spec -----------
+
+
+@pytest.fixture
+def clean_env(monkeypatch):
+    """Drop the override env var so each test sets it deliberately."""
+    monkeypatch.delenv("VOICEMODE_EXPOSE_LOCAL_VOICES_REMOTE", raising=False)
+    return monkeypatch
+
+
+def _patch_request(monkeypatch, request_obj):
+    """Make ``get_http_request()`` return ``request_obj``."""
+    monkeypatch.setattr(
+        "voice_mode.resources.voices.get_http_request",
+        lambda: request_obj,
+    )
+
+
+def _patch_no_request(monkeypatch):
+    """Make ``get_http_request()`` raise — emulating stdio / in-memory."""
+    def _raise():
+        raise RuntimeError("No active HTTP request found.")
+    monkeypatch.setattr("voice_mode.resources.voices.get_http_request", _raise)
+
+
+def test_stdio_no_http_context_is_local(clean_env):
+    _patch_no_request(clean_env)
+
+    assert _is_local_request() is True
+
+
+def test_http_loopback_ipv4_is_local(clean_env):
+    req = MagicMock()
+    req.client.host = "127.0.0.1"
+    _patch_request(clean_env, req)
+
+    assert _is_local_request() is True
+
+
+def test_http_loopback_ipv6_is_local(clean_env):
+    req = MagicMock()
+    req.client.host = "::1"
+    _patch_request(clean_env, req)
+
+    assert _is_local_request() is True
+
+
+def test_http_ipv4_mapped_ipv6_loopback_is_local(clean_env):
+    """IPv4-mapped IPv6 loopback (``::ffff:127.0.0.1``) — verified in spike-002."""
+    req = MagicMock()
+    req.client.host = "::ffff:127.0.0.1"
+    _patch_request(clean_env, req)
+
+    assert _is_local_request() is True
+
+
+def test_http_public_peer_is_remote(clean_env):
+    req = MagicMock()
+    req.client.host = "8.8.8.8"
+    _patch_request(clean_env, req)
+
+    assert _is_local_request() is False
+
+
+def test_http_lan_peer_is_remote(clean_env):
+    req = MagicMock()
+    req.client.host = "192.168.1.42"
+    _patch_request(clean_env, req)
+
+    assert _is_local_request() is False
+
+
+def test_env_override_forces_local_over_remote_peer(monkeypatch):
+    """``VOICEMODE_EXPOSE_LOCAL_VOICES_REMOTE=true`` short-circuits to local."""
+    req = MagicMock()
+    req.client.host = "8.8.8.8"
+    _patch_request(monkeypatch, req)
+    monkeypatch.setenv("VOICEMODE_EXPOSE_LOCAL_VOICES_REMOTE", "true")
+
+    assert _is_local_request() is True
+
+
+@pytest.mark.parametrize("value", ["1", "yes", "on", "TRUE", "  YES  "])
+def test_env_override_accepts_truthy_variants(monkeypatch, value):
+    _patch_no_request(monkeypatch)
+    monkeypatch.setenv("VOICEMODE_EXPOSE_LOCAL_VOICES_REMOTE", value)
+
+    assert _is_local_request() is True
+
+
+@pytest.mark.parametrize("value", ["false", "0", "no", "off", ""])
+def test_env_override_falsy_does_not_force_local(monkeypatch, value):
+    """Falsy values fall through to the normal detection path."""
+    req = MagicMock()
+    req.client.host = "8.8.8.8"
+    _patch_request(monkeypatch, req)
+    monkeypatch.setenv("VOICEMODE_EXPOSE_LOCAL_VOICES_REMOTE", value)
+
+    assert _is_local_request() is False
+
+
+def test_none_client_is_remote(clean_env):
+    """spike-002 hardening: missing ``request.client`` → safe-default remote."""
+    req = MagicMock()
+    req.client = None
+    _patch_request(clean_env, req)
+
+    assert _is_local_request() is False
+
+
+def test_empty_host_is_remote_not_crash(clean_env):
+    """spike-002 hardening: empty host string must NOT raise (UDS / proxy)."""
+    req = MagicMock()
+    req.client.host = ""
+    _patch_request(clean_env, req)
+
+    assert _is_local_request() is False
+
+
+def test_unparseable_host_is_remote_not_crash(clean_env):
+    """spike-002 hardening: malformed peer host must NOT raise."""
+    req = MagicMock()
+    req.client.host = "not-an-ip"
+    _patch_request(clean_env, req)
+
+    assert _is_local_request() is False
+
+
+# ---------- voice://voices envelope ---------------------------------------
+
+
+def _make_voice(provider, voice):
+    return {
+        "id": f"{provider}:{voice}",
+        "voice": voice,
+        "name": voice,
+        "provider": provider,
+        "language": None,
+        "gender": None,
+        "preview_url": None,
+    }
+
+
+@pytest.fixture
+def patched_enum(monkeypatch):
+    """Replace ``enumerate_voices`` with a controllable async fake.
+
+    Records the ``include_local_only`` value passed in so tests can
+    assert on the privacy decision.
+    """
+    calls = []
+    fake_voices = {
+        True: [
+            _make_voice("openai", "alloy"),
+            _make_voice("kokoro", "af_alpha"),
+            _make_voice("mlx-audio", "samantha"),  # impression
+        ],
+        False: [
+            _make_voice("openai", "alloy"),
+            _make_voice("kokoro", "af_alpha"),
+        ],
+    }
+
+    async def fake_enum(*, include_local_only):
+        calls.append(include_local_only)
+        return list(fake_voices[include_local_only])
+
+    monkeypatch.setattr("voice_mode.resources.voices.enumerate_voices", fake_enum)
+    return calls
+
+
+async def test_list_voices_returns_locked_envelope(patched_enum, clean_env):
+    _patch_no_request(clean_env)   # stdio context → local
+
+    body = await list_voices.fn()
+
+    assert body["schema_version"] == 1
+    assert isinstance(body["generated_at"], str)
+    # generated_at parses as ISO 8601 (use the same Z→+00:00 swap).
+    parsed = datetime.fromisoformat(body["generated_at"].replace("Z", "+00:00"))
+    assert parsed.tzinfo is not None
+    assert isinstance(body["voices"], list)
+    assert all({"id", "voice", "name", "provider", "language", "gender", "preview_url"} <= v.keys() for v in body["voices"])
+
+
+async def test_list_voices_stdio_includes_impressions(patched_enum, clean_env):
+    _patch_no_request(clean_env)
+
+    body = await list_voices.fn()
+
+    assert patched_enum == [True]   # stdio → include_local_only=True
+    assert any(v["provider"] == "mlx-audio" for v in body["voices"])
+
+
+async def test_list_voices_remote_omits_impressions(patched_enum, clean_env):
+    """Non-loopback HTTP peer → enumerator called with include_local_only=False."""
+    req = MagicMock()
+    req.client.host = "203.0.113.7"
+    _patch_request(clean_env, req)
+
+    body = await list_voices.fn()
+
+    assert patched_enum == [False]
+    assert all(v["provider"] != "mlx-audio" for v in body["voices"])
+
+
+async def test_list_voices_loopback_includes_impressions(patched_enum, clean_env):
+    req = MagicMock()
+    req.client.host = "127.0.0.1"
+    _patch_request(clean_env, req)
+
+    body = await list_voices.fn()
+
+    assert patched_enum == [True]
+    assert any(v["provider"] == "mlx-audio" for v in body["voices"])
+
+
+async def test_list_voices_env_override_forces_impressions_over_remote(
+    patched_enum, monkeypatch,
+):
+    req = MagicMock()
+    req.client.host = "203.0.113.7"
+    _patch_request(monkeypatch, req)
+    monkeypatch.setenv("VOICEMODE_EXPOSE_LOCAL_VOICES_REMOTE", "true")
+
+    body = await list_voices.fn()
+
+    assert patched_enum == [True]
+    assert any(v["provider"] == "mlx-audio" for v in body["voices"])
+
+
+async def test_list_voices_response_carries_no_raw_urls(patched_enum, clean_env):
+    """AC4: no ``http://`` / ``https://`` substrings anywhere in the body."""
+    _patch_no_request(clean_env)
+
+    body = await list_voices.fn()
+
+    import json
+    serialized = json.dumps(body)
+    assert "http://" not in serialized
+    assert "https://" not in serialized
+
+
+# ---------- voice://voices/{provider} filter ------------------------------
+
+
+async def test_per_provider_filter_returns_only_matching(patched_enum, clean_env):
+    _patch_no_request(clean_env)
+
+    body = await list_voices_for_provider.fn(provider="openai")
+
+    assert body["schema_version"] == 1
+    assert all(v["provider"] == "openai" for v in body["voices"])
+    assert len(body["voices"]) == 1
+
+
+async def test_per_provider_filter_empty_for_unknown_provider(patched_enum, clean_env):
+    _patch_no_request(clean_env)
+
+    body = await list_voices_for_provider.fn(provider="never-heard-of-it")
+
+    assert body["voices"] == []
+    assert body["schema_version"] == 1
+
+
+async def test_per_provider_filter_respects_privacy(patched_enum, clean_env):
+    """Asking ``/mlx-audio`` from a remote peer returns no impressions."""
+    req = MagicMock()
+    req.client.host = "203.0.113.7"
+    _patch_request(clean_env, req)
+
+    body = await list_voices_for_provider.fn(provider="mlx-audio")
+
+    # patched_enum returns no mlx-audio voices when include_local_only=False,
+    # so the per-provider filter yields nothing.
+    assert patched_enum == [False]
+    assert body["voices"] == []
+
+
+async def test_per_provider_envelope_matches_unfiltered(patched_enum, clean_env):
+    """Per-provider response carries the same envelope keys as the unfiltered one."""
+    _patch_no_request(clean_env)
+
+    full = await list_voices.fn()
+    one = await list_voices_for_provider.fn(provider="kokoro")
+
+    assert set(full.keys()) == set(one.keys())
+    assert full["schema_version"] == one["schema_version"]
+
+
+# ---------- registration sanity check -------------------------------------
+
+
+def test_resources_register_with_expected_uris():
+    """Both resources are loaded into the FastMCP instance with mime_type=json."""
+    # The resource objects expose .uri / .mime_type attributes once registered.
+    assert str(list_voices.uri) == "voice://voices"
+    assert list_voices.mime_type == "application/json"
+    assert "voice://voices/{provider}" in str(list_voices_for_provider.uri_template)
+    assert list_voices_for_provider.mime_type == "application/json"

--- a/tests/test_voices_resource_http.py
+++ b/tests/test_voices_resource_http.py
@@ -1,0 +1,290 @@
+"""Integration tests for ``voice://voices`` over real streamable HTTP.
+
+The in-memory tests in ``test_voices_resource.py`` exercise the resource
+handlers directly via ``FastMCPTransport``. This file goes one step
+further: a real ``uvicorn`` server hosts the production
+``voice_mode.server.mcp`` instance on a free loopback port, and a
+``fastmcp.Client`` connects over ``StreamableHttpTransport`` — the same
+wire path an iOS app or web client would use.
+
+VM-1208 test-002 step-by-step coverage:
+
+1. ``voicemode serve --transport http`` (in fixture) — uvicorn-on-free-port,
+   pattern from ``harness/spike-002/spike2_peer_address.py`` lifted to the
+   production ``mcp`` instance.
+2. Test MCP client — ``fastmcp.Client(StreamableHttpTransport(url))``.
+3. ``resources/list`` includes ``voice://voices`` —
+   ``test_resources_list_includes_voice_voices_over_http``.
+4. ``resources/read voice://voices`` returns schema-shaped JSON —
+   ``test_read_voice_voices_returns_locked_envelope_over_http``.
+5. No raw URLs in the body —
+   ``test_read_voice_voices_no_raw_urls_in_body``.
+6. stdio vs streamable HTTP parity (modulo ``generated_at``) —
+   ``test_stdio_and_http_bodies_match_modulo_generated_at``.
+
+The enumerator is monkey-patched to a deterministic list — this isolates
+the test from whether kokoro/mlx-audio happen to be running on the dev
+box. The privacy filter ``_is_local_request`` runs naturally because we
+are hitting the resource through real HTTP (loopback peer ⇒ local).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import socket
+import threading
+import time
+from typing import Any
+
+import pytest
+import uvicorn
+from fastmcp.client import Client
+from fastmcp.client.transports import FastMCPTransport, StreamableHttpTransport
+
+
+# ---------- deterministic enumerator -------------------------------------
+
+
+_FAKE_VOICES_LOCAL: list[dict[str, Any]] = [
+    {
+        "id": "openai:alloy",
+        "voice": "alloy",
+        "name": "alloy",
+        "provider": "openai",
+        "language": None,
+        "gender": None,
+        "preview_url": None,
+    },
+    {
+        "id": "kokoro:af_river",
+        "voice": "af_river",
+        "name": "af_river",
+        "provider": "kokoro",
+        "language": None,
+        "gender": None,
+        "preview_url": None,
+    },
+    {
+        "id": "mlx-audio:samantha",
+        "voice": "samantha",
+        "name": "samantha",
+        "provider": "mlx-audio",
+        "language": None,
+        "gender": None,
+        "preview_url": None,
+    },
+]
+
+
+async def _fake_enumerate(*, include_local_only: bool) -> list[dict[str, Any]]:
+    """Deterministic stand-in for ``enumerate_voices``.
+
+    Returns the same list whether called locally or remotely so that the
+    AC3 parity check (stdio vs HTTP) compares apples to apples. The
+    privacy decision is made by ``_is_local_request`` upstream — both
+    transports here are local (in-memory and loopback HTTP), so we
+    expect ``include_local_only=True`` from each.
+    """
+    return [dict(v) for v in _FAKE_VOICES_LOCAL]
+
+
+@pytest.fixture
+def patched_enum(monkeypatch):
+    """Patch the resource module's ``enumerate_voices`` for the test."""
+    monkeypatch.setattr(
+        "voice_mode.resources.voices.enumerate_voices",
+        _fake_enumerate,
+    )
+
+
+# ---------- uvicorn fixture ----------------------------------------------
+
+
+def _free_port() -> int:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        s.bind(("127.0.0.1", 0))
+        return s.getsockname()[1]
+
+
+def _wait_for_socket(host: str, port: int, timeout: float = 10.0) -> None:
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        try:
+            with socket.create_connection((host, port), timeout=0.2):
+                return
+        except OSError:
+            time.sleep(0.05)
+    raise RuntimeError(f"uvicorn did not start on {host}:{port} within {timeout}s")
+
+
+@pytest.fixture
+def http_server_url():
+    """Spin uvicorn over the production ``mcp`` instance on a free port.
+
+    Pattern lifted from ``harness/spike-002/spike2_peer_address.py``: a
+    daemon thread runs ``asyncio.run(server.serve())``; the fixture
+    waits for the listening socket then yields the MCP URL. Teardown
+    asks uvicorn to exit and joins the thread.
+    """
+    from voice_mode.server import mcp
+
+    host, port = "127.0.0.1", _free_port()
+    app = mcp.http_app(path="/mcp")
+    config = uvicorn.Config(
+        app,
+        host=host,
+        port=port,
+        log_level="warning",
+        lifespan="on",
+    )
+    server = uvicorn.Server(config)
+
+    thread = threading.Thread(target=lambda: asyncio.run(server.serve()), daemon=True)
+    thread.start()
+    try:
+        _wait_for_socket(host, port)
+        yield f"http://{host}:{port}/mcp"
+    finally:
+        server.should_exit = True
+        thread.join(timeout=5.0)
+
+
+# ---------- helpers -------------------------------------------------------
+
+
+async def _read_voice_voices(client: Client) -> tuple[str, dict[str, Any]]:
+    """Read ``voice://voices`` and return ``(raw_text, parsed_dict)``."""
+    blocks = await client.read_resource("voice://voices")
+    text = getattr(blocks[0], "text", None)
+    assert isinstance(text, str), f"expected text content block, got {blocks!r}"
+    return text, json.loads(text)
+
+
+# ---------- step 3: resources/list ---------------------------------------
+
+
+async def test_resources_list_includes_voice_voices_over_http(
+    patched_enum, http_server_url
+):
+    """test-002 step 3: ``voice://voices`` appears in ``resources/list``."""
+    transport = StreamableHttpTransport(url=http_server_url)
+    async with Client(transport=transport) as client:
+        resources = await client.list_resources()
+        templates = await client.list_resource_templates()
+
+    matches = [r for r in resources if str(r.uri) == "voice://voices"]
+    assert len(matches) == 1, f"expected exactly one voice://voices, got {matches!r}"
+    assert matches[0].mimeType == "application/json"
+
+    template_uris = {getattr(t, "uriTemplate", None) for t in templates}
+    assert "voice://voices/{provider}" in template_uris
+
+
+# ---------- step 4: resources/read schema --------------------------------
+
+
+async def test_read_voice_voices_returns_locked_envelope_over_http(
+    patched_enum, http_server_url
+):
+    """test-002 step 4: the body matches the locked v1 schema."""
+    from datetime import datetime
+
+    transport = StreamableHttpTransport(url=http_server_url)
+    async with Client(transport=transport) as client:
+        _raw, body = await _read_voice_voices(client)
+
+    assert body["schema_version"] == 1
+
+    # generated_at parses as ISO 8601 with timezone.
+    parsed = datetime.fromisoformat(body["generated_at"].replace("Z", "+00:00"))
+    assert parsed.tzinfo is not None
+
+    assert isinstance(body["voices"], list)
+    expected_keys = {"id", "voice", "name", "provider", "language", "gender", "preview_url"}
+    for entry in body["voices"]:
+        assert expected_keys <= set(entry.keys()), entry
+
+
+# ---------- step 5: no raw URLs ------------------------------------------
+
+
+async def test_read_voice_voices_no_raw_urls_in_body(
+    patched_enum, http_server_url
+):
+    """test-002 step 5 / AC4: no ``http://`` or ``https://`` in the body."""
+    transport = StreamableHttpTransport(url=http_server_url)
+    async with Client(transport=transport) as client:
+        raw_text, _body = await _read_voice_voices(client)
+
+    assert "http://" not in raw_text
+    assert "https://" not in raw_text
+
+
+# ---------- step 6: stdio vs HTTP parity ---------------------------------
+
+
+def _strip_generated_at(body: dict[str, Any]) -> dict[str, Any]:
+    body = dict(body)
+    body.pop("generated_at", None)
+    return body
+
+
+async def test_stdio_and_http_bodies_match_modulo_generated_at(
+    patched_enum, http_server_url
+):
+    """test-002 step 6 / AC3: stdio and HTTP bodies are identical except
+    for ``generated_at``.
+
+    "stdio" is approximated by the in-memory ``FastMCPTransport`` against
+    the same ``mcp`` instance (no HTTP request → ``_is_local_request``
+    returns True via the ``RuntimeError`` branch — same outcome as a
+    real stdio server). The HTTP side connects from loopback, which the
+    privacy predicate also classifies as local. With the deterministic
+    enumerator both paths produce the same voice list, so any diff
+    outside ``generated_at`` indicates a transport-level bug.
+    """
+    from voice_mode.server import mcp
+
+    in_memory = FastMCPTransport(mcp=mcp)
+    async with Client(transport=in_memory) as client:
+        _stdio_raw, stdio_body = await _read_voice_voices(client)
+
+    transport = StreamableHttpTransport(url=http_server_url)
+    async with Client(transport=transport) as client:
+        _http_raw, http_body = await _read_voice_voices(client)
+
+    # Sort keys before comparing so dict ordering can never trip us up,
+    # then strip the timestamp the schema explicitly excludes.
+    stdio_canonical = json.dumps(
+        _strip_generated_at(stdio_body), sort_keys=True
+    )
+    http_canonical = json.dumps(
+        _strip_generated_at(http_body), sort_keys=True
+    )
+    assert stdio_canonical == http_canonical
+
+
+# ---------- AC8 spot-check: loopback is local ----------------------------
+
+
+async def test_loopback_caller_treated_as_local(
+    patched_enum, http_server_url
+):
+    """AC8 spot-check: peer 127.0.0.1 ⇒ caller treated as local, so the
+    impression in the fake enumerator output appears in the response.
+
+    This is the privacy predicate exercised end-to-end through real
+    HTTP — the whole point of the integration test. With ``_is_local_request``
+    returning True for a loopback peer, the response carries every voice
+    in ``_FAKE_VOICES_LOCAL``, including the ``mlx-audio`` impression.
+    """
+    transport = StreamableHttpTransport(url=http_server_url)
+    async with Client(transport=transport) as client:
+        _raw, body = await _read_voice_voices(client)
+
+    providers = {v["provider"] for v in body["voices"]}
+    assert "mlx-audio" in providers, (
+        "loopback caller should see impressions; got providers="
+        f"{providers!r}"
+    )

--- a/voice_mode/resources/voices.py
+++ b/voice_mode/resources/voices.py
@@ -57,9 +57,16 @@ def _is_local_request() -> bool:
     if client is None or not client.host:
         return False
     try:
-        return ipaddress.ip_address(client.host).is_loopback
+        ip = ipaddress.ip_address(client.host)
     except ValueError:
         return False
+    if ip.is_loopback:
+        return True
+    # Python < 3.12's IPv6Address.is_loopback does not unwrap IPv4-mapped
+    # addresses, so ::ffff:127.0.0.1 reads as non-loopback. Check the mapped
+    # IPv4 explicitly for cross-version parity.
+    mapped = getattr(ip, "ipv4_mapped", None)
+    return mapped is not None and mapped.is_loopback
 
 
 def _now_iso() -> str:

--- a/voice_mode/resources/voices.py
+++ b/voice_mode/resources/voices.py
@@ -1,0 +1,105 @@
+"""MCP resources for voice discovery.
+
+Exposes two resources:
+
+* ``voice://voices`` — full list of TTS voices the server can produce.
+* ``voice://voices/{provider}`` — same envelope, filtered to entries
+  whose ``provider`` matches the path segment.
+
+Both return ``application/json``. The body is
+``{schema_version, generated_at, voices[]}`` per the locked v1 schema in
+the task README. Impressions/clones are local-only and only appear when
+the caller is local — see ``_is_local_request``.
+
+Design references: ``design.md`` §11 (privacy), §12 (AC cross-check);
+``harness/progress.json`` ``decisions.spike-001`` (mime_type) and
+``decisions.spike-002`` (peer-address introspection + hardened predicate).
+"""
+
+from __future__ import annotations
+
+import ipaddress
+import os
+from datetime import datetime, timezone
+from typing import Any
+
+from fastmcp.server.dependencies import get_http_request
+
+from ..server import mcp
+from ..voices import enumerate_voices
+
+_SCHEMA_VERSION = 1
+_TRUE_VALUES = frozenset({"1", "true", "yes", "on"})
+
+
+def _is_local_request() -> bool:
+    """Should this caller see local-only voices (impressions/clones)?
+
+    Resolution order, hardened per spike-002 review:
+
+    1. ``VOICEMODE_EXPOSE_LOCAL_VOICES_REMOTE`` truthy → True.
+    2. No active HTTP request (stdio / in-memory transport) → True.
+    3. HTTP request with a loopback peer (127/8, ::1, IPv4-mapped
+       loopback) → True.
+    4. Anything else — None client, empty host, unparseable IP, or a
+       public peer — → False (safe default: treat as remote).
+    """
+    override = os.environ.get("VOICEMODE_EXPOSE_LOCAL_VOICES_REMOTE", "")
+    if override.strip().lower() in _TRUE_VALUES:
+        return True
+
+    try:
+        req = get_http_request()
+    except RuntimeError:
+        return True
+
+    client = req.client
+    if client is None or not client.host:
+        return False
+    try:
+        return ipaddress.ip_address(client.host).is_loopback
+    except ValueError:
+        return False
+
+
+def _now_iso() -> str:
+    """ISO 8601 UTC timestamp with the ``Z`` suffix."""
+    return (
+        datetime.now(timezone.utc)
+        .isoformat(timespec="seconds")
+        .replace("+00:00", "Z")
+    )
+
+
+async def _build_response() -> dict[str, Any]:
+    voices = await enumerate_voices(include_local_only=_is_local_request())
+    return {
+        "schema_version": _SCHEMA_VERSION,
+        "generated_at": _now_iso(),
+        "voices": voices,
+    }
+
+
+@mcp.resource("voice://voices", mime_type="application/json")
+async def list_voices() -> dict[str, Any]:
+    """JSON list of TTS voices the server can produce.
+
+    Envelope: ``{schema_version, generated_at, voices[]}``. Each entry
+    has ``id`` (``{provider}:{voice}``), ``voice``, ``name``, ``provider``,
+    ``language``, ``gender``, ``preview_url``. Impressions/clones are
+    included only when the caller is local.
+    """
+    return await _build_response()
+
+
+@mcp.resource("voice://voices/{provider}", mime_type="application/json")
+async def list_voices_for_provider(provider: str) -> dict[str, Any]:
+    """Same envelope as ``voice://voices``, filtered to one provider.
+
+    Filters ``voices[]`` to entries with ``provider == {provider}``. An
+    unknown provider yields an empty ``voices`` list — the envelope is
+    well-formed either way.
+    """
+    body = await _build_response()
+    body["voices"] = [v for v in body["voices"] if v.get("provider") == provider]
+    return body

--- a/voice_mode/tools/voice_registry.py
+++ b/voice_mode/tools/voice_registry.py
@@ -1,7 +1,40 @@
-"""Voice provider registry tool for displaying available voice services."""
+"""Voice provider registry tool -- prose listing for the LLM converse loop.
 
+Refactored on 2026-05-10 (VM-1208 impl-003) to source the voice list
+from the shared ``enumerate_voices`` helper instead of the dormant
+``provider_registry``. Per-endpoint diagnostics (URL, status emoji,
+provider type, model defaults) are synthesised inline so the prose
+format stays identical to the prior implementation while the data
+source is now live and shared with the ``voice://voices`` MCP resource.
+
+See ``design.md`` §9 for the rationale (option (a): ignore
+``provider_registry`` entirely here; full retirement is VM-1214's job)
+and §12 for the AC9 contract.
+
+This module no longer imports ``provider_discovery``; ``detect_provider_type``
+is reached via ``voice_mode.voices`` (the new home of the URL-classification
+utility for tool-tier consumers), so leaving ``provider_registry`` truly
+unused in this code path is a one-grep audit.
+"""
+
+from voice_mode.config import STT_BASE_URLS, TTS_BASE_URLS
 from voice_mode.server import mcp
-from voice_mode.provider_discovery import provider_registry
+from voice_mode.voices import detect_provider_type, enumerate_voices
+
+
+def _default_tts_models(provider: str) -> list[str]:
+    if provider == "openai":
+        return ["gpt4o-mini-tts", "tts-1", "tts-1-hd"]
+    return ["tts-1"]
+
+
+def _default_stt_models(provider: str) -> list[str]:
+    # mlx-audio rejects "whisper-1" (it expects a full HF repo id), so
+    # advertise its websocket default instead. Mirrors the legacy
+    # provider_discovery._default_stt_models seeding behaviour.
+    if provider == "mlx-audio":
+        return ["mlx-community/whisper-large-v3-turbo"]
+    return ["whisper-1"]
 
 
 @mcp.tool()
@@ -17,46 +50,56 @@ async def voice_registry() -> str:
 
     This allows the LLM to see what voice services are currently available.
     """
-    # Ensure registry is initialized
-    await provider_registry.initialize()
-    
-    # Get registry data
-    registry_data = provider_registry.get_registry_for_llm()
-    
-    # Format the output
+    # Voice list comes from the shared enumerator -- same source as voice://voices.
+    # include_local_only=False keeps impressions out of the prose, matching this
+    # tool's prior behaviour (the tool never surfaced clones).
+    enumerated = await enumerate_voices(include_local_only=False)
+    voices_by_provider: dict[str, list[str]] = {}
+    for entry in enumerated:
+        voices_by_provider.setdefault(entry["provider"], []).append(entry["voice"])
+
     lines = ["Voice Provider Registry", "=" * 50, ""]
-    
+
     # TTS Endpoints
     lines.append("TTS Endpoints:")
     lines.append("-" * 30)
-    
-    for url, info in registry_data["tts"].items():
-        status = "❌" if info.get("last_error") else "✅"
+
+    for url in TTS_BASE_URLS:
+        provider = detect_provider_type(url)
+        models = _default_tts_models(provider)
+        voices = voices_by_provider.get(provider, [])
+        last_error = None
+        last_check = None
+        status = "❌" if last_error else "✅"
         lines.append(f"\n{status} {url}")
-        lines.append(f"   Provider: {info.get('provider_type', 'unknown')}")
-        lines.append(f"   Models: {', '.join(info['models']) if info['models'] else 'none detected'}")
-        lines.append(f"   Voices: {', '.join(info['voices']) if info['voices'] else 'none detected'}")
+        lines.append(f"   Provider: {provider}")
+        lines.append(f"   Models: {', '.join(models) if models else 'none detected'}")
+        lines.append(f"   Voices: {', '.join(voices) if voices else 'none detected'}")
 
-        if info.get("last_error"):
-            lines.append(f"   Last Error: {info['last_error']}")
+        if last_error:
+            lines.append(f"   Last Error: {last_error}")
 
-        if info.get('last_check'):
-            lines.append(f"   Last Check: {info['last_check']}")
-    
+        if last_check:
+            lines.append(f"   Last Check: {last_check}")
+
     # STT Endpoints
     lines.append("\n\nSTT Endpoints:")
     lines.append("-" * 30)
-    
-    for url, info in registry_data["stt"].items():
-        status = "❌" if info.get("last_error") else "✅"
+
+    for url in STT_BASE_URLS:
+        provider = detect_provider_type(url)
+        models = _default_stt_models(provider)
+        last_error = None
+        last_check = None
+        status = "❌" if last_error else "✅"
         lines.append(f"\n{status} {url}")
-        lines.append(f"   Provider: {info.get('provider_type', 'unknown')}")
-        lines.append(f"   Models: {', '.join(info['models']) if info['models'] else 'none detected'}")
+        lines.append(f"   Provider: {provider}")
+        lines.append(f"   Models: {', '.join(models) if models else 'none detected'}")
 
-        if info.get("last_error"):
-            lines.append(f"   Last Error: {info['last_error']}")
+        if last_error:
+            lines.append(f"   Last Error: {last_error}")
 
-        if info.get('last_check'):
-            lines.append(f"   Last Check: {info['last_check']}")
-    
+        if last_check:
+            lines.append(f"   Last Check: {last_check}")
+
     return "\n".join(lines)

--- a/voice_mode/voices.py
+++ b/voice_mode/voices.py
@@ -1,0 +1,194 @@
+"""Voice enumeration for the ``voice://voices`` MCP resource.
+
+Single source of truth for the TTS voices VoiceMode advertises. The
+resource handler (``voice_mode/resources/voices.py``) and the
+``voice_registry`` tool both call ``enumerate_voices`` so the prose tool
+and the JSON resource never drift on the actual voice list.
+
+See ``design.md`` at the task root for the full design rationale —
+sources (§3), freshness (§4), failure semantics (§5), dedup rule (§6),
+ordering (§7).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import time
+from typing import Any
+
+import httpx
+
+from .config import TTS_BASE_URLS
+from .provider_discovery import detect_provider_type
+from .voice_profiles import list_profiles
+
+logger = logging.getLogger("voicemode")
+
+# OpenAI TTS voices. Source: https://platform.openai.com/docs/guides/text-to-speech
+# OpenAI does NOT expose /audio/voices, so this list is hand-maintained.
+# Last verified: 2026-05-10. Update when OpenAI ships a new voice.
+OPENAI_TTS_VOICES = (
+    "alloy", "ash", "coral", "echo", "fable",
+    "nova", "onyx", "sage", "shimmer",
+)
+
+_PROBE_TIMEOUT = 5.0
+_CACHE_TTL = 60.0
+_IMPRESSION_PROVIDER = "mlx-audio"
+
+# Cache keyed by include_local_only → (monotonic timestamp, voice list).
+_cache: dict[bool, tuple[float, list[dict[str, Any]]]] = {}
+
+
+def _make_entry(provider: str, voice: str) -> dict[str, Any]:
+    """Build a voice entry matching the locked v1 schema."""
+    return {
+        "id": f"{provider}:{voice}",
+        "voice": voice,
+        "name": voice,
+        "provider": provider,
+        "language": None,
+        "gender": None,
+        "preview_url": None,
+    }
+
+
+async def _fetch_audio_voices(url: str) -> list[str]:
+    """``GET {url}/audio/voices`` and extract voice names.
+
+    Accepts both response shapes seen in the wild: a bare ``[...]`` list
+    and a ``{"voices": [...]}`` wrapper. List items may be plain strings
+    or ``{"id": ...}`` objects. Malformed individual items are dropped
+    silently — one bad row should not fail the whole probe.
+    """
+    endpoint = f"{url.rstrip('/')}/audio/voices"
+    async with httpx.AsyncClient(timeout=_PROBE_TIMEOUT) as client:
+        response = await client.get(endpoint)
+        response.raise_for_status()
+        data = response.json()
+
+    if isinstance(data, dict) and "voices" in data:
+        items = data["voices"]
+    elif isinstance(data, list):
+        items = data
+    else:
+        raise ValueError(
+            f"unexpected /audio/voices shape from {endpoint}: "
+            f"{type(data).__name__}"
+        )
+
+    voices: list[str] = []
+    for item in items:
+        if isinstance(item, str):
+            voices.append(item)
+        elif isinstance(item, dict) and isinstance(item.get("id"), str):
+            voices.append(item["id"])
+    return voices
+
+
+async def _voices_for_endpoint(url: str) -> tuple[str, list[str]] | None:
+    """Resolve ``(provider, voices)`` for a single ``TTS_BASE_URL``.
+
+    Returns ``None`` when the endpoint should not contribute (whisper
+    STT-only, or probe failure). Failures log at WARNING for recoverable
+    cases (connect, timeout, HTTP 4xx/5xx) and ERROR for malformed JSON
+    or unexpected exception types.
+    """
+    provider = detect_provider_type(url)
+    if provider == "whisper":
+        return None
+    if provider == "openai":
+        return provider, list(OPENAI_TTS_VOICES)
+
+    try:
+        voices = await _fetch_audio_voices(url)
+    except httpx.ConnectError as exc:
+        logger.warning("voice probe failed (connect) for %s: %s", url, exc)
+        return None
+    except httpx.TimeoutException as exc:
+        logger.warning("voice probe failed (timeout) for %s: %s", url, exc)
+        return None
+    except httpx.HTTPStatusError as exc:
+        logger.warning(
+            "voice probe failed (HTTP %d) for %s",
+            exc.response.status_code, url,
+        )
+        return None
+    except (ValueError, TypeError) as exc:
+        logger.error("voice probe returned malformed JSON from %s: %s", url, exc)
+        return None
+    except Exception as exc:  # noqa: BLE001 — silent-skip with log per design §5
+        logger.error(
+            "voice probe failed (%s) for %s: %s",
+            type(exc).__name__, url, exc,
+        )
+        return None
+
+    return provider, voices
+
+
+def _impression_entries() -> list[dict[str, Any]]:
+    """Materialise impression voices from ``voice_profiles.list_profiles``."""
+    try:
+        profiles = list_profiles()
+    except Exception as exc:  # noqa: BLE001 — never let this break enumeration
+        logger.error("voice_profiles.list_profiles() failed: %s", exc)
+        return []
+    return [
+        _make_entry(_IMPRESSION_PROVIDER, name)
+        for name in sorted(profiles, key=str.casefold)
+    ]
+
+
+async def enumerate_voices(*, include_local_only: bool) -> list[dict[str, Any]]:
+    """Return TTS voices the server can produce, as schema-shaped dicts.
+
+    Parameters
+    ----------
+    include_local_only:
+        When True, append local impressions/clones from ``VOICES_DIR``
+        (the stdio default). When False, omit them — the safe default
+        for remote streamable HTTP clients (AC8).
+
+    Returns
+    -------
+    A fresh shallow copy of the cached voice list. Mutating the returned
+    list does not affect future calls. The TTL cache (60 s) is keyed
+    independently per ``include_local_only`` value.
+    """
+    now = time.monotonic()
+    cached = _cache.get(include_local_only)
+    if cached is not None and (now - cached[0]) < _CACHE_TTL:
+        return list(cached[1])
+
+    probes = [_voices_for_endpoint(url) for url in TTS_BASE_URLS]
+    results = await asyncio.gather(*probes) if probes else []
+
+    merged: dict[str, dict[str, Any]] = {}
+    for result in results:
+        if result is None:
+            continue
+        provider, voices = result
+        for voice in sorted(voices, key=str.casefold):
+            entry = _make_entry(provider, voice)
+            merged[entry["id"]] = entry
+
+    if include_local_only:
+        for entry in _impression_entries():
+            existing = merged.pop(entry["id"], None)
+            if existing is not None:
+                logger.debug(
+                    "voice id collision %s: impression replaces %s entry",
+                    entry["id"], existing["provider"],
+                )
+            merged[entry["id"]] = entry
+
+    voices_list = list(merged.values())
+    _cache[include_local_only] = (now, voices_list)
+    return list(voices_list)
+
+
+def _reset_cache() -> None:
+    """Test seam — clear the in-process voice cache."""
+    _cache.clear()

--- a/voice_mode/voices.py
+++ b/voice_mode/voices.py
@@ -28,9 +28,11 @@ logger = logging.getLogger("voicemode")
 # OpenAI TTS voices. Source: https://platform.openai.com/docs/guides/text-to-speech
 # OpenAI does NOT expose /audio/voices, so this list is hand-maintained.
 # Last verified: 2026-05-10. Update when OpenAI ships a new voice.
+# `ballad` and `verse` were added with gpt-4o-mini-tts (Sep 2024); the original
+# six (alloy/echo/fable/nova/onyx/shimmer) work with tts-1 and tts-1-hd too.
 OPENAI_TTS_VOICES = (
-    "alloy", "ash", "coral", "echo", "fable",
-    "nova", "onyx", "sage", "shimmer",
+    "alloy", "ash", "ballad", "coral", "echo", "fable",
+    "nova", "onyx", "sage", "shimmer", "verse",
 )
 
 _PROBE_TIMEOUT = 5.0


### PR DESCRIPTION
# VM-1208: List available voices over MCP for streamable HTTP clients

Closes VM-1208 (parent VM-1156). Adds a structured-JSON voice catalog to MCP
streamable HTTP clients (iOS app, web client, other agents) so they can build
voice pickers without scraping the prose `voice_registry` tool or hardcoding
per-provider voice lists.

## What ships

Two new MCP resources, both `mime_type="application/json"`:

| URI | Behaviour |
|---|---|
| `voice://voices` | Full list of TTS voices the server can produce |
| `voice://voices/{provider}` | Same, filtered by `provider` field (`openai`, `kokoro`, `mlx-audio`, ...) — saves clients filtering work |

Wire schema (locked):

```json
{
  "schema_version": 1,
  "generated_at": "2026-05-10T08:38:45Z",
  "voices": [
    {
      "id": "openai:sage",
      "voice": "sage",
      "name": "sage",
      "provider": "openai",
      "language": null,
      "gender": null,
      "preview_url": null
    }
  ]
}
```

A shared `enumerate_voices()` helper in `voice_mode/voices.py` powers both the
new resources and the existing `voice_registry` LLM tool — single source of
truth. Per-provider strategy table (per design.md §3):

| `provider_type` | Source |
|---|---|
| `openai` | Hardcoded `OPENAI_TTS_VOICES` constant (11 voices: alloy, ash, ballad, coral, echo, fable, nova, onyx, sage, shimmer, verse) |
| `kokoro`, `mlx-audio` | Live `GET /audio/voices`, 5 s timeout |
| `local`, `unknown` | Live HTTP best-effort, skip on failure |
| `whisper` | Skipped (STT only) |
| Impressions/clones | `voice_profiles.list_profiles()` (filesystem), provider stamp = `mlx-audio`, **local callers only** |

Privacy: impressions are hidden from remote streamable HTTP callers by
default. Resolution order (per spike-002 hardened predicate):

1. `VOICEMODE_EXPOSE_LOCAL_VOICES_REMOTE=true` → include
2. No HTTP request context (stdio) → include
3. Loopback peer → include
4. Otherwise → omit (safe default — also covers None client / empty host /
   unparseable IP)

Freshness: 60 s in-process TTL keyed on `include_local_only`; OpenAI not
subject to TTL (hardcoded). Failure semantics: silent-skip with WARNING /
ERROR log; never raises. Full design rationale in `harness/design.md` (300
lines, 13 sections, AC cross-check table).

## How we got here — 13 features under harness

| # | Feature | Outcome |
|---|---|---|
| 1 | `ready-001` (problem-space gate) | passing |
| 2 | `spec-001` (spec lock — 4 refinement passes, A 94 %) | passing |
| 3 | `spike-001` `mime_type=` on `@mcp.resource` | **supported** (FastMCP 2.12.3) |
| 4 | `spike-002` peer-address from request context | **supported** (`get_http_request().client.host`); hardened against empty/unparseable host |
| 5 | `research-001` enumerator extraction shape | mechanical, plus surprise: impressions live outside `provider_registry` |
| 6 | `design-001` ULTRATHINK design.md | locked, 6 open Qs resolved by Mike in voice session |
| 7 | `impl-001` `enumerate_voices()` helper (`voice_mode/voices.py`, 196 LOC) | A 95 %; reviewer expanded `OPENAI_TTS_VOICES` 9 → 11 |
| 8 | `impl-002` `voice://voices` + `voice://voices/{provider}` resources | A 97 %, 100 % coverage on resource module |
| 9 | `impl-003` `voice_registry` tool refactored to share enumerator | A 95 %; AC9 clarified mid-flight |
| 10 | `test-001` unit tests (52 across enumerator + resource) | A 95 % (3 independent reviews + coverage matrix) |
| 11 | `test-002` integration test over real streamable HTTP | A 95 % |
| 12 | `docs-001` reference doc + skill + cross-links + CHANGELOG | A 95 % |
| 13 | `review-001` manual end-to-end + this PR | this PR — 17/17 wire-level AC checks pass |

Test suite: **1015 passed / 60 skipped** (no regressions; +5 from the
post-impl-003 baseline of 1010, all from `test_voices_resource_http.py`).

`make docs-check` warning count: 58 (parent: 57, +1 cairosvg system-dep
warning emitted per-page; zero new content/link warnings; pre-existing
strict-mode failures around `connect/*` nav and `guides/agents/call-routing/*`
broken links remain — none introduced here).

## AC9 clarification (mid-flight)

`AC9` originally read "voice_registry tool returns same prose format as
before". The impl-003 worker correctly noted that retiring
`provider_registry`'s hardcoded fallback list (per design §9 option (a))
changes the **content** of three lines (mlx-audio + kokoro: 67-voice phantom →
"none detected" when offline; openai: 6 → 11 voices to match
`OPENAI_TTS_VOICES`). Mike chose option 3 in foreman triage: format
byte-identical, content reflects what each endpoint can actually produce
right now. AC9 wording updated in the README YAML + body; commit
`AC9-CLARIFIED` in the harness Log section.

## Wire-level AC verification (review-001)

`harness/review-001/review_001_wire_check.py` spins up `voicemode serve
--transport http` (uvicorn + `mcp.http_app(path="/mcp")`) and connects with
`fastmcp.Client(StreamableHttpTransport(...))` to verify each AC against the
actual JSON-RPC response.

**Last run 2026-05-10: 17/17 checks passed** — output preserved at
`harness/review-001/review_001_output.txt`:

- AC1 envelope shape (`schema_version`, `generated_at`, `voices[]`); ISO 8601 generated_at; 7 schema keys per voice
- AC2 `voice://voices` in `resources/list` over both stdio and HTTP; `voice://voices/{provider}` in `resource_templates/list`
- AC3 stdio body == HTTP body modulo `generated_at` for same `include_local_only`
- AC4 raw-URL grep — body URL-free
- AC5 unique ids in `{provider}:{voice}` shape
- AC6 unhealthy/empty enumerator → `voices=[]` with intact envelope
- AC7 freshness/cadence section in `docs/reference/voices-resource.md`
- AC8 non-loopback caller → impressions omitted; loopback caller → impressions included
- AC9 voice_registry prose format byte-identical (verified upstream by impl-003 peer review)
- AC10 wire-level proxy: `voice://voices/{provider}` filter returns the picked
  voice (`openai:sage`). End-to-end TTS audition through `converse` requires
  kokoro/mlx-audio running locally and is verified by Mike at session-time.
- AC11 unit tests present and passing across `test_voices_enumerator.py` (21), `test_voices_resource.py` (31), `test_voices_resource_http.py` (5)

## Linked tasks

- Parent epic: VM-1156 (uplift streamable HTTP)
- Audit follow-up: **VM-1214** (provider_registry retirement — `voice_registry.py`
  is the first clean call site to drop it; remaining footprint = `providers.py`
  + `tools/{diagnostics,providers,devices,converse}.py` + 3 test files)
- Out of scope: STT model discovery (VM-1102), TTS parameter passthrough
  (VM-600), `resources/subscribe` for live updates (v2)

## Test plan

- [x] `make test` → 1015 passed / 60 skipped
- [x] `make docs-check` → 58 warnings, all pre-existing
- [x] Wire-level AC verification: 17/17 checks against `voicemode serve --transport http`
- [ ] Mike verifies AC10 audition: `voicemode serve --transport http`, read `voice://voices`, pick a non-default voice (e.g. `openai:sage`), `converse(voice="sage")`, hear the voice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)