### PR TITLE
feat(plugin): add homepage URL to plugin.json

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -16,5 +16,7 @@
     "./voice_mode/data/hooks/stop.json",
     "./voice_mode/data/hooks/pre-compact.json",
     "./voice_mode/data/hooks/permission-request.json"
-  ]
+  ],
+  "homepage": "https://github.com/mbailey/voicemode"
 }
+


### PR DESCRIPTION
Adds `homepage: https://github.com/mbailey/voicemode` to `.claude-plugin/plugin.json`.

Lets a downstream marketplace (e.g. skillbox's own `.claude-plugin/marketplace.json`) populate its per-plugin `homepage` field straight from this file — the two-way-sync direction Mike wants for external_plugins re-hydration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)