### PR TITLE
VM-1264: add --skip-conch / skip_conch to bypass conch coordination

### DIFF
--- a/tests/test_converse_skip_conch.py
+++ b/tests/test_converse_skip_conch.py
@@ -1,0 +1,142 @@
+"""Tests for converse's skip_conch parameter (VM-1264).
+
+skip_conch=True must bypass the conch coordination entirely:
+- Don't try to acquire the lock.
+- Don't return the "User is currently speaking with X" status message
+  when another agent holds the conch.
+- Don't release / delete a lock file owned by another process.
+
+We patch ``Conch.try_acquire`` because faithfully simulating a foreign
+holder requires holding an actual ``fcntl.flock`` from another process --
+overkill for a unit test of the bypass branch.
+"""
+
+from unittest.mock import patch
+
+import pytest
+
+from voice_mode.conch import Conch
+
+
+@pytest.fixture
+def clean_conch():
+    """Ensure no conch file exists before/after each test."""
+    conch_file = Conch.LOCK_FILE
+    if conch_file.exists():
+        conch_file.unlink()
+    yield
+    if conch_file.exists():
+        conch_file.unlink()
+
+
+class TestConverseSkipConch:
+    """skip_conch=True must bypass coordination without harming other holders."""
+
+    @pytest.mark.asyncio
+    async def test_default_returns_blocked_when_other_holder(self, clean_conch):
+        """Baseline: without skip_conch, an unavailable conch returns the blocked string."""
+        from voice_mode.tools.converse import converse
+
+        # Simulate "another agent owns the conch" by making try_acquire always fail.
+        with patch.object(Conch, "try_acquire", return_value=False), \
+             patch.object(
+                 Conch, "get_holder",
+                 return_value={"pid": 99999, "agent": "other_agent"},
+             ):
+            result = await getattr(converse, "fn", converse)(
+                message="Hello",
+                wait_for_response=False,
+            )
+
+        assert "User is currently speaking" in result, (
+            f"Without skip_conch, blocked conch must surface as status string. Got: {result!r}"
+        )
+
+    @pytest.mark.asyncio
+    async def test_skip_conch_bypasses_blocked_status(self, clean_conch):
+        """skip_conch=True must NOT return the 'User is currently speaking' string,
+        even if try_acquire would have failed."""
+        from voice_mode.tools.converse import converse
+
+        called = {"try_acquire": 0}
+
+        def fake_try_acquire(self, agent_name=None):
+            called["try_acquire"] += 1
+            return False  # If anything tries to acquire, it would block.
+
+        with patch.object(Conch, "try_acquire", new=fake_try_acquire), \
+             patch(
+                 "voice_mode.tools.converse.text_to_speech_with_failover",
+                 return_value=(False, {}, {"provider": "test"}),
+             ):
+            result = await getattr(converse, "fn", converse)(
+                message="Hello",
+                wait_for_response=False,
+                skip_conch=True,
+            )
+
+        assert "User is currently speaking" not in result, (
+            f"skip_conch=True should bypass coordination. Got: {result!r}"
+        )
+        assert called["try_acquire"] == 0, (
+            "skip_conch=True must not call try_acquire at all "
+            f"(called {called['try_acquire']} times)"
+        )
+
+    @pytest.mark.asyncio
+    async def test_skip_conch_does_not_release_unowned_lock(self, clean_conch):
+        """skip_conch=True must NOT delete a lock file it doesn't own.
+
+        The release() path already guards on conch._acquired; this test pins
+        that invariant against the skip_conch branch specifically.
+        """
+        import json
+        from datetime import datetime
+        from voice_mode.tools.converse import converse
+
+        # Plant a lock file that looks like it belongs to another agent.
+        Conch.LOCK_FILE.parent.mkdir(parents=True, exist_ok=True)
+        planted = {
+            "pid": 99999,
+            "agent": "other_agent",
+            "acquired": datetime.now().isoformat(),
+            "expires": None,
+        }
+        Conch.LOCK_FILE.write_text(json.dumps(planted))
+
+        with patch.object(Conch, "try_acquire", return_value=False), \
+             patch(
+                 "voice_mode.tools.converse.text_to_speech_with_failover",
+                 return_value=(False, {}, {"provider": "test"}),
+             ):
+            await getattr(converse, "fn", converse)(
+                message="Hello",
+                wait_for_response=False,
+                skip_conch=True,
+            )
+
+        assert Conch.LOCK_FILE.exists(), (
+            "skip_conch=True must not unlink another agent's lock file"
+        )
+        survivor = json.loads(Conch.LOCK_FILE.read_text())
+        assert survivor == planted, (
+            f"Other agent's lock file mutated: {survivor!r} != {planted!r}"
+        )
+
+    @pytest.mark.asyncio
+    async def test_skip_conch_accepts_string_true(self, clean_conch):
+        """String 'true' must coerce to bool True, matching sibling flags."""
+        from voice_mode.tools.converse import converse
+
+        with patch.object(Conch, "try_acquire", return_value=False), \
+             patch(
+                 "voice_mode.tools.converse.text_to_speech_with_failover",
+                 return_value=(False, {}, {"provider": "test"}),
+             ):
+            result = await getattr(converse, "fn", converse)(
+                message="Hello",
+                wait_for_response=False,
+                skip_conch="true",
+            )
+
+        assert "User is currently speaking" not in result

--- a/voice_mode/cli.py
+++ b/voice_mode/cli.py
@@ -1790,10 +1790,12 @@ voice_mode_main_cli.add_command(transcribe_audio_cmd)
 @click.option('--speed', type=float, help='Speech rate (0.25 to 4.0)')
 @click.option('--vad-aggressiveness', type=int, help='VAD aggressiveness (0-3)')
 @click.option('--skip-tts/--no-skip-tts', default=None, help='Skip TTS and only show text')
+@click.option('--skip-conch', is_flag=True, default=False,
+              help='Bypass the conch lock; speak immediately even if another agent holds it.')
 @click.option('--continuous', '-c', is_flag=True, help='Continuous conversation mode')
 def converse(message, wait, skip_stt, duration, min_duration, voice, tts_provider,
             tts_model, tts_instructions, audio_feedback, audio_format, disable_silence_detection,
-            speed, vad_aggressiveness, skip_tts, continuous):
+            speed, vad_aggressiveness, skip_tts, skip_conch, continuous):
     """Have a voice conversation directly from the command line.
 
     Examples:
@@ -1809,6 +1811,9 @@ def converse(message, wait, skip_stt, duration, min_duration, voice, tts_provide
 
         # Use specific voice
         voicemode converse --voice nova
+
+        # Bypass the conch lock (talk over another agent if one is active)
+        voicemode converse -m "Hey, urgent question." --skip-conch
     """
     # Deprecation: --no-wait was renamed to --skip-stt.
     # `wait` defaults to True, so `wait is False` means the user explicitly
@@ -1870,12 +1875,13 @@ def converse(message, wait, skip_stt, duration, min_duration, voice, tts_provide
                     disable_silence_detection=disable_silence_detection,
                     speed=speed,
                     vad_aggressiveness=vad_aggressiveness,
-                    skip_tts=skip_tts
+                    skip_tts=skip_tts,
+                    skip_conch=skip_conch,
                 )
-                
+
                 if result and "Voice response:" in result:
                     click.echo(f"You: {result.split('Voice response:')[1].split('|')[0].strip()}")
-                
+
                 # Continue conversation
                 while True:
                     # Wait for user's next input
@@ -1893,7 +1899,8 @@ def converse(message, wait, skip_stt, duration, min_duration, voice, tts_provide
                         disable_silence_detection=disable_silence_detection,
                         speed=speed,
                         vad_aggressiveness=vad_aggressiveness,
-                        skip_tts=skip_tts
+                        skip_tts=skip_tts,
+                        skip_conch=skip_conch,
                     )
                     
                     if result and "Voice response:" in result:
@@ -1910,7 +1917,8 @@ def converse(message, wait, skip_stt, duration, min_duration, voice, tts_provide
                                 tts_model=tts_model,
                                 audio_format=audio_format,
                                 speed=speed,
-                                skip_tts=skip_tts
+                                skip_tts=skip_tts,
+                                skip_conch=skip_conch,
                             )
                             break
             else:
@@ -1929,7 +1937,8 @@ def converse(message, wait, skip_stt, duration, min_duration, voice, tts_provide
                     disable_silence_detection=disable_silence_detection,
                     speed=speed,
                     vad_aggressiveness=vad_aggressiveness,
-                    skip_tts=skip_tts
+                    skip_tts=skip_tts,
+                    skip_conch=skip_conch,
                 )
 
                 # Display result

--- a/voice_mode/tools/converse.py
+++ b/voice_mode/tools/converse.py
@@ -1203,7 +1203,8 @@ async def converse(
     chime_leading_silence: Optional[float] = None,
     chime_trailing_silence: Optional[float] = None,
     metrics_level: Optional[Literal["minimal", "summary", "verbose"]] = None,
-    wait_for_conch: Union[bool, str] = False
+    wait_for_conch: Union[bool, str] = False,
+    skip_conch: Union[bool, str] = False,
 ) -> str:
     """Have an ongoing voice conversation - speak a message and optionally listen for response.
 
@@ -1250,6 +1251,11 @@ KEY PARAMETERS:
 • wait_for_conch (bool, default: false): Multi-agent coordination
   - false: If another agent is speaking, return status immediately
   - true: Wait until the other agent finishes, then speak
+• skip_conch (bool, default: false): Bypass conch entirely
+  - false: Honour the conch lock (default multi-agent coordination)
+  - true: Don't try to acquire or release the conch -- speak immediately
+    regardless of whether another agent holds it. Use when you intentionally
+    want to talk over other agents or run outside the coordination protocol.
 
 TIMING PARAMETERS (usually leave at defaults):
   Silence detection handles most cases automatically. Only override these if
@@ -1293,6 +1299,8 @@ consult the MCP resources listed above.
         skip_tts = skip_tts.lower() in ('true', '1', 'yes', 'on')
     if isinstance(wait_for_conch, str):
         wait_for_conch = wait_for_conch.lower() in ('true', '1', 'yes', 'on')
+    if isinstance(skip_conch, str):
+        skip_conch = skip_conch.lower() in ('true', '1', 'yes', 'on')
 
     # Convert vad_aggressiveness to integer if provided as string
     if vad_aggressiveness is not None and isinstance(vad_aggressiveness, str):
@@ -1413,7 +1421,9 @@ consult the MCP resources listed above.
 
     try:
         # Try to acquire conch atomically (no race condition)
-        if CONCH_ENABLED:
+        # skip_conch=true bypasses coordination entirely: don't acquire, don't
+        # check the holder, don't release. Speak regardless of who else has it.
+        if CONCH_ENABLED and not skip_conch:
             acquired = conch.try_acquire()
 
             if not acquired:
@@ -1465,6 +1475,19 @@ consult the MCP resources listed above.
                 })
 
             # Auto-focus tmux pane after conch acquisition, before audio playback
+            if AUTO_FOCUS_PANE and is_tmux():
+                focus_tmux_pane()
+        elif CONCH_ENABLED and skip_conch:
+            # Conch is enabled but the caller asked to bypass it.
+            if event_logger:
+                holder = Conch.get_holder()
+                event_logger.log_event("CONCH_SKIPPED", {
+                    "pid": os.getpid(),
+                    "agent": "converse",
+                    "holder_pid": holder.get('pid') if holder else None,
+                    "holder_agent": holder.get('agent') if holder else None,
+                })
+            # Still auto-focus tmux pane -- pane focus is unrelated to the conch.
             if AUTO_FOCUS_PANE and is_tmux():
                 focus_tmux_pane()
 


### PR DESCRIPTION
## Summary

- Adds `--skip-conch` flag to `voicemode converse` and `skip_conch` parameter to the converse MCP tool.
- When set, the conch lock is bypassed entirely -- no acquire, no holder check, no release.
- Lets an agent intentionally speak over another active session (urgent input, debugging, running outside the coordination protocol).
- Logs a `CONCH_SKIPPED` event with the current holder's pid/agent for observability.
- tmux pane auto-focus still runs since it's unrelated to the conch.

## Behaviour

| Scenario | Default | `--skip-conch` |
|----------|---------|----------------|
| No other agent | Acquires lock, speaks, releases | Speaks, never touches lock file |
| Another agent holds conch | Returns \"User is currently speaking with X\" | Speaks immediately, leaves other agent's lock intact |
| `wait_for_conch=true` + other holder | Polls until acquired or `CONCH_TIMEOUT` | Skipped -- skip_conch wins |

## Test plan

- [x] `pytest tests/test_converse_skip_conch.py` -- 4 new tests covering bypass, lock preservation, and string coercion
- [x] `pytest tests/test_conch.py tests/test_converse_cancellation.py` -- 36 existing tests still pass
- [x] `voicemode converse --help` shows the new flag with example
- [ ] Manual: run `voicemode converse -m \"hi\" --skip-conch` while another converse session is active and confirm both speak

## Notes

- `skip_conch` accepts string ("true"/"1"/"yes"/"on") for consistency with sibling MCP params.
- `release()` already short-circuits on `conch._acquired = False`, so the lock-preservation invariant falls out of existing code; the new test pins it explicitly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)