### PR TITLE
fix(install.sh): restore large orange VoiceMode logo (VM-1324)

### DIFF
--- a/docs/web/install.sh
+++ b/docs/web/install.sh
@@ -44,14 +44,18 @@ setup_colors() {
         GREEN=""
         YELLOW=""
         BLUE=""
+        ORANGE=""
         BOLD=""
+        DIM=""
         RESET=""
     else
         RED=$'\033[0;31m'
         GREEN=$'\033[0;32m'
         YELLOW=$'\033[0;33m'
         BLUE=$'\033[0;34m'
+        ORANGE=$'\033[38;5;208m' # Claude Code orange
         BOLD=$'\033[1m'
+        DIM=$'\033[2m'
         RESET=$'\033[0m'
     fi
 }
@@ -85,12 +89,36 @@ info() {
 }
 
 # Display VoiceMode logo
-# Compact 3-line version that fits in ~45 columns
+# Large orange ASCII-art banner (Claude Code orange, ANSI 256-color 208)
 show_logo() {
     echo ""
-    echo "${BOLD}██╗   ██╗ ██████╗ ██╗ ██████╗███████╗${RESET}"
-    echo "${BOLD}██║   ██║██╔═══██╗██║██╔════╝██╔════╝${RESET}   ${BLUE}MODE${RESET}"
-    echo "${BOLD} ╚████╔╝ ╚██████╔╝██║╚██████╗███████╗${RESET}"
+    printf '%s' "${ORANGE}${BOLD}"
+    cat <<'EOF'
+    ╔════════════════════════════════════════════╗
+    ║                                            ║
+    ║   ██╗   ██╗ ██████╗ ██╗ ██████╗███████╗    ║
+    ║   ██║   ██║██╔═══██╗██║██╔════╝██╔════╝    ║
+    ║   ██║   ██║██║   ██║██║██║     █████╗      ║
+    ║   ╚██╗ ██╔╝██║   ██║██║██║     ██╔══╝      ║
+    ║    ╚████╔╝ ╚██████╔╝██║╚██████╗███████╗    ║
+    ║     ╚═══╝   ╚═════╝ ╚═╝ ╚═════╝╚══════╝    ║
+    ║                                            ║
+    ║   ███╗   ███╗ ██████╗ ██████╗ ███████╗     ║
+    ║   ████╗ ████║██╔═══██╗██╔══██╗██╔════╝     ║
+    ║   ██╔████╔██║██║   ██║██║  ██║█████╗       ║
+    ║   ██║╚██╔╝██║██║   ██║██║  ██║██╔══╝       ║
+    ║   ██║ ╚═╝ ██║╚██████╔╝██████╔╝███████╗     ║
+    ║   ╚═╝     ╚═╝ ╚═════╝ ╚═════╝ ╚══════╝     ║
+    ║                                            ║
+    ║     🎙️  VoiceMode for Claude Code  🤖      ║
+    ║                                            ║
+    ╚════════════════════════════════════════════╝
+EOF
+    printf '%s\n' "${RESET}"
+    echo ""
+    echo "${BOLD}Talk to Claude like a colleague, not a chatbot.${RESET}"
+    echo ""
+    echo "${DIM}Transform your AI coding experience with natural voice conversations.${RESET}"
     echo ""
 }
 

--- a/docs/web/install.sh
+++ b/docs/web/install.sh
@@ -53,7 +53,7 @@ setup_colors() {
         GREEN=$'\033[0;32m'
         YELLOW=$'\033[0;33m'
         BLUE=$'\033[0;34m'
-        ORANGE=$'\033[38;5;208m' # Claude Code orange
+        ORANGE=$'\033[38;2;255;135;0m' # Claude Code orange (24-bit truecolor, theme-independent)
         BOLD=$'\033[1m'
         DIM=$'\033[2m'
         RESET=$'\033[0m'


### PR DESCRIPTION
## Problem

Mike ran the installer and the header showed a small white "VoiceMode" text — a regression. The original was a big orange ASCII-art logo.

## Fix

Restored the original large orange boxed ASCII-art banner from the pre-VM-329 `docs/web/install.sh` (commit `333c581^`), including:

- `ORANGE` (ANSI 256-color 208, "Claude Code orange") and `DIM` colors added to `setup_colors`, with NO_COLOR-safe empty fallbacks
- Full boxed double-line banner with the VoiceMode + MODE ASCII art and the mic/robot tagline line
- Tagline text ("Talk to Claude like a colleague, not a chatbot." / "Transform your AI coding experience…")

Integrated into the current installer's `show_logo()` (same function name, same call site preserved). `install.sh` at repo root is a symlink to `docs/web/install.sh`.

## Verification

- `bash -n docs/web/install.sh` passes
- Rendered `show_logo` in isolation — banner displays correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)