### PR TITLE
docs(VM-1400): surface permission allow-list in voicemode skill

### DIFF
--- a/.claude/skills/voicemode/SKILL.md
+++ b/.claude/skills/voicemode/SKILL.md
@@ -13,6 +13,8 @@ If VoiceMode isn't working or MCP fails to connect, run:
 
 After install, reconnect MCP: `/mcp` → select voicemode → "Reconnect" (or restart Claude Code).
 
+If Claude Code prompts you for permission on `voicemode:converse` or `voicemode:service`, see [references/permissions.md](references/permissions.md) for the one-time allow-list setup.
+
 ---
 
 # VoiceMode

--- a/.claude/skills/voicemode/references/permissions.md
+++ b/.claude/skills/voicemode/references/permissions.md
@@ -1,0 +1,85 @@
+# Permissions — stop the per-project prompt
+
+**Symptom:** Claude Code asks "Do you want to proceed?" the first time
+`mcp__voicemode__converse` or `mcp__voicemode__service` is used in a project.
+
+**Fix (one-time):** add VoiceMode's MCP tools to Claude Code's permission
+allow-list. Three application paths below — pick whichever is easiest.
+
+## Recommended snippet
+
+```json
+{
+  "permissions": {
+    "allow": [
+      "mcp__voicemode__converse",
+      "mcp__voicemode__service"
+    ]
+  }
+}
+```
+
+| Tool                       | What it does                                              |
+| -------------------------- | --------------------------------------------------------- |
+| `mcp__voicemode__converse` | Voice conversations (speak via TTS, listen via STT)       |
+| `mcp__voicemode__service`  | Start / stop / restart local Whisper and Kokoro services  |
+
+Install/uninstall tools (`whisper_install`, `kokoro_install`, etc.) are
+deliberately **not** on the recommended list — those download and compile
+software and benefit from per-invocation approval.
+
+## Three ways to apply it
+
+### 1. `/permissions` UI (in Claude Code)
+
+```
+/permissions
+```
+
+Add `mcp__voicemode__converse` and `mcp__voicemode__service` to the allow
+list. Persists to settings.json automatically.
+
+### 2. Edit settings.json directly
+
+```bash
+$EDITOR ~/.claude/settings.json
+```
+
+Merge the snippet above into the existing `permissions.allow` array (or
+add the whole `permissions` block if the file is empty).
+
+### 3. Shell heredoc (fresh install)
+
+```bash
+mkdir -p ~/.claude
+cat > ~/.claude/settings.json <<'EOF'
+{
+  "permissions": {
+    "allow": [
+      "mcp__voicemode__converse",
+      "mcp__voicemode__service"
+    ]
+  }
+}
+EOF
+```
+
+Only safe if `~/.claude/settings.json` doesn't already exist — otherwise
+this clobbers your other settings. Use option 1 or 2 if unsure.
+
+## Where to put it: global vs project vs project-local
+
+| File                            | Scope         | When to use                                                |
+| ------------------------------- | ------------- | ---------------------------------------------------------- |
+| `~/.claude/settings.json`       | All projects  | **Default.** Personal machine, one user — set once.        |
+| `.claude/settings.json`         | This project  | Team setting — commits to git so the whole team gets it.   |
+| `.claude/settings.local.json`   | This project  | Personal override on a team project — gitignored.          |
+
+Merge order: global → project → project-local (last wins).
+
+> The per-project prompt's "Yes, and don't ask again for plugin:voicemode:voicemode commands in /path/to/project" option also works — it writes to `.claude/settings.local.json`. But it only covers the one project you accepted it in. The snippet above, in `~/.claude/settings.json`, covers every project at once.
+
+## See also
+
+- **[Full permissions guide](../../../../docs/guides/permissions.md)** — three permission *levels* (voice-only, voice+service, all-tools-with-denies), troubleshooting, common JSON mistakes, security notes on what each tool can do.
+- **[Claude Code permissions docs](https://docs.claude.com/en/docs/claude-code/settings#permissions)** — upstream reference for the `permissions` schema.

--- a/.claude/skills/voicemode/references/permissions.md
+++ b/.claude/skills/voicemode/references/permissions.md
@@ -1,12 +1,14 @@
 # Permissions — stop the per-project prompt
 
-**Symptom:** Claude Code asks "Do you want to proceed?" the first time
-`mcp__voicemode__converse` or `mcp__voicemode__service` is used in a project.
+## Symptom
 
-**Fix (one-time):** add VoiceMode's MCP tools to Claude Code's permission
-allow-list. Three application paths below — pick whichever is easiest.
+Claude Code prompts "Do you want to proceed?" the first time
+`mcp__voicemode__converse` or `mcp__voicemode__service` is called in a
+project.
 
-## Recommended snippet
+## Fix
+
+Add to Claude Code's `permissions.allow`:
 
 ```json
 {
@@ -19,67 +21,20 @@ allow-list. Three application paths below — pick whichever is easiest.
 }
 ```
 
-| Tool                       | What it does                                              |
-| -------------------------- | --------------------------------------------------------- |
-| `mcp__voicemode__converse` | Voice conversations (speak via TTS, listen via STT)       |
-| `mcp__voicemode__service`  | Start / stop / restart local Whisper and Kokoro services  |
+Don't blanket-allow `mcp__voicemode__*` — install/uninstall tools
+(`whisper_install`, `kokoro_install`, `whisper_model_install`) download
+and compile software; per-invocation approval is correct for those.
 
-Install/uninstall tools (`whisper_install`, `kokoro_install`, etc.) are
-deliberately **not** on the recommended list — those download and compile
-software and benefit from per-invocation approval.
+## Where to put it
 
-## Three ways to apply it
+| File                          | Scope        | Pick when                                                       |
+| ----------------------------- | ------------ | --------------------------------------------------------------- |
+| `~/.claude/settings.json`     | USER         | Personal machine, one user — covers every project at once.      |
+| `.claude/settings.json`       | Project      | Team setting — committed to git so everyone on the project gets it. |
+| `.claude/settings.local.json` | Project (local) | Personal override on a team project — gitignored.            |
 
-### 1. `/permissions` UI (in Claude Code)
-
-```
-/permissions
-```
-
-Add `mcp__voicemode__converse` and `mcp__voicemode__service` to the allow
-list. Persists to settings.json automatically.
-
-### 2. Edit settings.json directly
-
-```bash
-$EDITOR ~/.claude/settings.json
-```
-
-Merge the snippet above into the existing `permissions.allow` array (or
-add the whole `permissions` block if the file is empty).
-
-### 3. Shell heredoc (fresh install)
-
-```bash
-mkdir -p ~/.claude
-cat > ~/.claude/settings.json <<'EOF'
-{
-  "permissions": {
-    "allow": [
-      "mcp__voicemode__converse",
-      "mcp__voicemode__service"
-    ]
-  }
-}
-EOF
-```
-
-Only safe if `~/.claude/settings.json` doesn't already exist — otherwise
-this clobbers your other settings. Use option 1 or 2 if unsure.
-
-## Where to put it: global vs project vs project-local
-
-| File                            | Scope         | When to use                                                |
-| ------------------------------- | ------------- | ---------------------------------------------------------- |
-| `~/.claude/settings.json`       | All projects  | **Default.** Personal machine, one user — set once.        |
-| `.claude/settings.json`         | This project  | Team setting — commits to git so the whole team gets it.   |
-| `.claude/settings.local.json`   | This project  | Personal override on a team project — gitignored.          |
-
-Merge order: global → project → project-local (last wins).
-
-> The per-project prompt's "Yes, and don't ask again for plugin:voicemode:voicemode commands in /path/to/project" option also works — it writes to `.claude/settings.local.json`. But it only covers the one project you accepted it in. The snippet above, in `~/.claude/settings.json`, covers every project at once.
+Merge order: USER → project → project-local (last wins).
 
 ## See also
 
-- **[Full permissions guide](../../../../docs/guides/permissions.md)** — three permission *levels* (voice-only, voice+service, all-tools-with-denies), troubleshooting, common JSON mistakes, security notes on what each tool can do.
-- **[Claude Code permissions docs](https://docs.claude.com/en/docs/claude-code/settings#permissions)** — upstream reference for the `permissions` schema.
+- **[Full permissions guide](../../../../docs/guides/permissions.md)** — permission levels (voice-only, voice+service, all-with-denies), security notes on what each tool can do, common JSON mistakes.


### PR DESCRIPTION
## Summary

- Add `.claude/skills/voicemode/references/permissions.md` — terse, in-session operational doc that names the symptom (Claude Code's "Do you want to proceed?" prompt on first `voicemode:converse` in a project) and shows three ways to fix it. Links to the existing `docs/guides/permissions.md` for the fuller user-guide treatment rather than duplicating it.
- Add a single trigger-aware sentence in `SKILL.md` near *First-Time Setup* pointing at the new reference, so a future agent loading the skill will surface the fix when the user hits the prompt.

## Why

The skill is the always-loaded surface for an agent. Until now it said nothing about Claude Code's permissions system, so an agent helping a user couldn't connect the prompt the user was staring at to the fix that already exists in the project docs. Found while debugging in `~/Code/github.com/mbailey/keycutter`.

## Design notes

- **`references/` chosen over `docs/`** to match the Anthropic skill convention for progressive-disclosure subfiles. The skill's existing `docs/transcript-visibility.md` is left in place; may migrate later in a separate cleanup.
- **No duplication** of `docs/guides/permissions.md` — different audience (agent in-session vs user on website), linked rather than copied to avoid drift.

## Test plan

- [ ] `cat .claude/skills/voicemode/references/permissions.md` renders cleanly
- [ ] Relative link in references doc resolves to `docs/guides/permissions.md` from `.claude/skills/voicemode/references/permissions.md` (4 levels up)
- [ ] One-liner in SKILL.md renders cleanly and the relative link `references/permissions.md` resolves

Refs: VM-1400