### PR TITLE
ci: add Dependabot config for uv and GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,68 @@
+# Dependabot configuration for VoiceMode
+# Docs: https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+version: 2
+
+updates:
+  # Python dependencies (main package) — managed via uv
+  - package-ecosystem: "uv"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 10
+    labels:
+      - "dependencies"
+      - "python"
+    commit-message:
+      prefix: "deps"
+      include: "scope"
+    groups:
+      python-minor-and-patch:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
+
+  # Python dependencies (installer package) — managed via uv
+  - package-ecosystem: "uv"
+    directory: "/installer"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+      - "python"
+      - "installer"
+    commit-message:
+      prefix: "deps(installer)"
+      include: "scope"
+    groups:
+      installer-minor-and-patch:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
+
+  # GitHub Actions
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+      - "github-actions"
+    commit-message:
+      prefix: "ci"
+      include: "scope"
+    groups:
+      actions-minor-and-patch:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"


### PR DESCRIPTION
## Summary
- Enables weekly Dependabot updates for the repo
- Covers three ecosystems: **uv** at `/`, **uv** at `/installer`, **github-actions** at `/`
- Groups minor/patch updates into single PRs to reduce noise; major bumps stay as individual PRs

## Why uv (not pip)?
GitHub added native `uv` ecosystem support so the lockfile (`uv.lock`) gets updated alongside `pyproject.toml` — using `pip` would leave the lockfile stale.

## Cadence
- Weekly, Mondays
- Open-PR caps: 10 (main), 5 (installer), 5 (actions)
- Labels: `dependencies` + ecosystem-specific tag

## Test plan
- [ ] Merge to master
- [ ] Confirm Dependabot creates initial PRs within ~24h on the next Monday cycle
- [ ] Verify `uv.lock` is updated alongside `pyproject.toml` in the first uv PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)