### PR TITLE
fix: don't uncomment a doc-default if an active line already exists

### DIFF
--- a/tests/test_configuration_management.py
+++ b/tests/test_configuration_management.py
@@ -307,6 +307,40 @@ class TestWriteEnvFileCommentedDefaults:
         finally:
             os.unlink(temp_path)
 
+    def test_active_line_and_commented_default_no_duplicate(self):
+        """If both an active line and a commented doc-default exist for the
+        same key, writing the key must not produce two active lines.
+
+        Regression test: the voicemode.env template ships with both
+            VOICEMODE_SOUNDFONTS_ENABLED=true
+            # VOICEMODE_SOUNDFONTS_ENABLED=true   (docs)
+        and previously write_env_file would emit BOTH (replacing the active
+        line in place AND uncommenting the docs line), silently disabling
+        consumers that fail on duplicate keys (e.g. the soundfonts shell
+        hook receiver).
+        """
+        fd, temp_path = tempfile.mkstemp(suffix='.env')
+        try:
+            with os.fdopen(fd, 'w') as f:
+                f.write("# Enable sound fonts for tool use hooks (true/false)\n")
+                f.write("VOICEMODE_SOUNDFONTS_ENABLED=true\n")
+                f.write("# VOICEMODE_SOUNDFONTS_ENABLED=true\n")
+
+            temp_file = Path(temp_path)
+            write_env_file(temp_file, {"VOICEMODE_SOUNDFONTS_ENABLED": "true"})
+
+            content = temp_file.read_text()
+            # Exactly one active line
+            assert content.count("\nVOICEMODE_SOUNDFONTS_ENABLED=") + \
+                   content.startswith("VOICEMODE_SOUNDFONTS_ENABLED=") == 1, \
+                   f"Expected exactly one active line, got:\n{content}"
+            # And the commented docs line preserved
+            assert "# VOICEMODE_SOUNDFONTS_ENABLED=true" in content
+
+        finally:
+            os.unlink(temp_path)
+
+
 class TestMultilineValueHandling:
     """Test handling of multiline quoted values in config files."""
 

--- a/voice_mode/tools/configuration_management.py
+++ b/voice_mode/tools/configuration_management.py
@@ -172,14 +172,25 @@ def write_env_file(file_path: Path, config: Dict[str, str], preserve_comments: b
                 commented_match = commented_config_pattern.match(stripped)
                 if commented_match:
                     key = commented_match.group(1)
-                    if key in config:
+                    # Only "uncomment" if this key is being written AND no
+                    # active line for the key has already been emitted in
+                    # this pass. Otherwise we'd duplicate the key -- e.g.
+                    # the voicemode.env template ships with both
+                    #     VOICEMODE_SOUNDFONTS_ENABLED=true
+                    #     # VOICEMODE_SOUNDFONTS_ENABLED=true   (docs)
+                    # and writing the key would produce two active lines,
+                    # silently breaking downstream consumers that don't
+                    # handle dotenv duplicates.
+                    if key in config and key not in existing_keys:
                         # Replace commented default with active value
                         formatted_value = _format_env_value(config[key])
                         existing_lines.append(f"{key}={formatted_value}\n")
                         existing_keys.add(key)
                         commented_keys_replaced.add(key)
                     else:
-                        # Keep the commented default as-is
+                        # Keep the commented default as-is (either we're not
+                        # updating this key, or an active line was already
+                        # emitted -- the comment is just docs in that case)
                         existing_lines.append(line)
                 else:
                     # Regular comment - preserve as-is


### PR DESCRIPTION
## Summary

Follow-up to #418. That PR fixed the **consumer** side (the shell hook receiver mis-parsing duplicate lines in `voicemode.env`). This PR fixes the **producer** — the code that was creating the duplicates in the first place.

## The bug

`write_env_file()` in `voice_mode/tools/configuration_management.py` walks the file and:

1. For each **active** `KEY=value` line: if `KEY` is in the config being written, replace in place.
2. For each **commented** `# KEY=value` line: if `KEY` is in the config being written, *uncomment it* (emit a new active line in its place).

The `voicemode.env` template ships with **both** an active line and a commented doc-default for many keys, e.g.:

```
# Enable sound fonts for tool use hooks (true/false)
VOICEMODE_SOUNDFONTS_ENABLED=true
# VOICEMODE_SOUNDFONTS_ENABLED=true
```

Calling `update_config(key='VOICEMODE_SOUNDFONTS_ENABLED', ...)` then produces:

```
# Enable sound fonts for tool use hooks (true/false)
VOICEMODE_SOUNDFONTS_ENABLED=true
VOICEMODE_SOUNDFONTS_ENABLED=true
```

Reproduced with the actual `write_env_file()` import on master.

## The fix

Only "uncomment" a commented default when no active line for the key has already been emitted in the same pass. Otherwise the comment stays as documentation.

```python
if key in config and key not in existing_keys:   # <-- new guard
    # Replace commented default with active value
    ...
else:
    # Keep the commented default as-is (either we're not updating this key,
    # or an active line was already emitted — the comment is just docs)
    ...
```

## Test plan

- [x] New regression test: file with both an active line and a commented doc-default for the same key → write the key → exactly one active line, comment preserved
- [x] All 20 existing `test_configuration_management.py` tests pass

```
20 passed in 5.55s
```

## Out of scope (filed under VM-1272)

- An audit for **other** shell parsers in the codebase that may mishandle duplicate keys (the consumer fix in #418 was for one specific parser; same pattern likely exists elsewhere).
- Whether the input file ALREADY has duplicate active lines (this PR doesn't dedupe those on write; preserving current behaviour). Worth revisiting if VM-1272 finds it matters.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
