### PR TITLE
converse: add --skip-stt flag, deprecate --no-wait

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **`voicemode converse --skip-stt`** -- Replaces `--no-wait` with a name that parallels the existing `--skip-tts` flag. Same behaviour: speak the message and exit without listening for a spoken response. The legacy `--no-wait` continues to work for now (see Deprecated).
+
 - **`voice://voices` and `voice://voices/{provider}` MCP resources for structured TTS voice discovery (VM-1208)** — Streamable HTTP MCP clients (iOS app, web client, other agents) can now enumerate available TTS voices as JSON instead of scraping prose from the `voice_registry` tool. Both resources advertise `mime_type=application/json`, share an enumerator with the `voice_registry` tool (so the JSON resource and the LLM-facing prose can never disagree), and include impressions only for local callers (toggleable via `VOICEMODE_EXPOSE_LOCAL_VOICES_REMOTE`). 60-second in-process TTL on `/audio/voices` probes; OpenAI voices come from a hand-maintained constant. As a side-effect the `voice_registry` tool now reports `Voices: none detected` for offline endpoints instead of the legacy 67-voice phantom fallback. See [`voice://voices` reference](docs/reference/voices-resource.md).
 
 #### Impressions (preview / experimental) (VM-1174)
@@ -65,10 +67,14 @@ Newer Claude Code releases collapse MCP tool calls in the visible transcript, wh
 - **Parallel tool calls section simplified** -- Trimmed the "speak + act in parallel" section in the voicemode skill while preserving the key teaching content.
 - **mlx-audio pin floored at `>=0.4.3`** (VM-1126) -- `MLX_AUDIO_PIP_PACKAGE` now embeds the version specifier, so `uv tool install` refuses earlier releases that needed the deleted patch.
 
+### Deprecated
+
+- **`voicemode converse --no-wait`** -- Renamed to `--skip-stt` to make the intent ("speak only; skip listening for a spoken response") obvious and parallel with `--skip-tts`. `--no-wait` still works for now: it continues to function, is still completed by shell completion, but its help text is marked `[DEPRECATED]` and using it prints a deprecation notice to stderr. It will be removed in a future release. Migrate to `voicemode converse --skip-stt`.
+
 ### Removed
 
 - **Bundled `voice_mode/data/patches/mlx_audio_server.patch`** (VM-1126) -- The Metal-lock half of the patch was upstreamed in mlx-audio 0.4.3. The patch-apply step in `voice_mode/tools/mlx_audio/install.py` (and its `_apply_server_patch` / `_find_installed_server_py` / `_query_installed_version` helpers) is gone, along with the `voice_mode/data/**/*.patch` packaging glob and the corresponding tests. (The STT `response_format` patch is restored separately under VM-1128.)
-- **`sayas` CLI** (VM-1174) -- the standalone `sayas <voice> "text"` command is gone, along with its bash completion (`voice_mode/data/completions/sayas.bash`), test module (`tests/test_sayas_cli.py`), and `[project.scripts]` entry. Migration: `voicemode converse --voice <name> -m "text" --no-wait` (or pass `voice="<name>"` to the `voicemode:converse` MCP tool).
+- **`sayas` CLI** (VM-1174) -- the standalone `sayas <voice> "text"` command is gone, along with its bash completion (`voice_mode/data/completions/sayas.bash`), test module (`tests/test_sayas_cli.py`), and `[project.scripts]` entry. Migration: `voicemode converse --voice <name> -m "text" --skip-stt` (or pass `voice="<name>"` to the `voicemode:converse` MCP tool).
 
 ## [8.6.1] - 2026-04-21
 

--- a/docs/guides/impressions.md
+++ b/docs/guides/impressions.md
@@ -103,7 +103,7 @@ The Qwen3-TTS model (~3.4 GB) downloads on the first synthesis call. Plan for a 
 
 ### `sayas` is removed
 
-The standalone `sayas <voice> <text>` CLI from the 8.6.x line is **gone in 8.7.0**. Use `voicemode converse --voice <name> -m "text" --no-wait` instead -- it routes through the same mlx-audio backend and gets the rest of the converse pipeline (silence detection, audio formats, providers) for free. From the MCP tool, pass `voice="<name>"` to `voicemode:converse`.
+The standalone `sayas <voice> <text>` CLI from the 8.6.x line is **gone in 8.7.0**. Use `voicemode converse --voice <name> -m "text" --skip-stt` instead -- it routes through the same mlx-audio backend and gets the rest of the converse pipeline (silence detection, audio formats, providers) for free. From the MCP tool, pass `voice="<name>"` to `voicemode:converse`. (`--no-wait` still works but is deprecated.)
 
 ## Configuration
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -174,9 +174,14 @@ Options:
   --voice TEXT          Override TTS voice
   --model TEXT          Override TTS model
   --debug               Enable debug mode
-  --skip-tts            Text-only output
+  --skip-tts            Text-only output (skip TTS)
+  --skip-stt            Speak only; skip listening for a response (replaces --no-wait)
   --timeout INTEGER     Recording timeout in seconds
 ```
+
+> `--no-wait` is deprecated. It still works (and is still completed by the shell)
+> but prints a deprecation notice and will be removed in a future release. Use
+> `--skip-stt` instead.
 
 ### transcribe
 Transcribe audio with optional word-level timestamps

--- a/docs/reference/code-path-guide.md
+++ b/docs/reference/code-path-guide.md
@@ -40,7 +40,7 @@ This is a Click command group that handles all subcommands. Without a subcommand
 
 Key parameters:
 - `--message, -m`: Initial message to speak
-- `--wait/--no-wait`: Whether to wait for response
+- `--skip-stt`: Speak only; skip listening for a spoken response (replaces `--no-wait`, which is deprecated)
 - `--duration, -d`: Listen duration
 - `--voice`: TTS voice to use
 - `--tts-provider`: OpenAI or Kokoro

--- a/voice_mode/cli.py
+++ b/voice_mode/cli.py
@@ -119,7 +119,7 @@ def clone():
     Quick Start:
       voicemode service install mlx-audio              # Install backend
       voicemode clone add mike ~/clip.wav              # Add a voice
-      voicemode converse --voice mike -m "Hello world" --no-wait  # Use it
+      voicemode converse --voice mike -m "Hello world" --skip-stt  # Use it
     """
     pass
 
@@ -1774,7 +1774,10 @@ voice_mode_main_cli.add_command(transcribe_audio_cmd)
 @voice_mode_main_cli.command()
 @click.help_option('-h', '--help')
 @click.option('--message', '-m', default="Hello! How can I help you today?", help='Initial message to speak')
-@click.option('--wait/--no-wait', default=True, help='Wait for response after speaking')
+@click.option('--wait/--no-wait', 'wait', default=True,
+              help='[DEPRECATED] --no-wait is deprecated; use --skip-stt instead. Wait for response after speaking.')
+@click.option('--skip-stt', is_flag=True, default=False,
+              help='Speak only; skip listening for a spoken response (STT). Replaces --no-wait.')
 @click.option('--duration', '-d', type=float, default=DEFAULT_LISTEN_DURATION, help='Listen duration in seconds')
 @click.option('--min-duration', type=float, default=MIN_RECORDING_DURATION, help='Minimum listen duration before silence detection')
 @click.option('--voice', help='TTS voice to use (e.g., nova, shimmer, af_sky)')
@@ -1788,7 +1791,7 @@ voice_mode_main_cli.add_command(transcribe_audio_cmd)
 @click.option('--vad-aggressiveness', type=int, help='VAD aggressiveness (0-3)')
 @click.option('--skip-tts/--no-skip-tts', default=None, help='Skip TTS and only show text')
 @click.option('--continuous', '-c', is_flag=True, help='Continuous conversation mode')
-def converse(message, wait, duration, min_duration, voice, tts_provider,
+def converse(message, wait, skip_stt, duration, min_duration, voice, tts_provider,
             tts_model, tts_instructions, audio_feedback, audio_format, disable_silence_detection,
             speed, vad_aggressiveness, skip_tts, continuous):
     """Have a voice conversation directly from the command line.
@@ -1798,8 +1801,8 @@ def converse(message, wait, duration, min_duration, voice, tts_provider,
         # Simple conversation
         voicemode converse
 
-        # Speak a message without waiting
-        voicemode converse -m "Hello there!" --no-wait
+        # Speak a message without listening for a response
+        voicemode converse -m "Hello there!" --skip-stt
 
         # Continuous conversation mode
         voicemode converse --continuous
@@ -1807,6 +1810,21 @@ def converse(message, wait, duration, min_duration, voice, tts_provider,
         # Use specific voice
         voicemode converse --voice nova
     """
+    # Deprecation: --no-wait was renamed to --skip-stt.
+    # `wait` defaults to True, so `wait is False` means the user explicitly
+    # passed --no-wait on the command line.
+    if wait is False:
+        click.echo(
+            "⚠️  --no-wait is deprecated and will be removed in a future release. "
+            "Use --skip-stt instead.",
+            err=True,
+        )
+        # Fold the legacy flag into the new one so downstream logic only
+        # needs to consult `skip_stt`.
+        skip_stt = True
+
+    # `wait_for_response` is the inverse of skip_stt going forward.
+    wait_for_response = not skip_stt
     # Check core dependencies before running
     from voice_mode.utils.dependencies.checker import check_component_dependencies
 
@@ -1899,7 +1917,7 @@ def converse(message, wait, duration, min_duration, voice, tts_provider,
                 # Single conversation
                 result = await getattr(converse_fn, 'fn', converse_fn)(
                     message=message,
-                    wait_for_response=wait,
+                    wait_for_response=wait_for_response,
                     listen_duration_max=duration,
                     listen_duration_min=min_duration,
                     voice=voice,
@@ -1913,7 +1931,7 @@ def converse(message, wait, duration, min_duration, voice, tts_provider,
                     vad_aggressiveness=vad_aggressiveness,
                     skip_tts=skip_tts
                 )
-                
+
                 # Display result
                 if result:
                     if "Voice response:" in result:
@@ -1921,9 +1939,9 @@ def converse(message, wait, duration, min_duration, voice, tts_provider,
                         parts = result.split('|')
                         response_text = result.split('Voice response:')[1].split('|')[0].strip()
                         timing_info = parts[1].strip() if len(parts) > 1 else ""
-                        
+
                         click.echo(f"\n📢 Spoke: {message}")
-                        if wait:
+                        if wait_for_response:
                             click.echo(f"🎤 Heard: {response_text}")
                         if timing_info:
                             click.echo(f"⏱️  {timing_info}")


### PR DESCRIPTION
## Summary

- Adds `--skip-stt` to `voicemode converse` so it parallels the existing `--skip-tts` flag (clearer intent: *speak only; skip listening for a spoken response*).
- Deprecates `--no-wait` -- it keeps working and shell completion still includes it, but the help text is marked `[DEPRECATED]` and using it prints a deprecation notice to stderr before falling through to the new behaviour.
- Updates docstrings, Quick Start example, CLI reference, code-path guide, impressions guide, and CHANGELOG (Added + Deprecated entries).

## Test plan

- [x] `voicemode converse --help` shows both flags; `--wait/--no-wait` is labelled `[DEPRECATED]`.
- [x] `voicemode converse -m hi --skip-stt` -> `wait_for_response=False`, no warning.
- [x] `voicemode converse -m hi --no-wait` -> deprecation notice to stderr, `wait_for_response=False`.
- [x] `voicemode converse -m hi` (default) -> no warning, `wait_for_response=True`.
- [x] `voicemode converse -m hi --no-wait --skip-stt` -> warning + skip-stt (idempotent).
- [x] `uv run pytest tests/test_skip_tts.py -v` -- 4 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)