### PR TITLE
feat(VM-1278): ref_text passthrough + sidecar auto-resolve for converse

### DIFF
--- a/docs/guides/impressions.md
+++ b/docs/guides/impressions.md
@@ -76,6 +76,40 @@ voicemode converse --voice fleabag
 
 VoiceMode automatically routes any voice name that matches a profile in `VOICEMODE_VOICES_DIR` to the mlx-audio service instead of Kokoro / OpenAI.
 
+### Ad-hoc clip without registering a profile
+
+You don't have to register a profile to clone from a clip. Pass an **absolute
+path to a `.wav`** as the voice and it's sent straight to mlx-audio as the
+reference audio:
+
+```python
+voicemode:converse("Audition take three.", voice="/abs/path/to/take-3.wav")
+```
+
+The reference transcript (`ref_text`) is resolved in this order:
+
+1. **`ref_text` argument** to `converse` — wins if supplied. It auto-detects
+   path-vs-inline: an existing file path is read; anything else is used as the
+   literal transcript text.
+2. **Sidecar transcript** next to the clip — `take-3.txt` (matching basename),
+   else `default.txt` in the same directory.
+3. **Empty** — sent with no `ref_text` (the server clones from audio alone).
+
+```python
+# Inline transcript
+voicemode:converse("…", voice="/clips/bit.wav", ref_text="so anyway, the thing is")
+
+# Transcript file
+voicemode:converse("…", voice="/clips/bit.wav", ref_text="/clips/bit.txt")
+```
+
+> **Remote-host constraint.** `voice=` and a `ref_text` *file path* are read
+> on the host running mlx-audio. With a remote mlx-audio (see
+> [Remote mlx-audio](#remote-mlx-audio-eg-running-on-a-beefy-ms2)) the audio
+> path must exist **on that remote host** — local sidecar auto-resolution only
+> works when the server can see the file. `ref_text` passed as *inline text*
+> is always safe; it travels as a string, not a path.
+
 ## Picking a good reference clip
 
 The model copies what it hears. Garbage in, garbage out.

--- a/tests/test_ref_text_passthrough.py
+++ b/tests/test_ref_text_passthrough.py
@@ -1,0 +1,38 @@
+"""Tests for converse(ref_text=...) passthrough (VM-1278).
+
+`resolve_ref_text` auto-detects whether the supplied value is a path to a
+transcript file or literal transcript text:
+
+- None        -> None  ("no override" sentinel)
+- existing fp -> file contents, stripped
+- anything    -> the literal string, unchanged
+"""
+
+from voice_mode.tools.converse import resolve_ref_text
+
+
+def test_none_returns_none():
+    assert resolve_ref_text(None) is None
+
+
+def test_existing_file_path_is_read(tmp_path):
+    f = tmp_path / "clip.txt"
+    f.write_text("  the quick brown fox  \n")
+    assert resolve_ref_text(str(f)) == "the quick brown fox"
+
+
+def test_inline_text_passes_through_unchanged():
+    text = "This is a literal transcript, not a path."
+    assert resolve_ref_text(text) == text
+
+
+def test_nonexistent_pathlike_string_treated_as_literal():
+    # Looks like a path but doesn't exist -> used verbatim as the transcript.
+    val = "/no/such/file/here.txt"
+    assert resolve_ref_text(val) == val
+
+
+def test_empty_string_is_preserved():
+    # Empty string is a valid override (clone with no reference transcript);
+    # it is NOT the None "no override" sentinel.
+    assert resolve_ref_text("") == ""

--- a/tests/test_voice_profiles.py
+++ b/tests/test_voice_profiles.py
@@ -134,6 +134,46 @@ def test_absolute_path_passes_through(vp):
     assert vp.is_clone_voice("/some/abs/path.wav")
 
 
+# ---------- absolute path + sidecar transcript (VM-1278) ----------
+
+def test_absolute_path_picks_up_sibling_sidecar(vp, tmp_path):
+    """An existing clip with a <basename>.txt sidecar resolves ref_text."""
+    clip = tmp_path / "louis-ck-bit.wav"
+    clip.write_bytes(b"riff-clip")
+    (tmp_path / "louis-ck-bit.txt").write_text("  so anyway, the thing is  \n")
+
+    p = vp.get_profile(str(clip))
+    assert p.ref_audio == str(clip)
+    assert p.ref_text == "so anyway, the thing is"
+
+
+def test_absolute_path_falls_back_to_default_txt(vp, tmp_path):
+    """No matching-basename sidecar -> default.txt in the same dir is used."""
+    clip = tmp_path / "take-3.wav"
+    clip.write_bytes(b"riff-clip")
+    (tmp_path / "default.txt").write_text("default clip transcript")
+
+    p = vp.get_profile(str(clip))
+    assert p.ref_text == "default clip transcript"
+
+
+def test_absolute_path_no_sidecar_keeps_empty_ref_text(vp, tmp_path):
+    """Existing clip but no sidecar at all -> ref_text stays empty."""
+    clip = tmp_path / "orphan.wav"
+    clip.write_bytes(b"riff-clip")
+
+    p = vp.get_profile(str(clip))
+    assert p.ref_audio == str(clip)
+    assert p.ref_text == ""
+
+
+def test_absolute_path_nonexistent_clip_keeps_empty_ref_text(vp):
+    """Non-existent path (e.g. remote-only) -> ref_text empty, no crash."""
+    p = vp.get_profile("/not/on/this/host/clip.wav")
+    assert p.ref_audio == "/not/on/this/host/clip.wav"
+    assert p.ref_text == ""
+
+
 # ---------- is_clone_voice ----------
 
 @pytest.mark.parametrize("expr", [

--- a/voice_mode/simple_failover.py
+++ b/voice_mode/simple_failover.py
@@ -33,9 +33,15 @@ async def simple_tts_failover(
     logger.info(f"simple_tts_failover called with: text='{text[:50]}...', voice={voice}, model={model}")
     logger.info(f"kwargs: {kwargs}")
 
+    from dataclasses import replace as _dc_replace
     from .core import text_to_speech
     from .conversation_logger import get_conversation_logger
     from .voice_profiles import get_profile, is_clone_voice
+
+    # Pull the optional ref_text override out of kwargs before it gets
+    # forwarded to text_to_speech (which has no ref_text param). None means
+    # "no override" — use the profile/sidecar transcript as resolved.
+    ref_text_override = kwargs.pop("ref_text", None)
 
     # Track attempted endpoints and their errors
     attempted_endpoints = []
@@ -47,8 +53,19 @@ async def simple_tts_failover(
     # Check if this is a clone voice — if so, route directly to its endpoint
     clone_profile = get_profile(voice) if is_clone_voice(voice) else None
     if clone_profile:
+        # An explicit ref_text override wins over the profile/sidecar
+        # transcript (VM-1278). Empty string is a valid override (clone
+        # with no reference transcript).
+        if ref_text_override is not None:
+            clone_profile = _dc_replace(clone_profile, ref_text=ref_text_override)
+            logger.info(f"Voice '{voice}': applying ref_text override ({len(ref_text_override)} chars)")
         endpoints_to_try = [clone_profile.base_url]
         logger.info(f"Voice '{voice}' is a clone profile, routing to {clone_profile.base_url}")
+    elif ref_text_override is not None:
+        logger.warning(
+            f"ref_text override supplied but voice '{voice}' is not a clone "
+            f"voice (no abs-path clip or registered profile) — override ignored"
+        )
     else:
         endpoints_to_try = TTS_BASE_URLS
 

--- a/voice_mode/tools/converse.py
+++ b/voice_mode/tools/converse.py
@@ -495,6 +495,32 @@ async def get_stt_config(provider: Optional[str] = None):
 
 
 
+def resolve_ref_text(ref_text: Optional[str]) -> Optional[str]:
+    """Resolve a ``ref_text`` argument that may be a file path OR literal text.
+
+    Auto-detect: if the value names an existing file, its contents (stripped)
+    are used as the transcript; otherwise the value is treated as the literal
+    transcript text. Returns ``None`` when no override was supplied, so callers
+    can distinguish "use the profile/sidecar transcript" from an explicit
+    override.
+
+    Note: path detection is local-only. For a remote TTS host the *audio*
+    path must exist on that host, but ``ref_text`` is sent as a string, so
+    reading the transcript file locally here is always correct.
+    """
+    if ref_text is None:
+        return None
+    candidate = os.path.expanduser(ref_text)
+    try:
+        if os.path.isfile(candidate):
+            with open(candidate, "r") as fh:
+                return fh.read().strip()
+    except OSError:
+        # Fall through and treat the value as literal text.
+        pass
+    return ref_text
+
+
 async def text_to_speech_with_failover(
     message: str,
     voice: Optional[str] = None,
@@ -502,7 +528,8 @@ async def text_to_speech_with_failover(
     instructions: Optional[str] = None,
     audio_format: Optional[str] = None,
     initial_provider: Optional[str] = None,
-    speed: Optional[float] = None
+    speed: Optional[float] = None,
+    ref_text: Optional[str] = None
 ) -> Tuple[bool, Optional[dict], Optional[dict]]:
     """
     Text to speech with automatic failover to next available endpoint.
@@ -527,7 +554,8 @@ async def text_to_speech_with_failover(
         debug_dir=DEBUG_DIR if DEBUG else None,
         save_audio=SAVE_AUDIO,
         audio_dir=AUDIO_DIR if SAVE_AUDIO else None,
-        speed=speed
+        speed=speed,
+        ref_text=ref_text
     )
 
 
@@ -1205,6 +1233,7 @@ async def converse(
     metrics_level: Optional[Literal["minimal", "summary", "verbose"]] = None,
     wait_for_conch: Union[bool, str] = False,
     skip_conch: Union[bool, str] = False,
+    ref_text: Optional[str] = None,
 ) -> str:
     """Have an ongoing voice conversation - speak a message and optionally listen for response.
 
@@ -1237,6 +1266,10 @@ KEY PARAMETERS:
 • wait_for_response (bool, default: true): Listen for response after speaking
 • voice (string): TTS voice name (auto-selected unless specified)
   - To list available voices, read MCP resource voice://voices
+  - An absolute path to a .wav clones from that clip directly (no profile needed)
+• ref_text (string): Reference transcript for clip-based cloning. A file path
+  is read; anything else is the literal transcript. Overrides any sidecar.
+  Only used with a clone voice (abs-path clip or registered profile).
 • tts_provider ("openai"|"kokoro"): Provider selection (auto-selected unless specified)
 • disable_silence_detection (bool, default: false): Disable auto-stop on silence
 • vad_aggressiveness (0-3, default: 3): Voice detection strictness (0=permissive, 3=strict)
@@ -1301,6 +1334,10 @@ consult the MCP resources listed above.
         wait_for_conch = wait_for_conch.lower() in ('true', '1', 'yes', 'on')
     if isinstance(skip_conch, str):
         skip_conch = skip_conch.lower() in ('true', '1', 'yes', 'on')
+
+    # Resolve ref_text override once (path-vs-inline auto-detect). None means
+    # "no override" — fall back to the resolved profile/sidecar transcript.
+    resolved_ref_text = resolve_ref_text(ref_text)
 
     # Convert vad_aggressiveness to integer if provided as string
     if vad_aggressiveness is not None and isinstance(vad_aggressiveness, str):
@@ -1518,7 +1555,8 @@ consult the MCP resources listed above.
                             instructions=tts_instructions,
                             audio_format=audio_format,
                             initial_provider=tts_provider,
-                            speed=speed
+                            speed=speed,
+                            ref_text=resolved_ref_text
                         )
                 
                 # Add TTS sub-metrics
@@ -1807,7 +1845,8 @@ consult the MCP resources listed above.
                                         instructions=tts_instructions,
                                         audio_format=audio_format,
                                         initial_provider=tts_provider,
-                                        speed=speed
+                                        speed=speed,
+                                        ref_text=resolved_ref_text
                                     )
                                 if not tts_success:
                                     logger.error("Failed to replay audio via TTS regeneration")
@@ -1822,7 +1861,8 @@ consult the MCP resources listed above.
                                     instructions=tts_instructions,
                                     audio_format=audio_format,
                                     initial_provider=tts_provider,
-                                    speed=speed
+                                    speed=speed,
+                                    ref_text=resolved_ref_text
                                 )
                             if not tts_success:
                                 logger.error("Failed to replay audio via TTS regeneration")

--- a/voice_mode/voice_profiles.py
+++ b/voice_mode/voice_profiles.py
@@ -323,12 +323,19 @@ def resolve_voice_expr(expr: str) -> Optional[VoiceProfile]:
 
     name, selector = parse_voice_expr(expr)
 
-    # Absolute-path escape hatch: no profile lookup, no transcript.
+    # Absolute-path escape hatch: no profile lookup. If a sidecar
+    # transcript sits next to the clip (``<basename>.txt`` or a
+    # ``default.txt`` in the same dir) we pick it up so cloning has a
+    # ref_text without registering a profile. If there's no sidecar,
+    # ref_text stays empty and either a caller-supplied override
+    # (VM-1278: converse(ref_text=...)) or the TTS server default applies.
     if name is None and selector and selector.startswith("/"):
+        clip_path = Path(selector)
+        sidecar_text = _resolve_transcript(clip_path) if clip_path.exists() else ""
         return VoiceProfile(
             name=expr,
             ref_audio=selector,
-            ref_text="",
+            ref_text=sidecar_text,
             model=DEFAULT_CLONE_MODEL,
             base_url=DEFAULT_CLONE_BASE_URL,
             description="(absolute path)",


### PR DESCRIPTION
## What

Lets a caller point `converse` straight at a reference clip (audio + transcript) **without registering a named voice profile** first.

## Why

The absolute-path escape hatch (`voice="/abs/clip.wav"`) already existed and routed the audio to mlx-audio — but it hardcoded `ref_text=""`, so cloning from an ad-hoc clip lost its transcript. That empty `ref_text` was the entire gap.

## Changes

- **`voice_profiles.py`** — the abs-path branch of `resolve_voice_expr` now auto-resolves a sibling transcript (`<basename>.txt`, else `default.txt`) via the existing `_resolve_transcript`, instead of forcing `""`.
- **`converse.py`** — new optional `ref_text` param with path-vs-inline auto-detect (`resolve_ref_text`: existing file → read & strip; else literal text), threaded through all three `text_to_speech_with_failover` call sites.
- **`simple_failover.py`** — pops `ref_text` from kwargs (so it isn't forwarded to `text_to_speech`) and applies it as an override on the clone profile via `dataclasses.replace`. Warns if supplied for a non-clone voice.
- **`docs/guides/impressions.md`** — documents the ad-hoc clip flow, the resolution precedence, and the remote-host path constraint.

**Precedence:** explicit `ref_text` > sidecar `.txt` > empty. Omitting both preserves current behaviour exactly.

## Remote constraint

`voice=` and a `ref_text` *file path* are read on the mlx-audio host. With remote mlx-audio the clip path must exist on that host. Inline `ref_text` text is always safe (travels as a string). Documented, not a blocker.

## Tests

New: sidecar pickup, `default.txt` fallback, no-sidecar, nonexistent-path (remote-only); `resolve_ref_text` path vs inline vs empty vs None. **237 passed, 0 regressions** across converse/failover/profile/clone/voice suites.

Closes VM-1278.

🤖 Generated with [Claude Code](https://claude.com/claude-code)