### PR TITLE
VM-1206: surface 'voicemode echo' rule in converse tool description

### DIFF
--- a/.claude/skills/voicemode/SKILL.md
+++ b/.claude/skills/voicemode/SKILL.md
@@ -78,9 +78,9 @@ For all parameters, see [Converse Parameters](../../docs/reference/converse-para
 4. **Let VoiceMode auto-select** - Don't hardcode providers unless user has preference
 5. **First run is slow** - Model downloads happen on first start (2-5 min), then instant
 
-## Transcript visibility
+## Voicemode echo (default ON)
 
-Newer Claude Code collapses MCP tool calls — voice turns vanish from the visible transcript. Echo them as Markdown blockquotes on both sides of every `voicemode:converse` call where `wait_for_response=true`:
+Some hosts (e.g. newer Claude Code) collapse MCP tool calls — voice turns vanish from the visible transcript. **Unless requested otherwise, default to voicemode echo:** print each `voicemode:converse` exchange as Markdown blockquotes so it stays readable on screen.
 
 ```
 > **ASSISTANT (voicemode):** <message arg passed to converse>
@@ -91,12 +91,11 @@ Newer Claude Code collapses MCP tool calls — voice turns vanish from the visib
 - Speaker first in caps; `(voicemode)` is the channel tag.
 - **ASSISTANT echo: always**, including `wait_for_response=false` (speak-only narration still produces visible content that would otherwise vanish).
 - **USER echo: only when a user message was captured** (skip on `wait_for_response=false`, empty result, or transcription failure — there is nothing to echo).
-- **Assistant echo defaults to companion** — Markdown-formatted (lists, code, etc) of the *same content* you spoke.
-- **User echo defaults to verbatim and full** — exact words, no truncation; rewriting or shortening risks distorting intent.
+- **Assistant echo: verbatim by default** — the exact string passed to `message`, not paraphrased or reformatted. Reasons: least-surprising for the reader + diagnostic value when comparing printed text to spoken audio.
+- **User echo: verbatim and full** — exact words, no truncation; rewriting or shortening risks distorting intent.
+- **Visual aids (lists, tables, code) belong AFTER the blockquote, not inside it.** The blockquote stays a clean verbatim copy of what was spoken; richer formatting can follow as separate prose.
 - Don't double-echo: if a sentence already appears as visible prose in the same response, don't also blockquote it.
-- Opt-out if asked ("stop echoing", "drop the voicemode lines").
-
-Deep dive (overrides, edge cases, worked examples, companion-mode constraints): [docs/transcript-visibility.md](docs/transcript-visibility.md).
+- **Disable by name**: if the user says "disable voicemode echo" (or has it in their startup context), stop echoing for the rest of the session. Useful on hosts that already render voice tool calls inline (avoids doubling).
 
 ## Parallel Tool Calls (Zero Dead Air)
 

--- a/.claude/skills/voicemode/SKILL.md
+++ b/.claude/skills/voicemode/SKILL.md
@@ -95,7 +95,7 @@ Some hosts (e.g. newer Claude Code) collapse MCP tool calls — voice turns vani
 - **User echo: verbatim and full** — exact words, no truncation; rewriting or shortening risks distorting intent.
 - **Visual aids (lists, tables, code) belong AFTER the blockquote, not inside it.** The blockquote stays a clean verbatim copy of what was spoken; richer formatting can follow as separate prose.
 - Don't double-echo: if a sentence already appears as visible prose in the same response, don't also blockquote it.
-- **Disable by name**: if the user says "disable voicemode echo" (or has it in their startup context), stop echoing for the rest of the session. Useful on hosts that already render voice tool calls inline (avoids doubling).
+- **Disable on request** — canonical phrase: **"disable voicemode echo"**. Stop echoing for the rest of the session and honour the same phrase if it appears in the user's startup context (some hosts already render voice tool calls inline, where echoes would double up).
 
 ## Parallel Tool Calls (Zero Dead Air)
 

--- a/voice_mode/tools/converse.py
+++ b/voice_mode/tools/converse.py
@@ -1264,6 +1264,23 @@ PRIVACY: Microphone access required when wait_for_response=true.
 RECOGNITION TIP: If specific words are consistently misrecognized, configure
    VOICEMODE_STT_PROMPT for vocabulary biasing - see voicemode://docs/parameters
 
+VOICEMODE ECHO (default ON): Some hosts (e.g. newer Claude Code) collapse MCP
+   tool calls, hiding voice turns from the visible transcript. To keep voice
+   exchanges readable on screen, echo each converse turn as Markdown blockquotes:
+       > **ASSISTANT (voicemode):** <message arg, verbatim>
+       [voicemode:converse tool call]
+       > **USER (voicemode):** <captured user message, verbatim>
+   - ASSISTANT echo: always (incl. wait_for_response=false). Verbatim — the
+     exact string passed to `message`, not a paraphrase or reformat.
+   - USER echo: only when a user message was captured (skip on empty result
+     or transcription failure). Verbatim, no truncation.
+   - Visual aids (lists, tables, code) may follow AFTER the blockquote, not
+     inside it — the blockquote stays a clean verbatim copy of what was spoken.
+   - Don't double-echo content already visible as prose.
+   - Disable by name: if the user says "disable voicemode echo" (or has it in
+     their startup context), stop echoing for the rest of the session. Useful
+     on hosts that already render voice tool calls inline (avoids doubling).
+
 For complete parameter list, advanced options, and detailed examples,
 consult the MCP resources listed above.
     """

--- a/voice_mode/tools/converse.py
+++ b/voice_mode/tools/converse.py
@@ -1277,9 +1277,7 @@ VOICEMODE ECHO (default ON): Some hosts (e.g. newer Claude Code) collapse MCP
    - Visual aids (lists, tables, code) may follow AFTER the blockquote, not
      inside it — the blockquote stays a clean verbatim copy of what was spoken.
    - Don't double-echo content already visible as prose.
-   - Disable by name: if the user says "disable voicemode echo" (or has it in
-     their startup context), stop echoing for the rest of the session. Useful
-     on hosts that already render voice tool calls inline (avoids doubling).
+   - Disable on request — canonical phrase: "disable voicemode echo".
 
 For complete parameter list, advanced options, and detailed examples,
 consult the MCP resources listed above.


### PR DESCRIPTION
## Summary

Adds a `VOICEMODE ECHO` block to the `converse` MCP tool docstring so the transcript-visibility rule is teachable from the tool description itself — visible whenever `converse` is callable, not only after the voicemode skill loads. Partial progress on VM-1206 (the "thin slice in MCP tool description" acceptance criterion).

Design decisions (voice conversation Mike↔Cora 2026-05-10):

- Names the behaviour **"voicemode echo"** (matches VM-1170's planned `/voicemode echo` slash command).
- **ASSISTANT echo defaults to verbatim**, not companion. Reverses VM-1166 default. Reasons: least-surprising for the reader + diagnostic value when comparing printed text to spoken audio.
- **Visual aids (lists, tables, code) belong AFTER the blockquote**, not inside — the blockquote stays a clean verbatim copy.
- **Default ON, opt-out by name.** Phrase: "disable voicemode echo". Useful on hosts (Codex, Goose, etc.) that already render voice tool calls inline — avoids doubling. Users can drop the phrase in their startup context once and forget.

### Known follow-up

`skills/voicemode/SKILL.md` is NOT updated here — its current text still says assistant echo defaults to *companion*. That contradiction resolves when VM-1206's broader SSOT-file refactor lands (extract the rule to `skills/voicemode/echo.md`, re-point `SKILL.md` + the converse skill). Flagged in commit message so the follow-up doesn't miss it.

## Test plan

- [x] Docstring still parses — module imports cleanly
- [x] New section renders as expected via `inspect.getsource`
- [ ] Manual: verify `mcp__voicemode__converse` tool description in a fresh session contains the new block
- [ ] Manual: verify a session that uses `converse` *without* loading the voicemode skill sees and acts on the rule

🤖 Generated with [Claude Code](https://claude.com/claude-code)