### PR TITLE
cli: accept positional MESSAGE for 'voicemode converse' (VM-1268)

### DIFF
--- a/tests/test_converse_cli_message_arg.py
+++ b/tests/test_converse_cli_message_arg.py
@@ -1,0 +1,179 @@
+"""Tests for `voicemode converse` positional MESSAGE argument (VM-1268).
+
+The converse subcommand accepts the message in two forms:
+
+  voicemode converse "Hello"          # positional (preferred)
+  voicemode converse -m "Hello"       # flag (kept for backward compat)
+
+Rules:
+  * Either form alone -> message resolves to the provided text.
+  * Multi-word positional args join with spaces.
+  * Neither form -> the default greeting is used.
+  * Both forms together -> `click.UsageError`, non-zero exit.
+  * Use `--` to pass a message that starts with a dash (standard POSIX escape).
+
+These tests target the CLI parser, not the underlying TTS/STT pipeline, so we
+mock the inner async `converse` call and the dependency check.
+"""
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from click.testing import CliRunner
+
+from voice_mode.cli import voice_mode_main_cli
+
+
+DEFAULT_GREETING = "Hello! How can I help you today?"
+
+
+@pytest.fixture
+def patched_converse():
+    """Patch deps + converse tool so the CLI command runs to completion
+    without needing audio devices, and yield the AsyncMock that captures
+    the `message` kwarg the CLI would have spoken.
+    """
+    async_mock = AsyncMock(return_value="Voice response: ack | provider=test")
+
+    # check_component_dependencies is imported inside the command body, so we
+    # patch at the source module.
+    with patch(
+        "voice_mode.utils.dependencies.checker.check_component_dependencies",
+        return_value={"core": True},
+    ), patch("voice_mode.tools.converse.converse") as mock_converse_tool:
+        # `converse_fn.fn` is the unwrapped coroutine inside FastMCP. The CLI
+        # uses getattr(converse_fn, 'fn', converse_fn) so providing `.fn` is
+        # the cleanest path.
+        mock_converse_tool.fn = async_mock
+        yield async_mock
+
+
+def _spoken_message(async_mock):
+    """Return the `message` kwarg of the last call to the patched converse."""
+    assert async_mock.await_count >= 1, "converse was never awaited"
+    return async_mock.await_args.kwargs["message"]
+
+
+class TestConversePositionalMessage:
+    """Parser behaviour for the new positional MESSAGE argument."""
+
+    def test_positional_single_word(self, patched_converse):
+        runner = CliRunner()
+        result = runner.invoke(
+            voice_mode_main_cli,
+            ["converse", "Hello", "--skip-stt"],
+        )
+        assert result.exit_code == 0, result.output
+        assert _spoken_message(patched_converse) == "Hello"
+
+    def test_positional_quoted_phrase(self, patched_converse):
+        runner = CliRunner()
+        result = runner.invoke(
+            voice_mode_main_cli,
+            ["converse", "Hello there", "--skip-stt"],
+        )
+        assert result.exit_code == 0, result.output
+        assert _spoken_message(patched_converse) == "Hello there"
+
+    def test_positional_multi_word_joins_with_space(self, patched_converse):
+        """`converse hello world` (unquoted) joins into 'hello world'."""
+        runner = CliRunner()
+        result = runner.invoke(
+            voice_mode_main_cli,
+            ["converse", "hello", "world", "--skip-stt"],
+        )
+        assert result.exit_code == 0, result.output
+        assert _spoken_message(patched_converse) == "hello world"
+
+    def test_no_args_uses_default_greeting(self, patched_converse):
+        runner = CliRunner()
+        result = runner.invoke(
+            voice_mode_main_cli,
+            ["converse", "--skip-stt"],
+        )
+        assert result.exit_code == 0, result.output
+        assert _spoken_message(patched_converse) == DEFAULT_GREETING
+
+    def test_flag_form_still_works(self, patched_converse):
+        """Backward compat: `-m "foo"` keeps working unchanged."""
+        runner = CliRunner()
+        result = runner.invoke(
+            voice_mode_main_cli,
+            ["converse", "-m", "via flag", "--skip-stt"],
+        )
+        assert result.exit_code == 0, result.output
+        assert _spoken_message(patched_converse) == "via flag"
+
+    def test_both_positional_and_flag_errors(self, patched_converse):
+        """Refuse ambiguity: error, don't silently pick one."""
+        runner = CliRunner()
+        result = runner.invoke(
+            voice_mode_main_cli,
+            ["converse", "positional", "-m", "via flag", "--skip-stt"],
+        )
+        assert result.exit_code != 0, result.output
+        assert "both" in result.output.lower()
+        # Crucially, the underlying converse must NOT have been called.
+        assert patched_converse.await_count == 0
+
+    def test_double_dash_escapes_dash_prefixed_message(self, patched_converse):
+        """`-- "-c rocks"` passes a literal message starting with `-`."""
+        runner = CliRunner()
+        result = runner.invoke(
+            voice_mode_main_cli,
+            ["converse", "--skip-stt", "--", "-c is short for continuous"],
+        )
+        assert result.exit_code == 0, result.output
+        # The message should be the literal dash-prefixed text...
+        assert _spoken_message(patched_converse) == "-c is short for continuous"
+        # ...and continuous mode must NOT have been activated by it.
+        kwargs = patched_converse.await_args.kwargs
+        # `continuous` is consumed by the CLI wrapper, not forwarded to the
+        # tool, so we infer it stayed False from the fact that we entered the
+        # single-call branch (one await, not the continuous loop).
+        assert patched_converse.await_count == 1
+
+    def test_interspersed_positional_before_option(self, patched_converse):
+        """`converse "hi" --voice nova` resolves message='hi' and voice='nova'."""
+        runner = CliRunner()
+        result = runner.invoke(
+            voice_mode_main_cli,
+            ["converse", "hi", "--voice", "nova", "--skip-stt"],
+        )
+        assert result.exit_code == 0, result.output
+        assert _spoken_message(patched_converse) == "hi"
+        assert patched_converse.await_args.kwargs["voice"] == "nova"
+
+    def test_interspersed_option_before_positional(self, patched_converse):
+        """`converse --voice nova "hi"` works identically to the reverse order."""
+        runner = CliRunner()
+        result = runner.invoke(
+            voice_mode_main_cli,
+            ["converse", "--voice", "nova", "hi", "--skip-stt"],
+        )
+        assert result.exit_code == 0, result.output
+        assert _spoken_message(patched_converse) == "hi"
+        assert patched_converse.await_args.kwargs["voice"] == "nova"
+
+
+class TestConverseHelpSurface:
+    """The help output should show the positional form (no underlying call)."""
+
+    def test_help_shows_positional_metavar(self):
+        runner = CliRunner()
+        result = runner.invoke(voice_mode_main_cli, ["converse", "-h"])
+        assert result.exit_code == 0
+        assert "[MESSAGE]" in result.output
+
+    def test_help_lists_positional_example_first(self):
+        runner = CliRunner()
+        result = runner.invoke(voice_mode_main_cli, ["converse", "-h"])
+        assert result.exit_code == 0
+        # The positional example should appear before the `-m` example.
+        positional_idx = result.output.find('converse "Hello there!"')
+        flag_idx = result.output.find('converse -m "Hello there!"')
+        assert positional_idx != -1, "positional example missing from help"
+        assert flag_idx != -1, "flag example missing from help (backward-compat reference)"
+        assert positional_idx < flag_idx, (
+            "positional example should come before the -m example in help"
+        )

--- a/voice_mode/cli.py
+++ b/voice_mode/cli.py
@@ -1881,7 +1881,25 @@ transcribe_audio_cmd.name = 'transcribe'
 voice_mode_main_cli.add_command(transcribe_audio_cmd)
 
 # Converse command - direct voice conversation from CLI
-@voice_mode_main_cli.command()
+#
+# Help layout uses Click's `epilog` so examples render at the bottom (after
+# Options), and `\b` markers preserve our line breaks (otherwise Click
+# reflows the paragraph and runs comment + command together on one line).
+_CONVERSE_EPILOG = """\
+\b
+Examples:
+  voicemode converse                                    # default greeting
+  voicemode converse "Hello there!"                     # positional message
+  voicemode converse "Hello there!" --skip-stt          # speak only, no listen
+  voicemode converse -m "Hello there!" --skip-stt       # equivalent via -m (back-compat)
+  voicemode converse -- "-c is short for continuous"    # `--` escapes dash-prefixed text
+  voicemode converse --continuous                       # continuous conversation mode
+  voicemode converse "Hello there!" --voice nova        # pick a TTS voice
+  voicemode converse "Hey, urgent question." --skip-conch  # bypass the conch lock
+"""
+
+
+@voice_mode_main_cli.command(epilog=_CONVERSE_EPILOG)
 @click.help_option('-h', '--help')
 @click.argument('message_args', nargs=-1, metavar='[MESSAGE]...')
 @click.option('--message', '-m', default=None,
@@ -1911,34 +1929,8 @@ def converse(message_args, message, wait, skip_stt, duration, min_duration, voic
             speed, vad_aggressiveness, skip_tts, skip_conch, continuous):
     """Have a voice conversation directly from the command line.
 
-    The MESSAGE to speak can be passed as a positional argument or via -m/--message.
-    Use `--` to pass a message that starts with a dash.
-
-    Examples:
-
-        # Simple conversation (default greeting)
-        voicemode converse
-
-        # Speak a positional message
-        voicemode converse "Hello there!"
-
-        # Speak and skip listening for a response
-        voicemode converse "Hello there!" --skip-stt
-
-        # Equivalent using -m (kept for backward compatibility)
-        voicemode converse -m "Hello there!" --skip-stt
-
-        # Message starting with a dash — use `--` to stop option parsing
-        voicemode converse -- "-c is short for continuous"
-
-        # Continuous conversation mode
-        voicemode converse --continuous
-
-        # Use specific voice
-        voicemode converse "Hello there!" --voice nova
-
-        # Bypass the conch lock (talk over another agent if one is active)
-        voicemode converse "Hey, urgent question." --skip-conch
+    The MESSAGE to speak can be passed as a positional argument or via
+    -m/--message. Use `--` to pass a message that starts with a dash.
     """
     # Resolve the message source:
     #   - positional MESSAGE wins when given

--- a/voice_mode/cli.py
+++ b/voice_mode/cli.py
@@ -1883,7 +1883,9 @@ voice_mode_main_cli.add_command(transcribe_audio_cmd)
 # Converse command - direct voice conversation from CLI
 @voice_mode_main_cli.command()
 @click.help_option('-h', '--help')
-@click.option('--message', '-m', default="Hello! How can I help you today?", help='Initial message to speak')
+@click.argument('message_args', nargs=-1, metavar='[MESSAGE]...')
+@click.option('--message', '-m', default=None,
+              help='Initial message to speak (alternative to positional MESSAGE)')
 @click.option('--wait/--no-wait', 'wait', default=True,
               help='[DEPRECATED] --no-wait is deprecated; use --skip-stt instead. Wait for response after speaking.')
 @click.option('--skip-stt', is_flag=True, default=False,
@@ -1904,28 +1906,54 @@ voice_mode_main_cli.add_command(transcribe_audio_cmd)
 @click.option('--skip-conch', is_flag=True, default=False,
               help='Bypass the conch lock; speak immediately even if another agent holds it.')
 @click.option('--continuous', '-c', is_flag=True, help='Continuous conversation mode')
-def converse(message, wait, skip_stt, duration, min_duration, voice, tts_provider,
+def converse(message_args, message, wait, skip_stt, duration, min_duration, voice, tts_provider,
             tts_model, tts_instructions, audio_feedback, audio_format, disable_silence_detection,
             speed, vad_aggressiveness, skip_tts, skip_conch, continuous):
     """Have a voice conversation directly from the command line.
 
+    The MESSAGE to speak can be passed as a positional argument or via -m/--message.
+    Use `--` to pass a message that starts with a dash.
+
     Examples:
 
-        # Simple conversation
+        # Simple conversation (default greeting)
         voicemode converse
 
-        # Speak a message without listening for a response
+        # Speak a positional message
+        voicemode converse "Hello there!"
+
+        # Speak and skip listening for a response
+        voicemode converse "Hello there!" --skip-stt
+
+        # Equivalent using -m (kept for backward compatibility)
         voicemode converse -m "Hello there!" --skip-stt
+
+        # Message starting with a dash — use `--` to stop option parsing
+        voicemode converse -- "-c is short for continuous"
 
         # Continuous conversation mode
         voicemode converse --continuous
 
         # Use specific voice
-        voicemode converse --voice nova
+        voicemode converse "Hello there!" --voice nova
 
         # Bypass the conch lock (talk over another agent if one is active)
-        voicemode converse -m "Hey, urgent question." --skip-conch
+        voicemode converse "Hey, urgent question." --skip-conch
     """
+    # Resolve the message source:
+    #   - positional MESSAGE wins when given
+    #   - --message/-m is kept for backward compatibility and scripts
+    #   - passing BOTH is ambiguous and errors loudly (no silent "pick one")
+    #   - if neither is given, fall back to the default greeting
+    if message_args:
+        if message is not None:
+            raise click.UsageError(
+                "Pass the message as either a positional argument OR --message/-m, not both."
+            )
+        message = ' '.join(message_args)
+    elif message is None:
+        message = "Hello! How can I help you today?"
+
     # Deprecation: --no-wait was renamed to --skip-stt.
     # `wait` defaults to True, so `wait is False` means the user explicitly
     # passed --no-wait on the command line.


### PR DESCRIPTION
## Summary

- `voicemode converse "Hello there"` now works without `-m`, matching the natural pattern of `say`/`espeak`
- `-m`/`--message` retained for backward compatibility and scripts
- Passing **both** positional and `-m` raises `click.UsageError` -- ambiguity fails loudly rather than silently picking one
- Multi-word positional args join with spaces: `converse hello world` -> `"hello world"`
- `--` still escapes dash-prefixed messages: `converse -- "-c rocks"`
- 11 new `CliRunner` tests cover positional, default greeting, conflict error, multi-word join, `--` escape, interspersed options, and help surface
- No change to the MCP `converse` tool -- CLI parser only

## Why error (not warn) when both given

A warn-and-pick-one rule means the same command produces different results depending on which form the user *thinks* takes precedence. Error is the least-surprise option.

## Test plan

- [x] `uv run pytest tests/test_converse_cli_message_arg.py` -- 11 passed
- [x] `uv run pytest tests/test_converse_cancellation.py tests/test_converse_critical_path.py tests/test_converse_skip_conch.py` -- 17 passed (no regression)
- [x] `voicemode converse --help` shows `[MESSAGE]...` and lists positional example first
- [ ] Manual smoke (reviewer): `voicemode converse "Cora, can you hear me?"` end-to-end

Task: VM-1268

🤖 Generated with [Claude Code](https://claude.com/claude-code)