### PR TITLE
VM-1218: surface voice://voices resource in converse tool description

### DIFF
--- a/voice_mode/tools/converse.py
+++ b/voice_mode/tools/converse.py
@@ -1228,11 +1228,14 @@ Example: If user says "search for tasks created yesterday", check for and invoke
    - voicemode://docs/languages - Non-English language support guide
    - voicemode://docs/patterns - Best practices and conversation patterns
    - voicemode://docs/troubleshooting - Audio, VAD, and connectivity issues
+   - voice://voices - JSON list of available TTS voices
+     (filter by provider with voice://voices/{provider}, e.g. voice://voices/kokoro)
 
 KEY PARAMETERS:
 • message (required): The message to speak
 • wait_for_response (bool, default: true): Listen for response after speaking
 • voice (string): TTS voice name (auto-selected unless specified)
+  - To list available voices, read MCP resource voice://voices
 • tts_provider ("openai"|"kokoro"): Provider selection (auto-selected unless specified)
 • disable_silence_detection (bool, default: false): Disable auto-stop on silence
 • vad_aggressiveness (0-3, default: 3): Voice detection strictness (0=permissive, 3=strict)


### PR DESCRIPTION
## Summary

- Adds `voice://voices` (and the per-provider URI template) to the `📚 DOCUMENTATION` block in the `converse` tool docstring.
- Adds a one-line sub-bullet under the `voice` parameter pointing at the same resource.
- Three lines added; no code or behavior change.

## Why

VM-1208 shipped two MCP resources (`voice://voices`, `voice://voices/{provider}`) that let any MCP client enumerate the TTS voices a server can produce. The `converse` tool description didn't mention them, so an LLM looking at the tool schema had no way to discover what values the `voice` parameter accepts.

## Format

Matches existing precedent in the same docstring — `metrics_level` and `wait_for_conch` already use indented sub-bullets under their parameter line. JSON-Schema parameter descriptions are not single-line in MCP; this docstring is shipped as one big `description` string anyway, so multi-line is a non-issue at the protocol layer.

## Out of scope

- The larger drift between this docstring and `voice_mode/resources/docs/parameters.md` (stale `transport`/`room_name` docs, missing `metrics_level`/`wait_for_conch`, etc.) — separate concern, will file a follow-up task.
- VM-25's planned move of all tool descriptions to external markdown variants. This PR is intentionally a tiny in-place edit so the discoverability win ships now.

## Test plan

- [x] `uv run pytest tests/ --no-cov` — 1015 passed, 60 skipped (unchanged from master)
- [x] Live `tools/list` payload contains the three new lines (verified via `mcp.get_tools()`)
- [ ] Manual: `voicemode serve --transport http`, hit `tools/list`, confirm description shows the new lines
- [ ] Manual: ask Claude Code "what voices are available?" with this build and confirm it reads `voice://voices`

🤖 Generated with [Claude Code](https://claude.com/claude-code)