### PR TITLE
VM-1246: optional [voice] [message] args for /voicemode:converse

### DIFF
--- a/.claude/commands/converse.md
+++ b/.claude/commands/converse.md
@@ -1,6 +1,6 @@
 ---
 description: Start an ongoing voice conversation
-argument-hint: [message]
+argument-hint: [voice] [message]
 ---
 
 # /voicemode:converse
@@ -9,7 +9,20 @@ Start an ongoing voice conversation with the user using the `voicemode:converse`
 
 ## Implementation
 
-Use the `voicemode:converse` tool with the user's message. All parameters have sensible defaults.
+Call the `voicemode:converse` MCP tool. Argument handling:
+
+- `$1` — optional voice name (e.g. `af_river`, `samantha`, `nova`). If non-empty, pass it as the `voice` parameter to the tool. If empty, omit `voice` so the tool uses its default.
+- `$2` — optional initial message. If non-empty, use it as the message to speak. If empty, let the tool / Claude choose an appropriate opener.
+
+All other parameters have sensible defaults.
+
+### Examples
+
+- `/voicemode:converse` — no args, default voice, Claude chooses opener
+- `/voicemode:converse af_river` — use voice `af_river`, Claude chooses opener
+- `/voicemode:converse af_river "let's plan the day"` — use voice `af_river`, open with the given message
+
+If `$1` is provided but doesn't look like a known voice name (e.g. it contains spaces or punctuation that voices don't have), assume the user meant it as a message and pass it as the message instead — don't fail silently on a typo.
 
 ## If MCP Connection Fails
 

--- a/.claude/skills/converse/SKILL.md
+++ b/.claude/skills/converse/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: converse
 description: Start an ongoing voice conversation
-argument-hint: [message]
+argument-hint: [voice] [message]
 ---
 
 # /voicemode:converse
@@ -10,7 +10,20 @@ Start an ongoing voice conversation with the user using the `voicemode:converse`
 
 ## Implementation
 
-Use the `voicemode:converse` tool with the user's message. All parameters have sensible defaults.
+Call the `voicemode:converse` MCP tool. Argument handling:
+
+- `$1` — optional voice name (e.g. `af_river`, `samantha`, `nova`). If non-empty, pass it as the `voice` parameter to the tool. If empty, omit `voice` so the tool uses its default.
+- `$2` — optional initial message. If non-empty, use it as the message to speak. If empty, let the tool / Claude choose an appropriate opener.
+
+All other parameters have sensible defaults.
+
+### Examples
+
+- `/voicemode:converse` — no args, default voice, Claude chooses opener
+- `/voicemode:converse af_river` — use voice `af_river`, Claude chooses opener
+- `/voicemode:converse af_river "let's plan the day"` — use voice `af_river`, open with the given message
+
+If `$1` is provided but doesn't look like a known voice name (e.g. it contains spaces or punctuation that voices don't have), assume the user meant it as a message and pass it as the message instead — don't fail silently on a typo.
 
 ## If MCP Connection Fails
 


### PR DESCRIPTION
## Summary

- `/voicemode:converse` now accepts two optional positional args: `[voice] [message]`
- Voice comes first so the most common 'just switch voice' invocation is the cleanest: `/voicemode:converse af_river`
- Both `.claude/skills/converse/SKILL.md` (canonical) and `.claude/commands/converse.md` (legacy) updated in lockstep

## Examples

\`\`\`
/voicemode:converse                                       # no args, default voice, Claude opens
/voicemode:converse af_river                              # voice af_river, Claude opens
/voicemode:converse af_river "let's plan the day"         # voice af_river, opens with given line
\`\`\`

## Research

Research task: [VM-1246](../taskmaster-tasks/blob/master/projects/voicemode/VM-1246_research_make-voice-an-arg-to-voicemodeconverse-slash-command/README.md) — confirmed Claude Code supports multi-positional args via \`\$1 \$2\` (documented in Anthropic's plugin-dev `command-development` SKILL). Substitution is string-only, so positional is the right call; `key=value` would shift parsing into model behaviour.

## Test plan

- [ ] `/voicemode:converse` (no args) — default voice, Claude chooses opener
- [ ] `/voicemode:converse af_river` — uses `af_river`, Claude chooses opener
- [ ] `/voicemode:converse af_river "hi there"` — uses `af_river`, opens with "hi there"
- [ ] `/voicemode:converse "hi there"` — `\$1` isn't a known voice; command body should fall back to treating it as a message (this is the typo/heuristic case — worth confirming the LLM does the right thing)
- [ ] Invalid voice name (e.g. `/voicemode:converse not_a_voice`) — verify the failure surface; if too rough, follow-up task to wire `voice://voices` validation

🤖 Generated with [Claude Code](https://claude.com/claude-code)