### PR TITLE
VM-1242: migrate fastmcp 2.x -> 3.x (fixes 2 critical CVEs)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ classifiers = [
 
 dependencies = [
     "uv>=0.4.0",
-    "fastmcp>=2.3.2,<3",  # Pin to 2.x until FastMCP 3.0 migration (VM-742)
+    "fastmcp>=3.2.0,<4",  # Migrated to 3.x in VM-1242. Fixes CVSS 10.0 (GHSA-vv7q-7jx5-f767).
     "numpy",
     "sounddevice",
     "scipy",

--- a/tests/test_audio_files_path_traversal.py
+++ b/tests/test_audio_files_path_traversal.py
@@ -26,8 +26,9 @@ from voice_mode.resources import audio_files as audio_files_module
 from voice_mode.resources.audio_files import get_audio_file
 
 
-# Resolve the underlying async function (FastMCP wraps the decorated fn).
-_handler = get_audio_file.fn
+# Resolve the underlying async function.
+# FastMCP 2.x: decorator wraps with .fn; 3.x: decorator returns the function directly.
+_handler = getattr(get_audio_file, 'fn', get_audio_file)
 
 
 def _run(coro):

--- a/tests/test_changelog_resource.py
+++ b/tests/test_changelog_resource.py
@@ -26,7 +26,7 @@ def test_changelog_resource_finds_file_from_source():
             mock_exists.side_effect = [True, False, False]
             mock_read.return_value = mock_content
             
-            result = changelog_resource.fn()
+            result = getattr(changelog_resource, 'fn', changelog_resource)()
             
             assert result == mock_content
             assert mock_exists.call_count == 1
@@ -42,7 +42,7 @@ def test_changelog_resource_fallback_paths():
             mock_exists.side_effect = [False, False, True]
             mock_read.return_value = mock_content
             
-            result = changelog_resource.fn()
+            result = getattr(changelog_resource, 'fn', changelog_resource)()
             
             assert result == mock_content
             assert mock_exists.call_count == 3
@@ -54,7 +54,7 @@ def test_changelog_resource_file_not_found():
         # No paths exist
         mock_exists.return_value = False
         
-        result = changelog_resource.fn()
+        result = getattr(changelog_resource, 'fn', changelog_resource)()
         
         assert "CHANGELOG.md not found in package" in result
         assert "https://github.com/mbailey/voicemode" in result
@@ -68,7 +68,7 @@ def test_changelog_resource_read_error():
             mock_exists.side_effect = [True, False, False]
             mock_read.side_effect = PermissionError("Access denied")
             
-            result = changelog_resource.fn()
+            result = getattr(changelog_resource, 'fn', changelog_resource)()
             
             assert "Error reading CHANGELOG.md" in result
             assert "Access denied" in result

--- a/tests/test_configuration_management.py
+++ b/tests/test_configuration_management.py
@@ -19,7 +19,7 @@ class TestConfigurationManagement:
     @pytest.mark.asyncio
     async def test_list_config_keys(self):
         """Test listing configuration keys."""
-        result = await list_config_keys.fn()
+        result = await getattr(list_config_keys, 'fn', list_config_keys)()
         
         # Should return a formatted string with config keys
         assert isinstance(result, str)
@@ -49,7 +49,7 @@ class TestConfigurationManagement:
             
             # Patch the config path
             with patch("voice_mode.tools.configuration_management.USER_CONFIG_PATH", Path(temp_path)):
-                result = await update_config.fn("TEST_KEY", "test_value")
+                result = await getattr(update_config, 'fn', update_config)("TEST_KEY", "test_value")
                 
                 # Should return a message (success or error)
                 assert isinstance(result, str)
@@ -65,20 +65,21 @@ class TestConfigurationManagement:
     async def test_update_config_function_exists(self):
         """Test that update_config function is callable."""
         # Just verify the function exists and is callable
-        assert callable(update_config.fn)
+        # FastMCP 2.x: .fn is the wrapped function; 3.x: tool IS the function
+        assert callable(getattr(update_config, 'fn', update_config))
         
         # Test with a mock path that doesn't exist
         with patch("voice_mode.tools.configuration_management.USER_CONFIG_PATH", Path("/nonexistent/test.env")):
             with patch("pathlib.Path.mkdir"), patch("pathlib.Path.exists", return_value=False):
                 with patch("builtins.open", mock_open()) as mock_file:
-                    result = await update_config.fn("TEST_KEY", "test_value")
+                    result = await getattr(update_config, 'fn', update_config)("TEST_KEY", "test_value")
                     # Should return a string result
                     assert isinstance(result, str)
 
     @pytest.mark.asyncio
     async def test_list_config_keys_structure(self):
         """Test that list_config_keys returns properly structured output."""
-        result = await list_config_keys.fn()
+        result = await getattr(list_config_keys, 'fn', list_config_keys)()
         
         # Should have sections
         assert "Core Configuration" in result or "Configuration" in result
@@ -91,14 +92,14 @@ class TestConfigurationManagement:
     async def test_config_functions_integration(self):
         """Test that config functions work together."""
         # List should work
-        list_result = await list_config_keys.fn()
+        list_result = await getattr(list_config_keys, 'fn', list_config_keys)()
         assert len(list_result) > 100  # Should have substantial content
         
         # Update should return a message (even if it fails due to permissions)
         with patch("voice_mode.tools.configuration_management.USER_CONFIG_PATH", Path("/tmp/test_config.env")):
             with patch("pathlib.Path.mkdir"):
                 try:
-                    update_result = await update_config.fn("TEST_INTEGRATION", "test")
+                    update_result = await getattr(update_config, 'fn', update_config)("TEST_INTEGRATION", "test")
                     assert isinstance(update_result, str)
                     assert len(update_result) > 0
                 except Exception:
@@ -108,7 +109,7 @@ class TestConfigurationManagement:
     @pytest.mark.asyncio
     async def test_list_config_keys_formatting(self):
         """Test that list_config_keys returns properly formatted output."""
-        result = await list_config_keys.fn()
+        result = await getattr(list_config_keys, 'fn', list_config_keys)()
         
         # Should have multiple lines
         lines = result.split('\n')
@@ -448,7 +449,7 @@ class TestMultilineValueHandling:
 
             # Update only VOICEMODE_WHISPER_MODEL
             with patch("voice_mode.tools.configuration_management.USER_CONFIG_PATH", temp_file):
-                result = asyncio.run(update_config.fn("VOICEMODE_WHISPER_MODEL", "large-v1"))
+                result = asyncio.run(getattr(update_config, 'fn', update_config)("VOICEMODE_WHISPER_MODEL", "large-v1"))
 
             # Should succeed
             assert "success" in result.lower() or "updated" in result.lower()

--- a/tests/test_converse_cancellation.py
+++ b/tests/test_converse_cancellation.py
@@ -28,7 +28,7 @@ class TestConverseCancellation:
 
             with patch("voice_mode.config.TTS_BASE_URLS", ["https://api.openai.com/v1"]):
                 with patch("voice_mode.config.OPENAI_API_KEY", "test-api-key"):
-                    result = await converse.fn(
+                    result = await getattr(converse, 'fn', converse)(
                         message="Test message",
                         wait_for_response=False,
                     )
@@ -51,7 +51,7 @@ class TestConverseCancellation:
 
             with patch("voice_mode.config.TTS_BASE_URLS", ["https://api.openai.com/v1"]):
                 with patch("voice_mode.config.OPENAI_API_KEY", "test-api-key"):
-                    await converse.fn(
+                    await getattr(converse, 'fn', converse)(
                         message="Test message",
                         wait_for_response=False,
                     )
@@ -78,7 +78,7 @@ class TestConverseCancellation:
             with patch("voice_mode.config.TTS_BASE_URLS", ["https://api.openai.com/v1"]):
                 with patch("voice_mode.config.OPENAI_API_KEY", "test-api-key"):
                     task = asyncio.create_task(
-                        converse.fn(message="Hello", wait_for_response=False)
+                        getattr(converse, 'fn', converse)(message="Hello", wait_for_response=False)
                     )
                     # Give it a moment to get into TTS
                     await asyncio.sleep(0.1)

--- a/tests/test_converse_critical_path.py
+++ b/tests/test_converse_critical_path.py
@@ -27,7 +27,7 @@ class TestConverseOpenAIErrors:
 
             with patch('voice_mode.config.TTS_BASE_URLS', ['https://api.openai.com/v1']):
                 with patch('voice_mode.config.OPENAI_API_KEY', 'test-api-key'):
-                    result = await converse.fn(
+                    result = await getattr(converse, 'fn', converse)(
                         message="Test message",
                         wait_for_response=False
                     )
@@ -52,7 +52,7 @@ class TestConverseOpenAIErrors:
 
             with patch('voice_mode.config.TTS_BASE_URLS', ['https://api.openai.com/v1']):
                 with patch('voice_mode.config.OPENAI_API_KEY', 'invalid-key'):
-                    result = await converse.fn(
+                    result = await getattr(converse, 'fn', converse)(
                         message="Test message",
                         wait_for_response=False
                     )
@@ -76,7 +76,7 @@ class TestConverseOpenAIErrors:
             )
 
             with patch('voice_mode.config.TTS_BASE_URLS', ['https://api.openai.com/v1']):
-                result = await converse.fn(
+                result = await getattr(converse, 'fn', converse)(
                     message="Test message",
                     wait_for_response=False
                 )
@@ -111,7 +111,7 @@ class TestConverseFailoverBehavior:
             ]
 
             with patch('voice_mode.config.TTS_BASE_URLS', test_urls):
-                result = await converse.fn(
+                result = await getattr(converse, 'fn', converse)(
                     message="Test message",
                     wait_for_response=False
                 )
@@ -130,7 +130,7 @@ class TestConverseFailoverBehavior:
         with patch('voice_mode.simple_failover.simple_tts_failover') as mock_tts:
             mock_tts.return_value = (True, {'duration_ms': 100}, {'provider': 'openai'})
 
-            result = await converse.fn(
+            result = await getattr(converse, 'fn', converse)(
                 message="Test message",
                 wait_for_response=False
             )
@@ -158,7 +158,7 @@ class TestConverseErrorMessages:
             })
 
             with patch('voice_mode.config.OPENAI_API_KEY', None):
-                result = await converse.fn(
+                result = await getattr(converse, 'fn', converse)(
                     message="Test",
                     wait_for_response=False
                 )
@@ -185,7 +185,7 @@ class TestConverseErrorMessages:
                 ]
             })
 
-            result = await converse.fn(
+            result = await getattr(converse, 'fn', converse)(
                 message="Test",
                 wait_for_response=False
             )
@@ -223,7 +223,7 @@ class TestConverseSTTFailures:
                         ]
                     }
 
-                    result = await converse.fn(
+                    result = await getattr(converse, 'fn', converse)(
                         message="Test",
                         wait_for_response=True
                     )
@@ -252,7 +252,7 @@ class TestConverseSTTFailures:
                         'provider': 'whisper'
                     }
 
-                    result = await converse.fn(
+                    result = await getattr(converse, 'fn', converse)(
                         message="Are you there?",
                         wait_for_response=True
                     )
@@ -275,7 +275,7 @@ class TestConverseMetrics:
                 'ttfb_ms': 50
             }, {'provider': 'openai'})
 
-            result = await converse.fn(
+            result = await getattr(converse, 'fn', converse)(
                 message="Test",
                 wait_for_response=False
             )

--- a/tests/test_diagnostics.py
+++ b/tests/test_diagnostics.py
@@ -19,7 +19,7 @@ class TestDiagnosticTools:
              patch("pathlib.Path.exists", return_value=True), \
              patch("pathlib.Path.home", return_value=Path("/home/test")):
             
-            result = await voice_mode_info.fn()
+            result = await getattr(voice_mode_info, 'fn', voice_mode_info)()
             
             # Should return formatted string
             assert isinstance(result, str)
@@ -63,7 +63,7 @@ class TestDiagnosticTools:
             
             mock_query.side_effect = query_side_effect
             
-            result = await check_audio_devices.fn()
+            result = await getattr(check_audio_devices, 'fn', check_audio_devices)()
             
             # Should return formatted string
             assert isinstance(result, str)
@@ -118,7 +118,7 @@ class TestDiagnosticTools:
             "voice_mode.tools.voice_registry.STT_BASE_URLS",
             ["http://127.0.0.1:2022/v1"],
         ):
-            result = await voice_registry.fn()
+            result = await getattr(voice_registry, 'fn', voice_registry)()
 
             # Should return formatted string
             assert isinstance(result, str)
@@ -175,7 +175,7 @@ class TestDiagnosticTools:
                         stdout="PulseAudio 15.0"
                     )
                     
-                    result = await check_audio_dependencies.fn()
+                    result = await getattr(check_audio_dependencies, 'fn', check_audio_dependencies)()
                     
                     # Should return dictionary with text and data
                     assert isinstance(result, dict)
@@ -220,7 +220,7 @@ class TestDiagnosticTools:
                 if 'voice_mode.tools.dependencies' in sys.modules:
                     importlib.reload(sys.modules['voice_mode.tools.dependencies'])
                 
-                result = await check_audio_dependencies.fn()
+                result = await getattr(check_audio_dependencies, 'fn', check_audio_dependencies)()
                 
                 # Should return dictionary with text and data
                 assert isinstance(result, dict)
@@ -251,7 +251,7 @@ class TestDiagnosticTools:
             # Mock WSL detection
             mock_exists.return_value = True  # /proc/sys/fs/binfmt_misc/WSLInterop exists
             
-            result = await check_audio_dependencies.fn()
+            result = await getattr(check_audio_dependencies, 'fn', check_audio_dependencies)()
             
             # Should return dictionary
             assert isinstance(result, dict)
@@ -283,7 +283,7 @@ class TestDiagnosticTools:
                     
             mock_query.side_effect = query_side_effect
             
-            result = await check_audio_devices.fn()
+            result = await getattr(check_audio_devices, 'fn', check_audio_devices)()
             
             # Should return formatted string
             assert isinstance(result, str)

--- a/tests/test_endpoint_info_attributes.py
+++ b/tests/test_endpoint_info_attributes.py
@@ -91,7 +91,7 @@ class TestProviderToolsUsage:
 
         with patch('voice_mode.tools.providers.provider_registry', mock_registry):
             # This should work if the fields exist
-            result = await refresh_provider_registry.fn(optimistic=False)
+            result = await getattr(refresh_provider_registry, 'fn', refresh_provider_registry)(optimistic=False)
             # The tool should be able to access endpoint.healthy without error
             assert "healthy" in str(result) or "✅" in result or "❌" in result
 
@@ -120,7 +120,7 @@ class TestProviderToolsUsage:
             from voice_mode.tools.devices import voice_status
 
             # This should work without AttributeError
-            result = await voice_status.fn()
+            result = await getattr(voice_status, 'fn', voice_status)()
             assert "TTS Endpoints" in result
 
 
@@ -147,7 +147,7 @@ class TestConverseIntegrationWithEndpointInfo:
             })
 
             # This should handle the error gracefully
-            result = await converse.fn(
+            result = await getattr(converse, 'fn', converse)(
                 message="Test message",
                 wait_for_response=False
             )
@@ -173,7 +173,7 @@ class TestConverseIntegrationWithEndpointInfo:
                 ]
             })
 
-            result = await converse.fn(
+            result = await getattr(converse, 'fn', converse)(
                 message="Test message",
                 wait_for_response=False
             )

--- a/tests/test_min_duration_integration.py
+++ b/tests/test_min_duration_integration.py
@@ -20,7 +20,8 @@ class TestMinDurationIntegration:
         from voice_mode.tools.converse import converse
         
         # Get the actual function from the MCP tool wrapper
-        converse_func = converse.fn
+        # FastMCP 2.x: tool has .fn attribute; 3.x: tool IS the function
+        converse_func = getattr(converse, 'fn', converse)
         
         # Mock required dependencies
         with patch('voice_mode.tools.converse.startup_initialization', new_callable=AsyncMock):
@@ -63,7 +64,8 @@ class TestMinDurationIntegration:
         from voice_mode.tools.converse import converse
         
         # Get the actual function from the MCP tool wrapper
-        converse_func = converse.fn
+        # FastMCP 2.x: tool has .fn attribute; 3.x: tool IS the function
+        converse_func = getattr(converse, 'fn', converse)
         
         # Mock all dependencies
         with patch('voice_mode.tools.converse.startup_initialization', new_callable=AsyncMock):

--- a/tests/test_release_notes_prompt.py
+++ b/tests/test_release_notes_prompt.py
@@ -30,7 +30,7 @@ def test_release_notes_prompt_parses_changelog():
     with patch("voice_mode.resources.changelog.changelog_resource") as mock_resource:
         mock_resource.fn.return_value = mock_changelog
         
-        result = release_notes_prompt.fn(versions="2")
+        result = getattr(release_notes_prompt, 'fn', release_notes_prompt)(versions="2")
         
         # Should show oldest first
         assert "[1.1.0]" in result
@@ -54,7 +54,7 @@ def test_release_notes_prompt_handles_missing_changelog():
     with patch("voice_mode.resources.changelog.changelog_resource") as mock_resource:
         mock_resource.fn.return_value = "CHANGELOG.md not found in package."
         
-        result = release_notes_prompt.fn()
+        result = getattr(release_notes_prompt, 'fn', release_notes_prompt)()
         
         assert "CHANGELOG.md not found" in result
 
@@ -64,7 +64,7 @@ def test_release_notes_prompt_handles_error():
     with patch("voice_mode.resources.changelog.changelog_resource") as mock_resource:
         mock_resource.fn.return_value = "Error reading CHANGELOG.md: Permission denied"
         
-        result = release_notes_prompt.fn()
+        result = getattr(release_notes_prompt, 'fn', release_notes_prompt)()
         
         assert "Error reading CHANGELOG.md" in result
 
@@ -101,7 +101,7 @@ def test_release_notes_prompt_default_versions():
     with patch("voice_mode.resources.changelog.changelog_resource") as mock_resource:
         mock_resource.fn.return_value = mock_changelog
         
-        result = release_notes_prompt.fn()  # No versions specified
+        result = getattr(release_notes_prompt, 'fn', release_notes_prompt)()  # No versions specified
         
         # Should show 5 versions (default)
         assert "[2.0.0]" in result
@@ -145,7 +145,7 @@ def test_release_notes_prompt_handles_empty_string():
         mock_resource.fn.return_value = mock_changelog
         
         # Test with empty string (what Claude Code sends)
-        result = release_notes_prompt.fn(versions="")
+        result = getattr(release_notes_prompt, 'fn', release_notes_prompt)(versions="")
         
         # Should use default of 5 versions
         assert "[2.0.0]" in result
@@ -177,13 +177,13 @@ def test_release_notes_prompt_respects_version_limit():
         mock_resource.fn.return_value = mock_changelog
         
         # Test with 1 version
-        result = release_notes_prompt.fn(versions="1")
+        result = getattr(release_notes_prompt, 'fn', release_notes_prompt)(versions="1")
         assert "[3.0.0]" in result
         assert "[2.0.0]" not in result
         assert "[1.0.0]" not in result
         
         # Test with all versions
-        result = release_notes_prompt.fn(versions="10")
+        result = getattr(release_notes_prompt, 'fn', release_notes_prompt)(versions="10")
         assert "[3.0.0]" in result
         assert "[2.0.0]" in result
         assert "[1.0.0]" in result

--- a/tests/test_simple.py
+++ b/tests/test_simple.py
@@ -149,8 +149,14 @@ async def test_mcp_server_import():
         async def test_tool(message: str) -> str:
             return f"Test response: {message}"
         
-        # Verify the tool was added
-        assert len(test_mcp._tool_manager._tools) > 0
+        # Verify the tool was added.
+        # FastMCP 3.x: list_tools() is the public API (async, returns list).
+        # FastMCP 2.x: _tool_manager._tools is the internal dict.
+        if hasattr(test_mcp, 'list_tools'):
+            tools = await test_mcp.list_tools()
+        else:
+            tools = test_mcp._tool_manager._tools
+        assert len(tools) > 0
         
     except ImportError:
         pytest.skip("FastMCP not available")

--- a/tests/test_voices_resource.py
+++ b/tests/test_voices_resource.py
@@ -196,7 +196,7 @@ def patched_enum(monkeypatch):
 async def test_list_voices_returns_locked_envelope(patched_enum, clean_env):
     _patch_no_request(clean_env)   # stdio context → local
 
-    body = await list_voices.fn()
+    body = await getattr(list_voices, 'fn', list_voices)()
 
     assert body["schema_version"] == 1
     assert isinstance(body["generated_at"], str)
@@ -210,7 +210,7 @@ async def test_list_voices_returns_locked_envelope(patched_enum, clean_env):
 async def test_list_voices_stdio_includes_impressions(patched_enum, clean_env):
     _patch_no_request(clean_env)
 
-    body = await list_voices.fn()
+    body = await getattr(list_voices, 'fn', list_voices)()
 
     assert patched_enum == [True]   # stdio → include_local_only=True
     assert any(v["provider"] == "mlx-audio" for v in body["voices"])
@@ -222,7 +222,7 @@ async def test_list_voices_remote_omits_impressions(patched_enum, clean_env):
     req.client.host = "203.0.113.7"
     _patch_request(clean_env, req)
 
-    body = await list_voices.fn()
+    body = await getattr(list_voices, 'fn', list_voices)()
 
     assert patched_enum == [False]
     assert all(v["provider"] != "mlx-audio" for v in body["voices"])
@@ -233,7 +233,7 @@ async def test_list_voices_loopback_includes_impressions(patched_enum, clean_env
     req.client.host = "127.0.0.1"
     _patch_request(clean_env, req)
 
-    body = await list_voices.fn()
+    body = await getattr(list_voices, 'fn', list_voices)()
 
     assert patched_enum == [True]
     assert any(v["provider"] == "mlx-audio" for v in body["voices"])
@@ -247,7 +247,7 @@ async def test_list_voices_env_override_forces_impressions_over_remote(
     _patch_request(monkeypatch, req)
     monkeypatch.setenv("VOICEMODE_EXPOSE_LOCAL_VOICES_REMOTE", "true")
 
-    body = await list_voices.fn()
+    body = await getattr(list_voices, 'fn', list_voices)()
 
     assert patched_enum == [True]
     assert any(v["provider"] == "mlx-audio" for v in body["voices"])
@@ -257,7 +257,7 @@ async def test_list_voices_response_carries_no_raw_urls(patched_enum, clean_env)
     """AC4: no ``http://`` / ``https://`` substrings anywhere in the body."""
     _patch_no_request(clean_env)
 
-    body = await list_voices.fn()
+    body = await getattr(list_voices, 'fn', list_voices)()
 
     import json
     serialized = json.dumps(body)
@@ -271,7 +271,7 @@ async def test_list_voices_response_carries_no_raw_urls(patched_enum, clean_env)
 async def test_per_provider_filter_returns_only_matching(patched_enum, clean_env):
     _patch_no_request(clean_env)
 
-    body = await list_voices_for_provider.fn(provider="openai")
+    body = await getattr(list_voices_for_provider, 'fn', list_voices_for_provider)(provider="openai")
 
     assert body["schema_version"] == 1
     assert all(v["provider"] == "openai" for v in body["voices"])
@@ -281,7 +281,7 @@ async def test_per_provider_filter_returns_only_matching(patched_enum, clean_env
 async def test_per_provider_filter_empty_for_unknown_provider(patched_enum, clean_env):
     _patch_no_request(clean_env)
 
-    body = await list_voices_for_provider.fn(provider="never-heard-of-it")
+    body = await getattr(list_voices_for_provider, 'fn', list_voices_for_provider)(provider="never-heard-of-it")
 
     assert body["voices"] == []
     assert body["schema_version"] == 1
@@ -293,7 +293,7 @@ async def test_per_provider_filter_respects_privacy(patched_enum, clean_env):
     req.client.host = "203.0.113.7"
     _patch_request(clean_env, req)
 
-    body = await list_voices_for_provider.fn(provider="mlx-audio")
+    body = await getattr(list_voices_for_provider, 'fn', list_voices_for_provider)(provider="mlx-audio")
 
     # patched_enum returns no mlx-audio voices when include_local_only=False,
     # so the per-provider filter yields nothing.
@@ -305,8 +305,8 @@ async def test_per_provider_envelope_matches_unfiltered(patched_enum, clean_env)
     """Per-provider response carries the same envelope keys as the unfiltered one."""
     _patch_no_request(clean_env)
 
-    full = await list_voices.fn()
-    one = await list_voices_for_provider.fn(provider="kokoro")
+    full = await getattr(list_voices, 'fn', list_voices)()
+    one = await getattr(list_voices_for_provider, 'fn', list_voices_for_provider)(provider="kokoro")
 
     assert set(full.keys()) == set(one.keys())
     assert full["schema_version"] == one["schema_version"]
@@ -315,10 +315,19 @@ async def test_per_provider_envelope_matches_unfiltered(patched_enum, clean_env)
 # ---------- registration sanity check -------------------------------------
 
 
-def test_resources_register_with_expected_uris():
+async def test_resources_register_with_expected_uris():
     """Both resources are loaded into the FastMCP instance with mime_type=json."""
-    # The resource objects expose .uri / .mime_type attributes once registered.
-    assert str(list_voices.uri) == "voice://voices"
-    assert list_voices.mime_type == "application/json"
-    assert "voice://voices/{provider}" in str(list_voices_for_provider.uri_template)
-    assert list_voices_for_provider.mime_type == "application/json"
+    # FastMCP 3.x: @mcp.resource decorator returns the raw function, so we
+    # query the server for registered resources rather than introspecting
+    # the decorated objects directly. (In 2.x the decorator returned a
+    # wrapper exposing .uri / .mime_type / .uri_template.)
+    from voice_mode.server import mcp
+
+    static = {str(r.uri): r for r in await mcp.list_resources()}
+    assert "voice://voices" in static
+    assert static["voice://voices"].mime_type == "application/json"
+
+    templates = {str(t.uri_template): t for t in await mcp.list_resource_templates()}
+    assert any("voice://voices/{provider}" in u for u in templates)
+    template = next(t for u, t in templates.items() if "voice://voices/{provider}" in u)
+    assert template.mime_type == "application/json"

--- a/uv.lock
+++ b/uv.lock
@@ -10,6 +10,18 @@ resolution-markers = [
 ]
 
 [[package]]
+name = "aiofile"
+version = "3.9.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "caio" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/67/e2/d7cb819de8df6b5c1968a2756c3cb4122d4fa2b8fc768b53b7c9e5edb646/aiofile-3.9.0.tar.gz", hash = "sha256:e5ad718bb148b265b6df1b3752c4d1d83024b93da9bd599df74b9d9ffcf7919b", size = 17943, upload-time = "2024-10-08T10:39:35.846Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/50/25/da1f0b4dd970e52bf5a36c204c107e11a0c6d3ed195eba0bfbc664c312b2/aiofile-3.9.0-py3-none-any.whl", hash = "sha256:ce2f6c1571538cbdfa0143b04e16b208ecb0e9cb4148e528af8a640ed51cc8aa", size = 19539, upload-time = "2024-10-08T10:39:32.955Z" },
+]
+
+[[package]]
 name = "aiofiles"
 version = "24.1.0"
 source = { registry = "https://pypi.org/simple" }
@@ -362,14 +374,15 @@ wheels = [
 
 [[package]]
 name = "authlib"
-version = "1.6.3"
+version = "1.7.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "cryptography" },
+    { name = "joserfc" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/5d/c6/d9a9db2e71957827e23a34322bde8091b51cb778dcc38885b84c772a1ba9/authlib-1.6.3.tar.gz", hash = "sha256:9f7a982cc395de719e4c2215c5707e7ea690ecf84f1ab126f28c053f4219e610", size = 160836, upload-time = "2025-08-26T12:13:25.206Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/36/98/7d93f30d029643c0275dbc0bd6d5a6f670661ee6c9a94d93af7ab4887600/authlib-1.7.2.tar.gz", hash = "sha256:2cea25fefcd4e7173bdf1372c0afc265c8034b23a8cd5dcb6a9164b826c64231", size = 176511, upload-time = "2026-05-06T08:10:23.116Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/25/2f/efa9d26dbb612b774990741fd8f13c7cf4cfd085b870e4a5af5c82eaf5f1/authlib-1.6.3-py2.py3-none-any.whl", hash = "sha256:7ea0f082edd95a03b7b72edac65ec7f8f68d703017d7e37573aee4fc603f2a48", size = 240105, upload-time = "2025-08-26T12:13:23.889Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/95/adcb68e20c34162e9135f370d6e31737719c2b6f94bc953fe7ed1f10fe21/authlib-1.7.2-py2.py3-none-any.whl", hash = "sha256:3e1faedc9d87e7d56a164eca3ccb6ace0d61b94abe83e92242f8dc8bba9b4a9f", size = 259548, upload-time = "2026-05-06T08:10:21.436Z" },
 ]
 
 [[package]]
@@ -461,6 +474,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/10/bf/fa31834dc27a7f05e5290eae47c82690edc3a7b37d58f7fb35a1bdbf355b/backrefs-5.9-py313-none-any.whl", hash = "sha256:cc37b19fa219e93ff825ed1fed8879e47b4d89aa7a1884860e2db64ccd7c676b", size = 399843, upload-time = "2025-06-22T19:34:09.68Z" },
     { url = "https://files.pythonhosted.org/packages/fc/24/b29af34b2c9c41645a9f4ff117bae860291780d73880f449e0b5d948c070/backrefs-5.9-py314-none-any.whl", hash = "sha256:df5e169836cc8acb5e440ebae9aad4bf9d15e226d3bad049cf3f6a5c20cc8dc9", size = 411762, upload-time = "2025-06-22T19:34:11.037Z" },
     { url = "https://files.pythonhosted.org/packages/41/ff/392bff89415399a979be4a65357a41d92729ae8580a66073d8ec8d810f98/backrefs-5.9-py39-none-any.whl", hash = "sha256:f48ee18f6252b8f5777a22a00a09a85de0ca931658f1dd96d4406a34f3748c60", size = 380265, upload-time = "2025-06-22T19:34:12.405Z" },
+]
+
+[[package]]
+name = "beartype"
+version = "0.22.9"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c7/94/1009e248bbfbab11397abca7193bea6626806be9a327d399810d523a07cb/beartype-0.22.9.tar.gz", hash = "sha256:8f82b54aa723a2848a56008d18875f91c1db02c32ef6a62319a002e3e25a975f", size = 1608866, upload-time = "2025-12-13T06:50:30.72Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/71/cc/18245721fa7747065ab478316c7fea7c74777d07f37ae60db2e84f8172e8/beartype-0.22.9-py3-none-any.whl", hash = "sha256:d16c9bbc61ea14637596c5f6fbff2ee99cbe3573e46a716401734ef50c3060c2", size = 1333658, upload-time = "2025-12-13T06:50:28.266Z" },
 ]
 
 [[package]]
@@ -586,6 +608,44 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/78/e0/df5e171f685f82f37b12e1f208064e24244911079d7b767447d1af7e0d70/build-1.5.0.tar.gz", hash = "sha256:302c22c3ba2a0fd5f3911918651341ebb3896176cbdec15bd421f80b1afc7647", size = 89796, upload-time = "2026-04-30T03:18:25.17Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/0d/fe/6bea5c9162869c5beba5d9c8abbed835ec85bf1ec1fba05a3822325c45f3/build-1.5.0-py3-none-any.whl", hash = "sha256:13f3eecb844759ab66efec90ca17639bbf14dc06cb2fdf37a9010322d9c50a6f", size = 26018, upload-time = "2026-04-30T03:18:23.644Z" },
+]
+
+[[package]]
+name = "cachetools"
+version = "7.1.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ff/e2/85f227594656000ff4d8adadae91a21f536d4a84c6c716a86bd6685874be/cachetools-7.1.1.tar.gz", hash = "sha256:27bdf856d68fd3c71c26c01b5edc312124ed427524d1ddb31aa2b7746fe20d4b", size = 40202, upload-time = "2026-05-03T20:00:29.391Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/bf/0f/f897abe4ea0a8c408ae65c8c83bffab4936ad65d6032d4fb4cd35bbdc3ee/cachetools-7.1.1-py3-none-any.whl", hash = "sha256:0335cd7a0952d2b22327441fb0628139e234c565559eeb91a8a4ac7551c5353d", size = 16775, upload-time = "2026-05-03T20:00:27.857Z" },
+]
+
+[[package]]
+name = "caio"
+version = "0.9.25"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/92/88/b8527e1b00c1811db339a1df8bd1ae49d146fcea9d6a5c40e3a80aaeb38d/caio-0.9.25.tar.gz", hash = "sha256:16498e7f81d1d0f5a4c0ad3f2540e65fe25691376e0a5bd367f558067113ed10", size = 26781, upload-time = "2025-12-26T15:21:36.501Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6a/80/ea4ead0c5d52a9828692e7df20f0eafe8d26e671ce4883a0a146bb91049e/caio-0.9.25-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:ca6c8ecda611478b6016cb94d23fd3eb7124852b985bdec7ecaad9f3116b9619", size = 36836, upload-time = "2025-12-26T15:22:04.662Z" },
+    { url = "https://files.pythonhosted.org/packages/17/b9/36715c97c873649d1029001578f901b50250916295e3dddf20c865438865/caio-0.9.25-cp310-cp310-manylinux2010_x86_64.manylinux2014_x86_64.manylinux_2_12_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:db9b5681e4af8176159f0d6598e73b2279bb661e718c7ac23342c550bd78c241", size = 79695, upload-time = "2025-12-26T15:22:18.818Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/ab/07080ecb1adb55a02cbd8ec0126aa8e43af343ffabb6a71125b42670e9a1/caio-0.9.25-cp310-cp310-manylinux_2_34_aarch64.whl", hash = "sha256:bf61d7d0c4fd10ffdd98ca47f7e8db4d7408e74649ffaf4bef40b029ada3c21b", size = 79457, upload-time = "2026-03-04T22:08:16.024Z" },
+    { url = "https://files.pythonhosted.org/packages/88/95/dd55757bb671eb4c376e006c04e83beb413486821f517792ea603ef216e9/caio-0.9.25-cp310-cp310-manylinux_2_34_x86_64.whl", hash = "sha256:ab52e5b643f8bbd64a0605d9412796cd3464cb8ca88593b13e95a0f0b10508ae", size = 77705, upload-time = "2026-03-04T22:08:17.202Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/90/543f556fcfcfa270713eef906b6352ab048e1e557afec12925c991dc93c2/caio-0.9.25-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:d6956d9e4a27021c8bd6c9677f3a59eb1d820cc32d0343cea7961a03b1371965", size = 36839, upload-time = "2025-12-26T15:21:40.267Z" },
+    { url = "https://files.pythonhosted.org/packages/51/3b/36f3e8ec38dafe8de4831decd2e44c69303d2a3892d16ceda42afed44e1b/caio-0.9.25-cp311-cp311-manylinux2010_x86_64.manylinux2014_x86_64.manylinux_2_12_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:bf84bfa039f25ad91f4f52944452a5f6f405e8afab4d445450978cd6241d1478", size = 80255, upload-time = "2025-12-26T15:22:20.271Z" },
+    { url = "https://files.pythonhosted.org/packages/df/ce/65e64867d928e6aff1b4f0e12dba0ef6d5bf412c240dc1df9d421ac10573/caio-0.9.25-cp311-cp311-manylinux_2_34_aarch64.whl", hash = "sha256:ae3d62587332bce600f861a8de6256b1014d6485cfd25d68c15caf1611dd1f7c", size = 80052, upload-time = "2026-03-04T22:08:20.402Z" },
+    { url = "https://files.pythonhosted.org/packages/46/90/e278863c47e14ec58309aa2e38a45882fbe67b4cc29ec9bc8f65852d3e45/caio-0.9.25-cp311-cp311-manylinux_2_34_x86_64.whl", hash = "sha256:fc220b8533dcf0f238a6b1a4a937f92024c71e7b10b5a2dfc1c73604a25709bc", size = 78273, upload-time = "2026-03-04T22:08:21.368Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/25/79c98ebe12df31548ba4eaf44db11b7cad6b3e7b4203718335620939083c/caio-0.9.25-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:fb7ff95af4c31ad3f03179149aab61097a71fd85e05f89b4786de0359dffd044", size = 36983, upload-time = "2025-12-26T15:21:36.075Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/2b/21288691f16d479945968a0a4f2856818c1c5be56881d51d4dac9b255d26/caio-0.9.25-cp312-cp312-manylinux2010_x86_64.manylinux2014_x86_64.manylinux_2_12_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:97084e4e30dfa598449d874c4d8e0c8d5ea17d2f752ef5e48e150ff9d240cd64", size = 82012, upload-time = "2025-12-26T15:22:20.983Z" },
+    { url = "https://files.pythonhosted.org/packages/03/c4/8a1b580875303500a9c12b9e0af58cb82e47f5bcf888c2457742a138273c/caio-0.9.25-cp312-cp312-manylinux_2_34_aarch64.whl", hash = "sha256:4fa69eba47e0f041b9d4f336e2ad40740681c43e686b18b191b6c5f4c5544bfb", size = 81502, upload-time = "2026-03-04T22:08:22.381Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/1c/0fe770b8ffc8362c48134d1592d653a81a3d8748d764bec33864db36319d/caio-0.9.25-cp312-cp312-manylinux_2_34_x86_64.whl", hash = "sha256:6bebf6f079f1341d19f7386db9b8b1f07e8cc15ae13bfdaff573371ba0575d69", size = 80200, upload-time = "2026-03-04T22:08:23.382Z" },
+    { url = "https://files.pythonhosted.org/packages/31/57/5e6ff127e6f62c9f15d989560435c642144aa4210882f9494204bc892305/caio-0.9.25-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:d6c2a3411af97762a2b03840c3cec2f7f728921ff8adda53d7ea2315a8563451", size = 36979, upload-time = "2025-12-26T15:21:35.484Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/9f/f21af50e72117eb528c422d4276cbac11fb941b1b812b182e0a9c70d19c5/caio-0.9.25-cp313-cp313-manylinux2010_x86_64.manylinux2014_x86_64.manylinux_2_12_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:0998210a4d5cd5cb565b32ccfe4e53d67303f868a76f212e002a8554692870e6", size = 81900, upload-time = "2025-12-26T15:22:21.919Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/12/c39ae2a4037cb10ad5eb3578eb4d5f8c1a2575c62bba675f3406b7ef0824/caio-0.9.25-cp313-cp313-manylinux_2_34_aarch64.whl", hash = "sha256:1a177d4777141b96f175fe2c37a3d96dec7911ed9ad5f02bac38aaa1c936611f", size = 81523, upload-time = "2026-03-04T22:08:25.187Z" },
+    { url = "https://files.pythonhosted.org/packages/22/59/f8f2e950eb4f1a5a3883e198dca514b9d475415cb6cd7b78b9213a0dd45a/caio-0.9.25-cp313-cp313-manylinux_2_34_x86_64.whl", hash = "sha256:9ed3cfb28c0e99fec5e208c934e5c157d0866aa9c32aa4dc5e9b6034af6286b7", size = 80243, upload-time = "2026-03-04T22:08:26.449Z" },
+    { url = "https://files.pythonhosted.org/packages/69/ca/a08fdc7efdcc24e6a6131a93c85be1f204d41c58f474c42b0670af8c016b/caio-0.9.25-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:fab6078b9348e883c80a5e14b382e6ad6aabbc4429ca034e76e730cf464269db", size = 36978, upload-time = "2025-12-26T15:21:41.055Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/6c/d4d24f65e690213c097174d26eda6831f45f4734d9d036d81790a27e7b78/caio-0.9.25-cp314-cp314-manylinux2010_x86_64.manylinux2014_x86_64.manylinux_2_12_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:44a6b58e52d488c75cfaa5ecaa404b2b41cc965e6c417e03251e868ecd5b6d77", size = 81832, upload-time = "2025-12-26T15:22:22.757Z" },
+    { url = "https://files.pythonhosted.org/packages/87/a4/e534cf7d2d0e8d880e25dd61e8d921ffcfe15bd696734589826f5a2df727/caio-0.9.25-cp314-cp314-manylinux_2_34_aarch64.whl", hash = "sha256:628a630eb7fb22381dd8e3c8ab7f59e854b9c806639811fc3f4310c6bd711d79", size = 81565, upload-time = "2026-03-04T22:08:27.483Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/ed/bf81aeac1d290017e5e5ac3e880fd56ee15e50a6d0353986799d1bc5cfd5/caio-0.9.25-cp314-cp314-manylinux_2_34_x86_64.whl", hash = "sha256:0ba16aa605ccb174665357fc729cf500679c2d94d5f1458a6f0d5ca48f2060a7", size = 80071, upload-time = "2026-03-04T22:08:28.751Z" },
+    { url = "https://files.pythonhosted.org/packages/86/93/1f76c8d1bafe3b0614e06b2195784a3765bbf7b0a067661af9e2dd47fc33/caio-0.9.25-py3-none-any.whl", hash = "sha256:06c0bb02d6b929119b1cfbe1ca403c768b2013a369e2db46bfa2a5761cf82e40", size = 19087, upload-time = "2025-12-26T15:22:00.221Z" },
 ]
 
 [[package]]
@@ -1086,18 +1146,19 @@ nvtx = [
 
 [[package]]
 name = "cyclopts"
-version = "3.24.0"
+version = "4.11.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "attrs" },
-    { name = "docstring-parser", marker = "python_full_version < '4'" },
+    { name = "docstring-parser" },
     { name = "rich" },
     { name = "rich-rst" },
+    { name = "tomli", marker = "python_full_version < '3.11'" },
     { name = "typing-extensions", marker = "python_full_version < '3.11'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/30/ca/7782da3b03242d5f0a16c20371dff99d4bd1fedafe26bc48ff82e42be8c9/cyclopts-3.24.0.tar.gz", hash = "sha256:de6964a041dfb3c57bf043b41e68c43548227a17de1bad246e3a0bfc5c4b7417", size = 76131, upload-time = "2025-09-08T15:40:57.75Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e4/f7/3ee212c1bc314551094fc8fda7b4b63c647ac5c32d06daa285d04d33edfc/cyclopts-4.11.2.tar.gz", hash = "sha256:8c9b77921660fa1ee52c150e2217ced672323efb3434e9b338077de1bc551ff4", size = 175935, upload-time = "2026-05-04T00:11:57.857Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/f0/8b/2c95f0645c6f40211896375e6fa51f504b8ccb29c21f6ae661fe87ab044e/cyclopts-3.24.0-py3-none-any.whl", hash = "sha256:809d04cde9108617106091140c3964ee6fceb33cecdd537f7ffa360bde13ed71", size = 86154, upload-time = "2025-09-08T15:40:56.41Z" },
+    { url = "https://files.pythonhosted.org/packages/23/18/4cedda786e7da429e7489549a9e5461530d4133130e541f25fb94f015776/cyclopts-4.11.2-py3-none-any.whl", hash = "sha256:838020120b939549ff7c8423aca29c86764b5dd1d8a5d7f3753a6327861f537b", size = 213537, upload-time = "2026-05-04T00:11:56.103Z" },
 ]
 
 [[package]]
@@ -1256,24 +1317,35 @@ wheels = [
 
 [[package]]
 name = "fastmcp"
-version = "2.12.3"
+version = "3.2.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "authlib" },
     { name = "cyclopts" },
     { name = "exceptiongroup" },
+    { name = "griffelib" },
     { name = "httpx" },
+    { name = "jsonref" },
+    { name = "jsonschema-path" },
     { name = "mcp" },
-    { name = "openapi-core" },
     { name = "openapi-pydantic" },
+    { name = "opentelemetry-api" },
+    { name = "packaging" },
+    { name = "platformdirs" },
+    { name = "py-key-value-aio", extra = ["filetree", "keyring", "memory"] },
     { name = "pydantic", extra = ["email"] },
     { name = "pyperclip" },
     { name = "python-dotenv" },
+    { name = "pyyaml" },
     { name = "rich" },
+    { name = "uncalled-for" },
+    { name = "uvicorn" },
+    { name = "watchfiles" },
+    { name = "websockets" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/99/5e/035fdfa23646de8811776cd62d93440e334e8a4557b35c63c1bff125c08c/fastmcp-2.12.3.tar.gz", hash = "sha256:541dd569d5b6c083140b04d997ba3dc47f7c10695cee700d0a733ce63b20bb65", size = 5246812, upload-time = "2025-09-12T12:28:07.136Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/9c/13/29544fbc6dfe45ea38046af0067311e0bad7acc7d1f2ad38bb08f2409fe2/fastmcp-3.2.4.tar.gz", hash = "sha256:083ecb75b44a4169e7fc0f632f94b781bdb0ff877c6b35b9877cbb566fd4d4d1", size = 28746127, upload-time = "2026-04-14T01:42:24.174Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/96/79/0fd386e61819e205563d4eb15da76564b80dc2edd3c64b46f2706235daec/fastmcp-2.12.3-py3-none-any.whl", hash = "sha256:aee50872923a9cba731861fc0120e7dbe4642a2685ba251b2b202b82fb6c25a9", size = 314031, upload-time = "2025-09-12T12:28:05.024Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/76/b310d52fa0e30d39bd937eb58ec2c1f1ea1b5f519f0575e9dd9612f01deb/fastmcp-3.2.4-py3-none-any.whl", hash = "sha256:e6c9c429171041455e47ab94bb3f83c4657622a0ec28922f6940053959bd58a9", size = 728599, upload-time = "2026-04-14T01:42:26.85Z" },
 ]
 
 [[package]]
@@ -1537,6 +1609,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/16/70/c2989a14bfb3975ca4923463b2e01eb917a79f8842aac48cb472a133cf26/gradio_client-1.13.0.tar.gz", hash = "sha256:07de7e8e58553335d56e0c7db6af60f1205fd1f167bf07f3e0f587888695a8f3", size = 322963, upload-time = "2025-09-10T17:06:32.23Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/92/aa/8ad1cc8be082867aaa941aae30a38d68db9fbaf4306a51143307acd79b7a/gradio_client-1.13.0-py3-none-any.whl", hash = "sha256:4489ebd07ae40c6cc7a6a02cf60a53e9e3345aa5342a3814c356775bbad64bbc", size = 325012, upload-time = "2025-09-10T17:06:30.721Z" },
+]
+
+[[package]]
+name = "griffelib"
+version = "2.0.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/9d/82/74f4a3310cdabfbb10da554c3a672847f1ed33c6f61dd472681ce7f1fe67/griffelib-2.0.2.tar.gz", hash = "sha256:3cf20b3bc470e83763ffbf236e0076b1211bac1bc67de13daf494640f2de707e", size = 166461, upload-time = "2026-03-27T11:34:51.091Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/11/8c/c9138d881c79aa0ea9ed83cbd58d5ca75624378b38cee225dcf5c42cc91f/griffelib-2.0.2-py3-none-any.whl", hash = "sha256:925c857658fb1ba40c0772c37acbc2ab650bd794d9c1b9726922e36ea4117ea1", size = 142357, upload-time = "2026-03-27T11:34:46.275Z" },
 ]
 
 [[package]]
@@ -1846,15 +1927,6 @@ wheels = [
 ]
 
 [[package]]
-name = "isodate"
-version = "0.7.2"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/54/4d/e940025e2ce31a8ce1202635910747e5a87cc3a6a6bb2d00973375014749/isodate-0.7.2.tar.gz", hash = "sha256:4cd1aa0f43ca76f4a6c6c0292a85f40b35ec2e43e315b59f06e6d32171a953e6", size = 29705, upload-time = "2024-10-08T23:04:11.5Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/15/aa/0aca39a37d3c7eb941ba736ede56d689e7be91cab5d9ca846bde3999eba6/isodate-0.7.2-py3-none-any.whl", hash = "sha256:28009937d8031054830160fce6d409ed342816b543597cece116d966c6d99e15", size = 22320, upload-time = "2024-10-08T23:04:09.501Z" },
-]
-
-[[package]]
 name = "isoduration"
 version = "20.11.0"
 source = { registry = "https://pypi.org/simple" }
@@ -2017,6 +2089,18 @@ wheels = [
 ]
 
 [[package]]
+name = "joserfc"
+version = "1.6.5"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cryptography" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/3b/dc/5f768c2e391e9afabe5d18e3221346deb5fb6338565f1ccc9e7c6d7befdd/joserfc-1.6.5.tar.gz", hash = "sha256:1482a7db78fb4602e44ed89e51b599d052e091288c7c532c5b694e20149dec48", size = 231881, upload-time = "2026-05-06T04:58:13.408Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/3b/ad1cb22e75c963b1f07c8a2329bf47227ce7e4361df5eb2fb101b2ce33ef/joserfc-1.6.5-py3-none-any.whl", hash = "sha256:e9878a0f8243fe7b95e11fdda81374ca9f7a689e302751579d3dfdeec559675e", size = 70464, upload-time = "2026-05-06T04:58:11.668Z" },
+]
+
+[[package]]
 name = "jsmin"
 version = "3.0.1"
 source = { registry = "https://pypi.org/simple" }
@@ -2038,6 +2122,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/6a/0a/eebeb1fa92507ea94016a2a790b93c2ae41a7e18778f85471dc54475ed25/jsonpointer-3.0.0.tar.gz", hash = "sha256:2b2d729f2091522d61c3b31f82e11870f60b68f43fbc705cb76bf4b832af59ef", size = 9114, upload-time = "2024-06-10T19:24:42.462Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/71/92/5e77f98553e9e75130c78900d000368476aed74276eb8ae8796f65f00918/jsonpointer-3.0.0-py2.py3-none-any.whl", hash = "sha256:13e088adc14fca8b6aa8177c044e12701e6ad4b28ff10e65f2267a90109c9942", size = 7595, upload-time = "2024-06-10T19:24:40.698Z" },
+]
+
+[[package]]
+name = "jsonref"
+version = "1.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/aa/0d/c1f3277e90ccdb50d33ed5ba1ec5b3f0a242ed8c1b1a85d3afeb68464dca/jsonref-1.1.0.tar.gz", hash = "sha256:32fe8e1d85af0fdefbebce950af85590b22b60f9e95443176adbde4e1ecea552", size = 8814, upload-time = "2023-01-16T16:10:04.455Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0c/ec/e1db9922bceb168197a558a2b8c03a7963f1afe93517ddd3cf99f202f996/jsonref-1.1.0-py3-none-any.whl", hash = "sha256:590dc7773df6c21cbf948b5dac07a72a251db28b0238ceecce0a2abfa8ec30a9", size = 9425, upload-time = "2023-01-16T16:10:02.255Z" },
 ]
 
 [[package]]
@@ -2325,51 +2418,6 @@ wheels = [
 ]
 
 [[package]]
-name = "lazy-object-proxy"
-version = "1.12.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/08/a2/69df9c6ba6d316cfd81fe2381e464db3e6de5db45f8c43c6a23504abf8cb/lazy_object_proxy-1.12.0.tar.gz", hash = "sha256:1f5a462d92fd0cfb82f1fab28b51bfb209fabbe6aabf7f0d51472c0c124c0c61", size = 43681, upload-time = "2025-08-22T13:50:06.783Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/d6/2b/d5e8915038acbd6c6a9fcb8aaf923dc184222405d3710285a1fec6e262bc/lazy_object_proxy-1.12.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:61d5e3310a4aa5792c2b599a7a78ccf8687292c8eb09cf187cca8f09cf6a7519", size = 26658, upload-time = "2025-08-22T13:42:23.373Z" },
-    { url = "https://files.pythonhosted.org/packages/da/8f/91fc00eeea46ee88b9df67f7c5388e60993341d2a406243d620b2fdfde57/lazy_object_proxy-1.12.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c1ca33565f698ac1aece152a10f432415d1a2aa9a42dfe23e5ba2bc255ab91f6", size = 68412, upload-time = "2025-08-22T13:42:24.727Z" },
-    { url = "https://files.pythonhosted.org/packages/07/d2/b7189a0e095caedfea4d42e6b6949d2685c354263bdf18e19b21ca9b3cd6/lazy_object_proxy-1.12.0-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d01c7819a410f7c255b20799b65d36b414379a30c6f1684c7bd7eb6777338c1b", size = 67559, upload-time = "2025-08-22T13:42:25.875Z" },
-    { url = "https://files.pythonhosted.org/packages/a3/ad/b013840cc43971582ff1ceaf784d35d3a579650eb6cc348e5e6ed7e34d28/lazy_object_proxy-1.12.0-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:029d2b355076710505c9545aef5ab3f750d89779310e26ddf2b7b23f6ea03cd8", size = 66651, upload-time = "2025-08-22T13:42:27.427Z" },
-    { url = "https://files.pythonhosted.org/packages/7e/6f/b7368d301c15612fcc4cd00412b5d6ba55548bde09bdae71930e1a81f2ab/lazy_object_proxy-1.12.0-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:cc6e3614eca88b1c8a625fc0a47d0d745e7c3255b21dac0e30b3037c5e3deeb8", size = 66901, upload-time = "2025-08-22T13:42:28.585Z" },
-    { url = "https://files.pythonhosted.org/packages/61/1b/c6b1865445576b2fc5fa0fbcfce1c05fee77d8979fd1aa653dd0f179aefc/lazy_object_proxy-1.12.0-cp310-cp310-win_amd64.whl", hash = "sha256:be5fe974e39ceb0d6c9db0663c0464669cf866b2851c73971409b9566e880eab", size = 26536, upload-time = "2025-08-22T13:42:29.636Z" },
-    { url = "https://files.pythonhosted.org/packages/01/b3/4684b1e128a87821e485f5a901b179790e6b5bc02f89b7ee19c23be36ef3/lazy_object_proxy-1.12.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:1cf69cd1a6c7fe2dbcc3edaa017cf010f4192e53796538cc7d5e1fedbfa4bcff", size = 26656, upload-time = "2025-08-22T13:42:30.605Z" },
-    { url = "https://files.pythonhosted.org/packages/3a/03/1bdc21d9a6df9ff72d70b2ff17d8609321bea4b0d3cffd2cea92fb2ef738/lazy_object_proxy-1.12.0-cp311-cp311-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:efff4375a8c52f55a145dc8487a2108c2140f0bec4151ab4e1843e52eb9987ad", size = 68832, upload-time = "2025-08-22T13:42:31.675Z" },
-    { url = "https://files.pythonhosted.org/packages/3d/4b/5788e5e8bd01d19af71e50077ab020bc5cce67e935066cd65e1215a09ff9/lazy_object_proxy-1.12.0-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1192e8c2f1031a6ff453ee40213afa01ba765b3dc861302cd91dbdb2e2660b00", size = 69148, upload-time = "2025-08-22T13:42:32.876Z" },
-    { url = "https://files.pythonhosted.org/packages/79/0e/090bf070f7a0de44c61659cb7f74c2fe02309a77ca8c4b43adfe0b695f66/lazy_object_proxy-1.12.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:3605b632e82a1cbc32a1e5034278a64db555b3496e0795723ee697006b980508", size = 67800, upload-time = "2025-08-22T13:42:34.054Z" },
-    { url = "https://files.pythonhosted.org/packages/cf/d2/b320325adbb2d119156f7c506a5fbfa37fcab15c26d13cf789a90a6de04e/lazy_object_proxy-1.12.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:a61095f5d9d1a743e1e20ec6d6db6c2ca511961777257ebd9b288951b23b44fa", size = 68085, upload-time = "2025-08-22T13:42:35.197Z" },
-    { url = "https://files.pythonhosted.org/packages/6a/48/4b718c937004bf71cd82af3713874656bcb8d0cc78600bf33bb9619adc6c/lazy_object_proxy-1.12.0-cp311-cp311-win_amd64.whl", hash = "sha256:997b1d6e10ecc6fb6fe0f2c959791ae59599f41da61d652f6c903d1ee58b7370", size = 26535, upload-time = "2025-08-22T13:42:36.521Z" },
-    { url = "https://files.pythonhosted.org/packages/0d/1b/b5f5bd6bda26f1e15cd3232b223892e4498e34ec70a7f4f11c401ac969f1/lazy_object_proxy-1.12.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:8ee0d6027b760a11cc18281e702c0309dd92da458a74b4c15025d7fc490deede", size = 26746, upload-time = "2025-08-22T13:42:37.572Z" },
-    { url = "https://files.pythonhosted.org/packages/55/64/314889b618075c2bfc19293ffa9153ce880ac6153aacfd0a52fcabf21a66/lazy_object_proxy-1.12.0-cp312-cp312-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:4ab2c584e3cc8be0dfca422e05ad30a9abe3555ce63e9ab7a559f62f8dbc6ff9", size = 71457, upload-time = "2025-08-22T13:42:38.743Z" },
-    { url = "https://files.pythonhosted.org/packages/11/53/857fc2827fc1e13fbdfc0ba2629a7d2579645a06192d5461809540b78913/lazy_object_proxy-1.12.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:14e348185adbd03ec17d051e169ec45686dcd840a3779c9d4c10aabe2ca6e1c0", size = 71036, upload-time = "2025-08-22T13:42:40.184Z" },
-    { url = "https://files.pythonhosted.org/packages/2b/24/e581ffed864cd33c1b445b5763d617448ebb880f48675fc9de0471a95cbc/lazy_object_proxy-1.12.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:c4fcbe74fb85df8ba7825fa05eddca764138da752904b378f0ae5ab33a36c308", size = 69329, upload-time = "2025-08-22T13:42:41.311Z" },
-    { url = "https://files.pythonhosted.org/packages/78/be/15f8f5a0b0b2e668e756a152257d26370132c97f2f1943329b08f057eff0/lazy_object_proxy-1.12.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:563d2ec8e4d4b68ee7848c5ab4d6057a6d703cb7963b342968bb8758dda33a23", size = 70690, upload-time = "2025-08-22T13:42:42.51Z" },
-    { url = "https://files.pythonhosted.org/packages/5d/aa/f02be9bbfb270e13ee608c2b28b8771f20a5f64356c6d9317b20043c6129/lazy_object_proxy-1.12.0-cp312-cp312-win_amd64.whl", hash = "sha256:53c7fd99eb156bbb82cbc5d5188891d8fdd805ba6c1e3b92b90092da2a837073", size = 26563, upload-time = "2025-08-22T13:42:43.685Z" },
-    { url = "https://files.pythonhosted.org/packages/f4/26/b74c791008841f8ad896c7f293415136c66cc27e7c7577de4ee68040c110/lazy_object_proxy-1.12.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:86fd61cb2ba249b9f436d789d1356deae69ad3231dc3c0f17293ac535162672e", size = 26745, upload-time = "2025-08-22T13:42:44.982Z" },
-    { url = "https://files.pythonhosted.org/packages/9b/52/641870d309e5d1fb1ea7d462a818ca727e43bfa431d8c34b173eb090348c/lazy_object_proxy-1.12.0-cp313-cp313-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:81d1852fb30fab81696f93db1b1e55a5d1ff7940838191062f5f56987d5fcc3e", size = 71537, upload-time = "2025-08-22T13:42:46.141Z" },
-    { url = "https://files.pythonhosted.org/packages/47/b6/919118e99d51c5e76e8bf5a27df406884921c0acf2c7b8a3b38d847ab3e9/lazy_object_proxy-1.12.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:be9045646d83f6c2664c1330904b245ae2371b5c57a3195e4028aedc9f999655", size = 71141, upload-time = "2025-08-22T13:42:47.375Z" },
-    { url = "https://files.pythonhosted.org/packages/e5/47/1d20e626567b41de085cf4d4fb3661a56c159feaa73c825917b3b4d4f806/lazy_object_proxy-1.12.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:67f07ab742f1adfb3966c40f630baaa7902be4222a17941f3d85fd1dae5565ff", size = 69449, upload-time = "2025-08-22T13:42:48.49Z" },
-    { url = "https://files.pythonhosted.org/packages/58/8d/25c20ff1a1a8426d9af2d0b6f29f6388005fc8cd10d6ee71f48bff86fdd0/lazy_object_proxy-1.12.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:75ba769017b944fcacbf6a80c18b2761a1795b03f8899acdad1f1c39db4409be", size = 70744, upload-time = "2025-08-22T13:42:49.608Z" },
-    { url = "https://files.pythonhosted.org/packages/c0/67/8ec9abe15c4f8a4bcc6e65160a2c667240d025cbb6591b879bea55625263/lazy_object_proxy-1.12.0-cp313-cp313-win_amd64.whl", hash = "sha256:7b22c2bbfb155706b928ac4d74c1a63ac8552a55ba7fff4445155523ea4067e1", size = 26568, upload-time = "2025-08-22T13:42:57.719Z" },
-    { url = "https://files.pythonhosted.org/packages/23/12/cd2235463f3469fd6c62d41d92b7f120e8134f76e52421413a0ad16d493e/lazy_object_proxy-1.12.0-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:4a79b909aa16bde8ae606f06e6bbc9d3219d2e57fb3e0076e17879072b742c65", size = 27391, upload-time = "2025-08-22T13:42:50.62Z" },
-    { url = "https://files.pythonhosted.org/packages/60/9e/f1c53e39bbebad2e8609c67d0830cc275f694d0ea23d78e8f6db526c12d3/lazy_object_proxy-1.12.0-cp313-cp313t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:338ab2f132276203e404951205fe80c3fd59429b3a724e7b662b2eb539bb1be9", size = 80552, upload-time = "2025-08-22T13:42:51.731Z" },
-    { url = "https://files.pythonhosted.org/packages/4c/b6/6c513693448dcb317d9d8c91d91f47addc09553613379e504435b4cc8b3e/lazy_object_proxy-1.12.0-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:8c40b3c9faee2e32bfce0df4ae63f4e73529766893258eca78548bac801c8f66", size = 82857, upload-time = "2025-08-22T13:42:53.225Z" },
-    { url = "https://files.pythonhosted.org/packages/12/1c/d9c4aaa4c75da11eb7c22c43d7c90a53b4fca0e27784a5ab207768debea7/lazy_object_proxy-1.12.0-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:717484c309df78cedf48396e420fa57fc8a2b1f06ea889df7248fdd156e58847", size = 80833, upload-time = "2025-08-22T13:42:54.391Z" },
-    { url = "https://files.pythonhosted.org/packages/0b/ae/29117275aac7d7d78ae4f5a4787f36ff33262499d486ac0bf3e0b97889f6/lazy_object_proxy-1.12.0-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:a6b7ea5ea1ffe15059eb44bcbcb258f97bcb40e139b88152c40d07b1a1dfc9ac", size = 79516, upload-time = "2025-08-22T13:42:55.812Z" },
-    { url = "https://files.pythonhosted.org/packages/19/40/b4e48b2c38c69392ae702ae7afa7b6551e0ca5d38263198b7c79de8b3bdf/lazy_object_proxy-1.12.0-cp313-cp313t-win_amd64.whl", hash = "sha256:08c465fb5cd23527512f9bd7b4c7ba6cec33e28aad36fbbe46bf7b858f9f3f7f", size = 27656, upload-time = "2025-08-22T13:42:56.793Z" },
-    { url = "https://files.pythonhosted.org/packages/ef/3a/277857b51ae419a1574557c0b12e0d06bf327b758ba94cafc664cb1e2f66/lazy_object_proxy-1.12.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:c9defba70ab943f1df98a656247966d7729da2fe9c2d5d85346464bf320820a3", size = 26582, upload-time = "2025-08-22T13:49:49.366Z" },
-    { url = "https://files.pythonhosted.org/packages/1a/b6/c5e0fa43535bb9c87880e0ba037cdb1c50e01850b0831e80eb4f4762f270/lazy_object_proxy-1.12.0-cp314-cp314-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:6763941dbf97eea6b90f5b06eb4da9418cc088fce0e3883f5816090f9afcde4a", size = 71059, upload-time = "2025-08-22T13:49:50.488Z" },
-    { url = "https://files.pythonhosted.org/packages/06/8a/7dcad19c685963c652624702f1a968ff10220b16bfcc442257038216bf55/lazy_object_proxy-1.12.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:fdc70d81235fc586b9e3d1aeef7d1553259b62ecaae9db2167a5d2550dcc391a", size = 71034, upload-time = "2025-08-22T13:49:54.224Z" },
-    { url = "https://files.pythonhosted.org/packages/12/ac/34cbfb433a10e28c7fd830f91c5a348462ba748413cbb950c7f259e67aa7/lazy_object_proxy-1.12.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:0a83c6f7a6b2bfc11ef3ed67f8cbe99f8ff500b05655d8e7df9aab993a6abc95", size = 69529, upload-time = "2025-08-22T13:49:55.29Z" },
-    { url = "https://files.pythonhosted.org/packages/6f/6a/11ad7e349307c3ca4c0175db7a77d60ce42a41c60bcb11800aabd6a8acb8/lazy_object_proxy-1.12.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:256262384ebd2a77b023ad02fbcc9326282bcfd16484d5531154b02bc304f4c5", size = 70391, upload-time = "2025-08-22T13:49:56.35Z" },
-    { url = "https://files.pythonhosted.org/packages/59/97/9b410ed8fbc6e79c1ee8b13f8777a80137d4bc189caf2c6202358e66192c/lazy_object_proxy-1.12.0-cp314-cp314-win_amd64.whl", hash = "sha256:7601ec171c7e8584f8ff3f4e440aa2eebf93e854f04639263875b8c2971f819f", size = 26988, upload-time = "2025-08-22T13:49:57.302Z" },
-    { url = "https://files.pythonhosted.org/packages/41/a0/b91504515c1f9a299fc157967ffbd2f0321bce0516a3d5b89f6f4cad0355/lazy_object_proxy-1.12.0-pp39.pp310.pp311.graalpy311-none-any.whl", hash = "sha256:c3b2e0af1f7f77c4263759c4824316ce458fabe0fceadcd24ef8ca08b2d1e402", size = 15072, upload-time = "2025-08-22T13:50:05.498Z" },
-]
-
-[[package]]
 name = "livekit"
 version = "1.1.7"
 source = { registry = "https://pypi.org/simple" }
@@ -2625,7 +2673,7 @@ wheels = [
 
 [[package]]
 name = "mcp"
-version = "1.14.0"
+version = "1.27.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
@@ -2634,15 +2682,18 @@ dependencies = [
     { name = "jsonschema" },
     { name = "pydantic" },
     { name = "pydantic-settings" },
+    { name = "pyjwt", extra = ["crypto"] },
     { name = "python-multipart" },
     { name = "pywin32", marker = "sys_platform == 'win32'" },
     { name = "sse-starlette" },
     { name = "starlette" },
+    { name = "typing-extensions" },
+    { name = "typing-inspection" },
     { name = "uvicorn", marker = "sys_platform != 'emscripten'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/95/fd/d6e941a52446198b73e5e4a953441f667f1469aeb06fb382d9f6729d6168/mcp-1.14.0.tar.gz", hash = "sha256:2e7d98b195e08b2abc1dc6191f6f3dc0059604ac13ee6a40f88676274787fac4", size = 454855, upload-time = "2025-09-11T17:40:48.667Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/38/83/d1efe7c2980d8a3afa476f4e3d42d53dd54c0ab94c27bee5d755b45c8b73/mcp-1.27.1.tar.gz", hash = "sha256:0f47e1820f8f8f941466b39749eb1d1839a04caddca2bc60e9d46e8a99914924", size = 608458, upload-time = "2026-05-08T16:50:12.601Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/04/7b/84b0dd4c2c5a499d2c5d63fb7a1224c25fc4c8b6c24623fa7a566471480d/mcp-1.14.0-py3-none-any.whl", hash = "sha256:b2d27feba27b4c53d41b58aa7f4d090ae0cb740cbc4e339af10f8cbe54c4e19d", size = 163805, upload-time = "2025-09-11T17:40:46.891Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/73/42d9596facebdb533b7f0b86c1b0364ef350d1f8ba78b1052e8a58b48b65/mcp-1.27.1-py3-none-any.whl", hash = "sha256:1af3c4203b329430fde7a87b4fcb6392a041f5cb851fd68fc674016ab4e7c06f", size = 216260, upload-time = "2026-05-08T16:50:10.547Z" },
 ]
 
 [[package]]
@@ -3425,26 +3476,6 @@ realtime = [
 ]
 
 [[package]]
-name = "openapi-core"
-version = "0.19.5"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "isodate" },
-    { name = "jsonschema" },
-    { name = "jsonschema-path" },
-    { name = "more-itertools" },
-    { name = "openapi-schema-validator" },
-    { name = "openapi-spec-validator" },
-    { name = "parse" },
-    { name = "typing-extensions" },
-    { name = "werkzeug" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/b1/35/1acaa5f2fcc6e54eded34a2ec74b479439c4e469fc4e8d0e803fda0234db/openapi_core-0.19.5.tar.gz", hash = "sha256:421e753da56c391704454e66afe4803a290108590ac8fa6f4a4487f4ec11f2d3", size = 103264, upload-time = "2025-03-20T20:17:28.193Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/27/6f/83ead0e2e30a90445ee4fc0135f43741aebc30cca5b43f20968b603e30b6/openapi_core-0.19.5-py3-none-any.whl", hash = "sha256:ef7210e83a59394f46ce282639d8d26ad6fc8094aa904c9c16eb1bac8908911f", size = 106595, upload-time = "2025-03-20T20:17:26.77Z" },
-]
-
-[[package]]
 name = "openapi-pydantic"
 version = "0.5.1"
 source = { registry = "https://pypi.org/simple" }
@@ -3454,35 +3485,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/02/2e/58d83848dd1a79cb92ed8e63f6ba901ca282c5f09d04af9423ec26c56fd7/openapi_pydantic-0.5.1.tar.gz", hash = "sha256:ff6835af6bde7a459fb93eb93bb92b8749b754fc6e51b2f1590a19dc3005ee0d", size = 60892, upload-time = "2025-01-08T19:29:27.083Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/12/cf/03675d8bd8ecbf4445504d8071adab19f5f993676795708e36402ab38263/openapi_pydantic-0.5.1-py3-none-any.whl", hash = "sha256:a3a09ef4586f5bd760a8df7f43028b60cafb6d9f61de2acba9574766255ab146", size = 96381, upload-time = "2025-01-08T19:29:25.275Z" },
-]
-
-[[package]]
-name = "openapi-schema-validator"
-version = "0.6.3"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "jsonschema" },
-    { name = "jsonschema-specifications" },
-    { name = "rfc3339-validator" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/8b/f3/5507ad3325169347cd8ced61c232ff3df70e2b250c49f0fe140edb4973c6/openapi_schema_validator-0.6.3.tar.gz", hash = "sha256:f37bace4fc2a5d96692f4f8b31dc0f8d7400fd04f3a937798eaf880d425de6ee", size = 11550, upload-time = "2025-01-10T18:08:22.268Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/21/c6/ad0fba32775ae749016829dace42ed80f4407b171da41313d1a3a5f102e4/openapi_schema_validator-0.6.3-py3-none-any.whl", hash = "sha256:f3b9870f4e556b5a62a1c39da72a6b4b16f3ad9c73dc80084b1b11e74ba148a3", size = 8755, upload-time = "2025-01-10T18:08:19.758Z" },
-]
-
-[[package]]
-name = "openapi-spec-validator"
-version = "0.7.2"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "jsonschema" },
-    { name = "jsonschema-path" },
-    { name = "lazy-object-proxy" },
-    { name = "openapi-schema-validator" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/82/af/fe2d7618d6eae6fb3a82766a44ed87cd8d6d82b4564ed1c7cfb0f6378e91/openapi_spec_validator-0.7.2.tar.gz", hash = "sha256:cc029309b5c5dbc7859df0372d55e9d1ff43e96d678b9ba087f7c56fc586f734", size = 36855, upload-time = "2025-06-07T14:48:56.299Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/27/dd/b3fd642260cb17532f66cc1e8250f3507d1e580483e209dc1e9d13bd980d/openapi_spec_validator-0.7.2-py3-none-any.whl", hash = "sha256:4bbdc0894ec85f1d1bea1d6d9c8b2c3c8d7ccaa13577ef40da9c006c9fd0eb60", size = 39713, upload-time = "2025-06-07T14:48:54.077Z" },
 ]
 
 [[package]]
@@ -3771,15 +3773,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/70/6f/3dd4940bbe001c06a65f88e36bad298bc7a0de5036115639926b0c5c0458/pandocfilters-1.5.1.tar.gz", hash = "sha256:002b4a555ee4ebc03f8b66307e287fa492e4a77b4ea14d3f934328297bb4939e", size = 8454, upload-time = "2024-01-18T20:08:13.726Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ef/af/4fbc8cab944db5d21b7e2a5b8e9211a03a79852b1157e2c102fcc61ac440/pandocfilters-1.5.1-py2.py3-none-any.whl", hash = "sha256:93be382804a9cdb0a7267585f157e5d1731bbe5545a85b268d6f5fe6232de2bc", size = 8663, upload-time = "2024-01-18T20:08:11.28Z" },
-]
-
-[[package]]
-name = "parse"
-version = "1.20.2"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/4f/78/d9b09ba24bb36ef8b83b71be547e118d46214735b6dfb39e4bfde0e9b9dd/parse-1.20.2.tar.gz", hash = "sha256:b41d604d16503c79d81af5165155c0b20f6c8d6c559efa66b4b695c3e5a0a0ce", size = 29391, upload-time = "2024-06-11T04:41:57.34Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/d0/31/ba45bf0b2aa7898d81cbbfac0e88c267befb59ad91a19e36e1bc5578ddb1/parse-1.20.2-py2.py3-none-any.whl", hash = "sha256:967095588cb802add9177d0c0b6133b5ba33b1ea9007ca800e526f42a85af558", size = 20126, upload-time = "2024-06-11T04:41:55.057Z" },
 ]
 
 [[package]]
@@ -4135,6 +4128,31 @@ wheels = [
 ]
 
 [[package]]
+name = "py-key-value-aio"
+version = "0.4.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "beartype" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/04/3c/0397c072a38d4bc580994b42e0c90c5f44f679303489e4376289534735e5/py_key_value_aio-0.4.4.tar.gz", hash = "sha256:e3012e6243ed7cc09bb05457bd4d03b1ba5c2b1ca8700096b3927db79ffbbe55", size = 92300, upload-time = "2026-02-16T21:21:43.245Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/32/69/f1b537ee70b7def42d63124a539ed3026a11a3ffc3086947a1ca6e861868/py_key_value_aio-0.4.4-py3-none-any.whl", hash = "sha256:18e17564ecae61b987f909fc2cd41ee2012c84b4b1dcb8c055cf8b4bc1bf3f5d", size = 152291, upload-time = "2026-02-16T21:21:44.241Z" },
+]
+
+[package.optional-dependencies]
+filetree = [
+    { name = "aiofile" },
+    { name = "anyio" },
+]
+keyring = [
+    { name = "keyring" },
+]
+memory = [
+    { name = "cachetools" },
+]
+
+[[package]]
 name = "pyaml"
 version = "25.7.0"
 source = { registry = "https://pypi.org/simple" }
@@ -4301,6 +4319,11 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/e7/46/bd74733ff231675599650d3e47f361794b22ef3e3770998dda30d3b63726/pyjwt-2.10.1.tar.gz", hash = "sha256:3cc5772eb20009233caf06e9d8a0577824723b44e6648ee0a2aedb6cf9381953", size = 87785, upload-time = "2024-11-28T03:43:29.933Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/61/ad/689f02752eeec26aed679477e80e632ef1b682313be70793d798c1d5fc8f/PyJWT-2.10.1-py3-none-any.whl", hash = "sha256:dcdd193e30abefd5debf142f9adfcdd2b58004e644f25406ffaebd50bd98dacb", size = 22997, upload-time = "2024-11-28T03:43:27.893Z" },
+]
+
+[package.optional-dependencies]
+crypto = [
+    { name = "cryptography" },
 ]
 
 [[package]]
@@ -5673,6 +5696,15 @@ wheels = [
 ]
 
 [[package]]
+name = "uncalled-for"
+version = "0.3.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/b5/82/345cc927f7fbdae6065e7768759932fcc827fc20b29b45dfbafa2f1f7da4/uncalled_for-0.3.2.tar.gz", hash = "sha256:89f5dbcd71e2b8f47c030b1fa302e6cce2ec795d1ac565eeb6525c5fe55cb8a2", size = 50032, upload-time = "2026-05-06T13:38:25.204Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3b/25/2c87754f3a9e692315f7b811244090e68f362979fc8886b3fbd2985a1d8c/uncalled_for-0.3.2-py3-none-any.whl", hash = "sha256:0ff60b142c7d1f8070bde9d42afaa70aedc77dcc10998c227687e9c15713418e", size = 11444, upload-time = "2026-05-06T13:38:24.025Z" },
+]
+
+[[package]]
 name = "uri-template"
 version = "1.3.0"
 source = { registry = "https://pypi.org/simple" }
@@ -5812,7 +5844,7 @@ requires-dist = [
     { name = "click", specifier = ">=8.0.0" },
     { name = "coremltools", marker = "extra == 'coreml'", specifier = ">=7.0" },
     { name = "coverage", extras = ["toml"], marker = "extra == 'test'", specifier = ">=7.4.0" },
-    { name = "fastmcp", specifier = ">=2.3.2,<3" },
+    { name = "fastmcp", specifier = ">=3.2.0,<4" },
     { name = "flask", marker = "extra == 'scripts'", specifier = ">=3.0.0" },
     { name = "gradio", marker = "extra == 'notebooks'", specifier = ">=4.0.0" },
     { name = "httpx" },

--- a/voice_mode/cli.py
+++ b/voice_mode/cli.py
@@ -495,7 +495,7 @@ def service_install(service_name, force):
     """
     if service_name == 'whisper':
         from voice_mode.tools.whisper.install import whisper_install
-        result = asyncio.run(whisper_install.fn(force_reinstall=force))
+        result = asyncio.run(getattr(whisper_install, 'fn', whisper_install)(force_reinstall=force))
         # Handle dict result from tool
         if isinstance(result, dict):
             if result.get("success"):
@@ -508,7 +508,7 @@ def service_install(service_name, force):
             click.echo(result)
     elif service_name == 'kokoro':
         from voice_mode.tools.kokoro.install import kokoro_install
-        result = asyncio.run(kokoro_install.fn(force_reinstall=force))
+        result = asyncio.run(getattr(kokoro_install, 'fn', kokoro_install)(force_reinstall=force))
         if isinstance(result, dict):
             if result.get("success"):
                 click.echo(f"✅ Kokoro installed successfully")
@@ -678,7 +678,7 @@ def health():
 def install(install_dir, port, force, version, auto_enable, skip_deps):
     """Install kokoro-fastapi TTS service."""
     from voice_mode.tools.kokoro.install import kokoro_install
-    result = asyncio.run(kokoro_install.fn(
+    result = asyncio.run(getattr(kokoro_install, 'fn', kokoro_install)(
         install_dir=install_dir,
         port=port,
         force_reinstall=force,
@@ -715,7 +715,7 @@ def install(install_dir, port, force, version, auto_enable, skip_deps):
 def uninstall(remove_models, remove_all_data):
     """Uninstall kokoro-fastapi service and optionally remove data."""
     from voice_mode.tools.kokoro.uninstall import kokoro_uninstall
-    result = asyncio.run(kokoro_uninstall.fn(
+    result = asyncio.run(getattr(kokoro_uninstall, 'fn', kokoro_uninstall)(
         remove_models=remove_models,
         remove_all_data=remove_all_data
     ))
@@ -849,7 +849,7 @@ def whisper_service_health():
 def whisper_service_install(install_dir, model, use_gpu, force, version, auto_enable, skip_deps):
     """Install whisper.cpp STT service with automatic system detection."""
     from voice_mode.tools.whisper.install import whisper_install
-    result = asyncio.run(whisper_install.fn(
+    result = asyncio.run(getattr(whisper_install, 'fn', whisper_install)(
         install_dir=install_dir,
         model=model,
         use_gpu=use_gpu,
@@ -904,7 +904,7 @@ def whisper_service_install(install_dir, model, use_gpu, force, version, auto_en
 def whisper_service_uninstall(remove_models, remove_all_data):
     """Uninstall whisper.cpp and optionally remove models and data."""
     from voice_mode.tools.whisper.uninstall import whisper_uninstall
-    result = asyncio.run(whisper_uninstall.fn(
+    result = asyncio.run(getattr(whisper_uninstall, 'fn', whisper_uninstall)(
         remove_models=remove_models,
         remove_all_data=remove_all_data
     ))
@@ -1511,7 +1511,7 @@ def config():
 def config_list():
     """List all configuration keys with their descriptions."""
     from voice_mode.tools.configuration_management import list_config_keys
-    result = asyncio.run(list_config_keys.fn())
+    result = asyncio.run(getattr(list_config_keys, 'fn', list_config_keys)())
     click.echo(result)
 
 
@@ -1560,7 +1560,7 @@ def config_get(key):
 def config_set(key, value):
     """Set a configuration value."""
     from voice_mode.tools.configuration_management import update_config
-    result = asyncio.run(update_config.fn(key, value))
+    result = asyncio.run(getattr(update_config, 'fn', update_config)(key, value))
     click.echo(result)
 
 
@@ -1709,7 +1709,7 @@ def diag():
 def info():
     """Show voicemode installation information."""
     from voice_mode.tools.diagnostics import voice_mode_info
-    result = asyncio.run(voice_mode_info.fn())
+    result = asyncio.run(getattr(voice_mode_info, 'fn', voice_mode_info)())
     click.echo(result)
 
 
@@ -1717,7 +1717,7 @@ def info():
 def devices():
     """List available audio input and output devices."""
     from voice_mode.tools.devices import check_audio_devices
-    result = asyncio.run(check_audio_devices.fn())
+    result = asyncio.run(getattr(check_audio_devices, 'fn', check_audio_devices)())
     click.echo(result)
 
 
@@ -1725,7 +1725,7 @@ def devices():
 def registry():
     """Show voice provider registry with all discovered endpoints."""
     from voice_mode.tools.voice_registry import voice_registry
-    result = asyncio.run(voice_registry.fn())
+    result = asyncio.run(getattr(voice_registry, 'fn', voice_registry)())
     click.echo(result)
 
 
@@ -1838,7 +1838,7 @@ def converse(message, wait, duration, min_duration, voice, tts_provider,
                 click.echo("   Press Ctrl+C to exit\n")
                 
                 # First message
-                result = await converse_fn.fn(
+                result = await getattr(converse_fn, 'fn', converse_fn)(
                     message=message,
                     wait_for_response=True,
                     listen_duration_max=duration,
@@ -1861,7 +1861,7 @@ def converse(message, wait, duration, min_duration, voice, tts_provider,
                 # Continue conversation
                 while True:
                     # Wait for user's next input
-                    result = await converse_fn.fn(
+                    result = await getattr(converse_fn, 'fn', converse_fn)(
                         message="",  # Empty message for listening only
                         wait_for_response=True,
                         listen_duration_max=duration,
@@ -1884,7 +1884,7 @@ def converse(message, wait, duration, min_duration, voice, tts_provider,
                         
                         # Check for exit commands
                         if user_text.lower() in ['exit', 'quit', 'goodbye', 'bye']:
-                            await converse_fn.fn(
+                            await getattr(converse_fn, 'fn', converse_fn)(
                                 message="Goodbye!",
                                 wait_for_response=False,
                                 voice=voice,
@@ -1897,7 +1897,7 @@ def converse(message, wait, duration, min_duration, voice, tts_provider,
                             break
             else:
                 # Single conversation
-                result = await converse_fn.fn(
+                result = await getattr(converse_fn, 'fn', converse_fn)(
                     message=message,
                     wait_for_response=wait,
                     listen_duration_max=duration,

--- a/voice_mode/prompts/release_notes.py
+++ b/voice_mode/prompts/release_notes.py
@@ -23,12 +23,10 @@ def release_notes_prompt(versions: str = "5") -> str:
     if not versions or versions == "":
         versions = "5"
 
-    # Get the changelog content from the resource
-    # Resources decorated with @mcp.resource need to access the fn attribute
-    if hasattr(changelog_resource, 'fn'):
-        changelog_content = changelog_resource.fn()
-    else:
-        changelog_content = changelog_resource()
+    # Get the changelog content from the resource.
+    # FastMCP 2.x: @mcp.resource wraps the function; access via .fn
+    # FastMCP 3.x: @mcp.resource returns the raw function
+    changelog_content = getattr(changelog_resource, 'fn', changelog_resource)()
     
     # If we got an error message, return it
     if changelog_content.startswith("Error") or changelog_content.startswith("CHANGELOG.md not found"):


### PR DESCRIPTION
## Summary

Migrates the `fastmcp` constraint from `>=2.3.2,<3` to `>=3.2.0,<4`, eliminating both remaining Critical-severity vulnerabilities found by `osv-scanner` (the third Critical, aiohttp, was fixed by the merged Dependabot batch in #391).

| Vuln | CVSS | Status |
|------|------|--------|
| fastmcp `GHSA-vv7q-7jx5-f767` | **10.0** | ✅ Fixed (2.12.3 → 3.2.4) |
| authlib `GHSA-wvwj-cvrp-7pv5` | 9.1 | ✅ Fixed (1.6.3 → 1.7.2) |
| 7× authlib High/Medium vulns | various | ✅ Fixed |
| mcp `GHSA-9h52-p55h-vw2f` | 7.6 | ✅ Fixed (1.14.0 → 1.27.1) |

`osv-scanner` reports: **73 → 55 total vulns; 2 → 0 Critical.**

## What changed

The only fastmcp 3.x breaking change that affects voicemode is the decorator return type:

- **2.x**: `@mcp.tool()` returns a `FunctionTool` wrapper exposing `.fn`
- **3.x**: `@mcp.tool()` returns the raw function

VM-742 mapped the entire surface in Feb 2026 and recommended a `getattr(tool, 'fn', tool)` shim that works on both versions. This PR applies that shim everywhere.

### Code changes

- `pyproject.toml` — bumped `fastmcp>=3.2.0,<4`
- `uv.lock` — fastmcp 3.2.4, authlib 1.7.2, mcp 1.27.1
- 70 `.fn(...)` call sites updated to `getattr(tool, 'fn', tool)(...)`
  - `voice_mode/cli.py` (15 sites)
  - `voice_mode/prompts/release_notes.py` (1 site, plus removal of redundant `if hasattr` block)
  - 8 test files (54 sites)
- 4 special-case sites:
  - 3× assignment (`converse_func = converse.fn` etc) → use `getattr`
  - 1× `assert callable(update_config.fn)` → use `getattr`
  - `tests/test_simple.py` — switched `_tool_manager._tools` (private) to `list_tools()` (public)
- `tests/test_voices_resource.py::test_resources_register_with_expected_uris` rewritten to query `mcp.list_resources()` / `mcp.list_resource_templates()` instead of introspecting the now-raw decorated functions

## Verification

- ✅ `make test`: **1015 passed, 0 failed** (60 skipped, all pre-existing)
- ✅ `voice-mode --help`: CLI loads cleanly
- ✅ MCP server smoke test: starts and enumerates tools
- ✅ `make audit-deps-critical`: 0 Critical findings remaining

## Out of scope (follow-up candidates)

- **cryptography 45.0.7 still has 3 vulns** (highest 8.2). No transitive dep requires a bump — needs an explicit constraint. Worth a small follow-up under VM-1236.
- The `getattr(tool, 'fn', tool)` shim is defensive — it works on both 2.x and 3.x. Now that the constraint locks to 3.x, a future cleanup pass can drop the shim and call decorated functions directly.

## Test plan

- [ ] CI green on Ubuntu (3.10/3.11/3.12) and macOS
- [ ] Manual: `voicemode converse` end-to-end works (stdio MCP transport)
- [ ] Manual: `voicemode serve` works (HTTP transport)
- [ ] After merge, re-run `make audit-deps` to confirm scan agrees

🤖 Generated with [Claude Code](https://claude.com/claude-code)