### PR TITLE
fix(VM-1409): point service install errors at real CLI commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,7 @@ Newer Claude Code releases collapse MCP tool calls in the visible transcript, wh
 
 ### Fixed
 
+- **Service install error messages now reference real CLI commands** (VM-1409) -- Errors like "Whisper start script not found. Please run whisper_install first." pointed at MCP tool names (`whisper_install`, `kokoro_install`, `download_model`) that don't exist as CLI commands, so users hitting the error from the CLI had no way to act on it. Updated to match the existing mlx-audio branch's style -- now reference `voicemode service install whisper`, `voicemode service install kokoro`, and `voicemode whisper model <name>`.
 - **mlx-audio install no longer fails at the patch step** (VM-1126) -- `voicemode service install mlx-audio` would fail with "Patch step failed: ... 2 out of 5 hunks failed" against mlx-audio 0.4.3. The MLX Metal serialisation lock the bundled patch carried ([ml-explore/mlx#2133](https://github.com/ml-explore/mlx/issues/2133)) is upstream from 0.4.3 on, so the patch now adds lines that already exist and rejects.
 - **mlx-audio STT `response_format` patch restored** (VM-1128) -- VM-1126 over-removed: while the Metal lock was upstreamed, the OpenAI-style STT `response_format` handling on `/v1/audio/transcriptions` is *not* yet in mlx-audio 0.4.3. Restored as a separate patch.
 

--- a/voice_mode/tools/service.py
+++ b/voice_mode/tools/service.py
@@ -454,12 +454,12 @@ async def start_service(service_name: str) -> str:
         # Find whisper-server binary
         whisper_bin = find_whisper_server()
         if not whisper_bin:
-            return "❌ whisper-server not found. Please run whisper_install first."
+            return "❌ whisper-server not found. Run `voicemode service install whisper` first."
         
         # Find model
         model_file = find_whisper_model()
         if not model_file:
-            return "❌ No Whisper model found. Please run download_model first."
+            return "❌ No Whisper model found. Run `voicemode whisper model <name>` first (e.g. `voicemode whisper model large-v2`)."
         
         # Start whisper-server
         start_script = Path(config_vars["START_SCRIPT"])
@@ -478,7 +478,7 @@ async def start_service(service_name: str) -> str:
         # Find kokoro installation
         kokoro_dir = find_kokoro_fastapi()
         if not kokoro_dir:
-            return "❌ kokoro-fastapi not found. Please run kokoro_install first."
+            return "❌ kokoro-fastapi not found. Run `voicemode service install kokoro` first."
         
         # Use appropriate start script
         if platform.system() == "Darwin":
@@ -677,12 +677,12 @@ async def enable_service(service_name: str) -> str:
         if service_name == "whisper":
             start_script = config_vars.get("START_SCRIPT", "")
             if not start_script or not Path(start_script).exists():
-                return "❌ Whisper start script not found. Please run whisper_install first."
+                return "❌ Whisper start script not found. Run `voicemode service install whisper` first."
 
         elif service_name == "kokoro":
             start_script = config_vars.get("START_SCRIPT", "")
             if not start_script or not Path(start_script).exists():
-                return "❌ Kokoro start script not found. Please run kokoro_install first."
+                return "❌ Kokoro start script not found. Run `voicemode service install kokoro` first."
 
         elif service_name == "mlx_audio":
             # Validate the uv-tool entry point exists rather than a start

--- a/voice_mode/tools/whisper/model_install.py
+++ b/voice_mode/tools/whisper/model_install.py
@@ -78,7 +78,7 @@ async def whisper_model_install(
         else:
             return json.dumps({
                 "success": False,
-                "error": "Whisper.cpp not installed. Please run whisper_install first."
+                "error": "Whisper.cpp not installed. Run `voicemode service install whisper` first."
             }, indent=2)
         
         # CoreML dependencies no longer needed - using pre-built models from Hugging Face!


### PR DESCRIPTION
## Summary

Five error strings in service tooling told users to "run `whisper_install` first" / "run `kokoro_install` first" / "run `download_model` first" -- but these are **MCP tool names**, not CLI commands. A user hitting the error from the CLI (e.g. `voicemode service enable whisper` on a fresh machine) had no path forward. The mlx-audio branch in the same file already does this right (`Run \`voicemode service install mlx-audio\` first.`); this brings the other branches into line.

### Before

```
$ voicemode service enable whisper
❌ Whisper start script not found. Please run whisper_install first.
```

### After

```
$ voicemode service enable whisper
❌ Whisper start script not found. Run `voicemode service install whisper` first.
```

### Mapping

| Old (MCP tool name) | New (CLI command) |
|---|---|
| `whisper_install` | `voicemode service install whisper` |
| `kokoro_install` | `voicemode service install kokoro` |
| `download_model` | `voicemode whisper model <name>` |

Six occurrences updated -- five in `voice_mode/tools/service.py`, one in `voice_mode/tools/whisper/model_install.py`. CHANGELOG entry added under `[Unreleased] / Fixed`.

Task: VM-1409

## Test plan

- [ ] `voicemode service enable whisper` on a machine without Whisper installed -- error message points at `voicemode service install whisper`
- [ ] `voicemode service start whisper` after install but with no model -- error points at `voicemode whisper model <name>`
- [ ] `voicemode service enable kokoro` without Kokoro installed -- error points at `voicemode service install kokoro`
- [ ] Run `make test` -- existing tests still pass
- [ ] No regressions in MCP tool callers (the strings are returned identically from MCP and CLI paths; CLI command names also read fine in MCP context)

🤖 Generated with [Claude Code](https://claude.com/claude-code)