### PR TITLE
VM-1236: add audit-deps Makefile targets for local vuln scanning

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,8 @@
 	test-installer-ubuntu test-installer-fedora test-installer-all test-installer-ci \
 	test-installer-pypi test-installer-pypi-ubuntu test-installer-pypi-fedora \
 	test-installer-pypi-all \
-	vm-ubuntu vm-fedora vm-macos vm-ubuntu-quick vm-fedora-quick vm-macos-quick vm-clean vm-list
+	vm-ubuntu vm-fedora vm-macos vm-ubuntu-quick vm-fedora-quick vm-macos-quick vm-clean vm-list \
+	audit-deps audit-deps-critical audit-deps-json
 
 # Default target
 help:
@@ -75,6 +76,11 @@ help:
 	@echo "  docs-build    - Build documentation site"
 	@echo "  docs-check    - Check documentation for errors (strict mode)"
 	@echo "  docs-deploy   - Deploy to ReadTheDocs (requires auth)"
+	@echo ""
+	@echo "Security:"
+	@echo "  audit-deps          - Scan dependencies for known vulnerabilities (osv-scanner)"
+	@echo "  audit-deps-critical - Show only Critical and High severity findings"
+	@echo "  audit-deps-json     - Output full scan as JSON (for tooling)"
 	@echo ""
 	@echo "Manual VM Testing:"
 	@echo "  vm-ubuntu     - Start fresh Ubuntu VM and show SSH command"
@@ -714,3 +720,49 @@ test-installer-pypi-all:
 	echo ""; \
 	echo "=== Testing Fedora (fresh clone) ==="; \
 	uv run python scripts/test_installer.py fedora --pypi --backend tart --clone-fresh || true
+# ============================================================================
+# Security: dependency vulnerability scanning
+# ============================================================================
+# Uses osv-scanner (Google's OSV.dev client) to scan uv.lock + workflows
+# against known CVE/GHSA databases. Mirrors the Dependabot config in
+# .github/dependabot.yml but runs locally on demand.
+#
+# Install: brew install osv-scanner
+
+# Scan all dependencies for known vulnerabilities (full report)
+audit-deps:
+	@if ! command -v osv-scanner >/dev/null 2>&1; then \
+		echo "❌ osv-scanner is not installed!"; \
+		echo "Install with: brew install osv-scanner"; \
+		echo "Docs: https://google.github.io/osv-scanner/"; \
+		exit 1; \
+	fi
+	@echo "Scanning dependencies with osv-scanner..."
+	@osv-scanner scan source --recursive .
+
+# Show only Critical and High severity findings (CVSS >= 7.0)
+audit-deps-critical:
+	@if ! command -v osv-scanner >/dev/null 2>&1; then \
+		echo "❌ osv-scanner is not installed!"; \
+		echo "Install with: brew install osv-scanner"; \
+		exit 1; \
+	fi
+	@echo "Scanning for Critical and High severity vulnerabilities (CVSS >= 7.0)..."
+	@osv-scanner scan source --recursive . --format=table 2>&1 | awk ' \
+		/^Total/ { print; next } \
+		/^\| OSV URL/ { print; next } \
+		/^\+--/ { print; next } \
+		/^\| https/ { \
+			n = split($$0, parts, "|"); \
+			cvss = parts[3] + 0; \
+			if (cvss >= 7.0) print; \
+			next \
+		}'
+
+# Output full scan as JSON (for piping into other tools)
+audit-deps-json:
+	@if ! command -v osv-scanner >/dev/null 2>&1; then \
+		echo "❌ osv-scanner is not installed!" >&2; \
+		exit 1; \
+	fi
+	@osv-scanner scan source --recursive . --format=json


### PR DESCRIPTION
## Summary
Three new Makefile targets wrapping `osv-scanner` for on-demand local vulnerability scanning:

- **`make audit-deps`** — full report (everything osv-scanner finds across `uv.lock`, `installer/uv.lock`, and GH Actions workflows)
- **`make audit-deps-critical`** — filtered to CVSS ≥ 7.0 (Critical + High only)
- **`make audit-deps-json`** — full output as JSON, for piping into other tools

Each target exits with a clear `brew install osv-scanner` hint if the binary isn't present, so `make help` doesn't lie about what runs.

## Why
Mirrors the [Dependabot config](.github/dependabot.yml) (#384) but lets devs check vulnerability status locally without waiting for the weekly Dependabot cycle. Useful for:
- Verifying a fresh vuln remediation actually landed (re-run after merging upgrade PRs)
- Spot-checking a dep before adding it
- Triage during the active VM-1236 epic

## Help section addition
```
Security:
  audit-deps          - Scan dependencies for known vulnerabilities (osv-scanner)
  audit-deps-critical - Show only Critical and High severity findings
  audit-deps-json     - Output full scan as JSON (for tooling)
```

## Test plan
- [ ] `make help` shows the new Security section
- [ ] `make audit-deps` runs the full scan
- [ ] `make audit-deps-critical` shows only CVSS ≥ 7.0 findings
- [ ] Without osv-scanner installed, all three targets exit with the install hint

🤖 Generated with [Claude Code](https://claude.com/claude-code)