### PR TITLE
VM-1232: restore explicit ordering rule in voicemode echo section

### DIFF
--- a/.claude/skills/voicemode/SKILL.md
+++ b/.claude/skills/voicemode/SKILL.md
@@ -89,6 +89,7 @@ Some hosts (e.g. newer Claude Code) collapse MCP tool calls — voice turns vani
 ```
 
 - Speaker first in caps; `(voicemode)` is the channel tag.
+- **Order matters.** Write the **ASSISTANT** blockquote *before* the `voicemode:converse` tool call, in the same response that issues it — so the user can read along while the audio plays (and recover the message if they miss part of it). Write the **USER** blockquote in your *next* response, after the tool result returns. Don't batch both echoes after the call.
 - **ASSISTANT echo: always**, including `wait_for_response=false` (speak-only narration still produces visible content that would otherwise vanish).
 - **USER echo: only when a user message was captured** (skip on `wait_for_response=false`, empty result, or transcription failure — there is nothing to echo).
 - **Assistant echo: verbatim by default** — the exact string passed to `message`, not paraphrased or reformatted. Reasons: least-surprising for the reader + diagnostic value when comparing printed text to spoken audio.


### PR DESCRIPTION
## Summary

- Restores the prose rule (dropped in VM-1206 / 097d0cc) that the **ASSISTANT** blockquote goes *before* the `voicemode:converse` call and the **USER** blockquote goes in the *next* response.
- Diagram at the top of the section already showed the correct order; without the explicit prose rule, agents read the section and put both blockquotes after the call -- defeating the readability/recovery purpose.
- One bullet added; nothing else changed.

## Why

Mike caught it in a voice session: he wants to see the assistant message *while* the TTS is playing so he can read along (or recover the message if he misses part of the audio). Putting both echoes after the converse call returns means the assistant text appears only once the user has finished speaking and STT has run.

## Test plan

- [ ] On next `/voicemode:voicemode` invocation, the loaded SKILL.md instructs the agent to emit the ASSISTANT blockquote in the same response as the converse call, before the tool use.
- [ ] Confirm verbatim assistant text shows up on screen during TTS playback, not after STT returns.

🤖 Generated with [Claude Code](https://claude.com/claude-code)