### PR TITLE
fix: handle duplicate VOICEMODE_SOUNDFONTS_ENABLED lines in voicemode.env

### DIFF
--- a/voice_mode/data/hooks/voicemode-hook-receiver.sh
+++ b/voice_mode/data/hooks/voicemode-hook-receiver.sh
@@ -155,10 +155,15 @@ soundfonts_enabled() {
     return
   fi
 
-  # Check voicemode.env config file
+  # Check voicemode.env config file.
+  # Use tail -n 1 for last-wins semantics if the key appears multiple times
+  # (dotenv convention). Without this, a duplicate line produces a multi-line
+  # value ("true\ntrue") that fails the equality checks below and silently
+  # disables soundfonts.
+  # Use -f2- (not -f2) so values containing '=' aren't truncated.
   local config_file="$HOME/.voicemode/voicemode.env"
   if [[ -f "$config_file" ]]; then
-    enabled=$(grep -E '^VOICEMODE_SOUNDFONTS_ENABLED=' "$config_file" 2>/dev/null | cut -d= -f2 | tr -d '"' | tr -d "'" || echo "")
+    enabled=$(grep -E '^VOICEMODE_SOUNDFONTS_ENABLED=' "$config_file" 2>/dev/null | tail -n 1 | cut -d= -f2- | tr -d '"' | tr -d "'" || echo "")
     if [[ -n "$enabled" ]]; then
       [[ "$enabled" == "true" || "$enabled" == "1" || "$enabled" == "yes" || "$enabled" == "on" ]]
       return


### PR DESCRIPTION
## Summary

A duplicate `VOICEMODE_SOUNDFONTS_ENABLED=true` line in `~/.voicemode/voicemode.env` silently disables soundfonts. `grep` returns both matching lines, producing a two-line value (`"true\ntrue"`) that fails every equality check in `soundfonts_enabled()` — so the function returns false and the hook exits without playing a sound.

This was caught when the line accidentally got doubled in Mike's `voicemode.env` and tool-use sounds stopped playing.

## Fix

- `| tail -n 1 |` — last-wins semantics if the key appears multiple times (standard dotenv convention)
- `cut -d= -f2-` (was `-f2`) — preserve values that contain `=`

## Reproducer

```bash
printf 'VOICEMODE_SOUNDFONTS_ENABLED=true\nVOICEMODE_SOUNDFONTS_ENABLED=true\n' > test.env

# Before:
enabled=$(grep -E '^VOICEMODE_SOUNDFONTS_ENABLED=' test.env | cut -d= -f2 | tr -d '"' | tr -d "'")
[[ "$enabled" == "true" ]] && echo MATCH || echo "NO MATCH"
# -> NO MATCH

# After:
enabled=$(grep -E '^VOICEMODE_SOUNDFONTS_ENABLED=' test.env | tail -n 1 | cut -d= -f2- | tr -d '"' | tr -d "'")
[[ "$enabled" == "true" ]] && echo MATCH || echo "NO MATCH"
# -> MATCH
```

## Test plan

- [ ] `voicemode.env` with a single `VOICEMODE_SOUNDFONTS_ENABLED=true` line — soundfonts play (unchanged behaviour)
- [ ] `voicemode.env` with a duplicate `VOICEMODE_SOUNDFONTS_ENABLED=true` line — soundfonts play (previously broken)
- [ ] `voicemode.env` with `VOICEMODE_SOUNDFONTS_ENABLED=false` followed by `VOICEMODE_SOUNDFONTS_ENABLED=true` — last wins, soundfonts play
- [ ] No `voicemode.env` and no env var — default-enabled path still works

## Note

A follow-up task will audit the rest of the voicemode codebase for similar duplicate-key handling assumptions in shell parsing of dotenv files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
