### PR TITLE
chore(dependabot): group every bump into one weekly PR

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -17,10 +17,13 @@ updates:
       prefix: "deps"
       include: "scope"
     groups:
-      python-minor-and-patch:
+      # Group every bump (major/minor/patch) into a single weekly PR.
+      # Trades fine-grained review for a clean inbox; CI is the gate.
+      python-all:
         patterns:
           - "*"
         update-types:
+          - "major"
           - "minor"
           - "patch"
 
@@ -39,10 +42,11 @@ updates:
       prefix: "deps(installer)"
       include: "scope"
     groups:
-      installer-minor-and-patch:
+      installer-all:
         patterns:
           - "*"
         update-types:
+          - "major"
           - "minor"
           - "patch"
 
@@ -60,9 +64,10 @@ updates:
       prefix: "ci"
       include: "scope"
     groups:
-      actions-minor-and-patch:
+      actions-all:
         patterns:
           - "*"
         update-types:
+          - "major"
           - "minor"
           - "patch"


### PR DESCRIPTION
## Summary

The existing dependabot config grouped only `minor` + `patch` bumps, so every major bump opened its own PR. Combined with weekly cadence and the fact that 0.x bumps are treated as majors (`starlette 0.47 → 0.49`, `python-multipart 0.0.20 → 0.0.27`, etc.), the open-PR list accumulated faster than it could be merged — 15 open Dependabot PRs at time of change.

This widens each ecosystem's group `update-types` to `[major, minor, patch]` so every bump lands in a single weekly PR per ecosystem. Groups are renamed to drop the now-misleading `-minor-and-patch` suffix:

- `python-minor-and-patch` → `python-all`
- `installer-minor-and-patch` → `installer-all`
- `actions-minor-and-patch` → `actions-all`

## Trade-off

- **Lose:** fine-grained review per dependency
- **Gain:** one CI-gated PR per ecosystem per week instead of N

CI is the gate. If a major bump in the bundle breaks something, the whole PR fails until the offending dep is pinned or its breaking change is addressed.

## Follow-up

The existing backlog of 15 open Dependabot PRs is being closed in bulk alongside this change. Dependabot will recreate any still-needed bumps on the next Monday run under the new grouped shape.

## Test plan

- [ ] Merge to master
- [ ] Wait for next Monday's Dependabot run
- [ ] Verify exactly one PR opens per ecosystem (or zero if no bumps available)