### PR TITLE
feat(VM-1024): voicemode autofocus on|off|status — quick-toggle sentinel

### DIFF
--- a/tests/test_auto_focus_pane.py
+++ b/tests/test_auto_focus_pane.py
@@ -137,6 +137,24 @@ class TestFocusTmuxPane:
 
                     mock_run.assert_not_called()
 
+    def test_respects_autofocus_disabled_sentinel(self):
+        """When the autofocus-disabled sentinel exists, focus is suppressed entirely.
+
+        Wired up for VM-1024 (`voicemode autofocus off`). Should fire before
+        the focus-hold check — i.e. user-toggled "off" wins over the transient
+        "another tool just took focus" suppressor as well as `_is_focus_held`.
+        """
+        with patch.dict("os.environ", {"TMUX_PANE": "%5"}, clear=False):
+            with patch(
+                "voice_mode.cli_commands.autofocus.is_autofocus_disabled_by_sentinel",
+                return_value=True,
+            ):
+                with patch("subprocess.run") as mock_run:
+                    from voice_mode.tools.converse import focus_tmux_pane
+                    focus_tmux_pane()
+
+                    mock_run.assert_not_called()
+
 
 class TestAutoFocusPaneConfig:
     """Test the AUTO_FOCUS_PANE config option."""

--- a/tests/test_autofocus_cli.py
+++ b/tests/test_autofocus_cli.py
@@ -1,0 +1,180 @@
+"""Tests for the `voicemode autofocus` CLI toggle (VM-1024).
+
+Mirrors the soundfonts toggle pattern (see voice_mode/cli_commands/soundfonts.py
+and the same-shaped tests there if/when they're added). Targets:
+
+- Sentinel file create / remove via `autofocus off` / `autofocus on`
+- `--config` flag persists VOICEMODE_AUTO_FOCUS_PANE in voicemode.env
+- `autofocus status` reports correctly across the four states
+  (no sentinel + env unset / env true / env false; sentinel present)
+"""
+
+from pathlib import Path
+from unittest.mock import patch
+
+import click.testing
+import pytest
+
+# Import autofocus at test-module load time, BEFORE any pytest fixture has
+# patched Path.home(). This ensures SENTINEL_FILE / VOICEMODE_ENV_FILE bind
+# to the real user home (where the sentinel typically does NOT exist) — and
+# our tests then explicitly monkeypatch those attrs to point under fake_home.
+# Without this, autofocus would be imported lazily under a fixture-patched
+# Path.home, leaving a stale tmp_path baked into the module forever (and
+# leaking sentinel files into later tests in the same session).
+from voice_mode.cli_commands import autofocus as _autofocus_eager_import  # noqa: F401
+
+
+@pytest.fixture
+def tmp_voicemode_dir(isolate_home_directory, monkeypatch):
+    """Provide handles to the autofocus module's sentinel/env paths.
+
+    Relies on the project-wide autouse `isolate_home_directory` fixture
+    (tests/conftest.py:99) which patches `Path.home()` to a tmp dir.
+
+    We pin the autofocus module's module-level `SENTINEL_FILE` and
+    `VOICEMODE_ENV_FILE` to paths under this test's fake home via
+    `monkeypatch.setattr`. `monkeypatch` undoes the patch at teardown, so
+    no module reload is needed — other tests see the originals. This
+    avoids the stale-Path bug where a previous test's tmp_path leaks
+    into a later test's SENTINEL_FILE via module-level binding.
+    """
+    from voice_mode.cli_commands import autofocus
+    fake_home = isolate_home_directory
+    sentinel_path = fake_home / ".voicemode" / "autofocus-disabled"
+    env_path = fake_home / ".voicemode" / "voicemode.env"
+    monkeypatch.setattr(autofocus, "SENTINEL_FILE", sentinel_path)
+    monkeypatch.setattr(autofocus, "VOICEMODE_ENV_FILE", env_path)
+    monkeypatch.delenv("VOICEMODE_AUTO_FOCUS_PANE", raising=False)
+    yield {
+        "home": fake_home,
+        "voicemode_dir": fake_home / ".voicemode",
+        "sentinel": sentinel_path,
+        "env_file": env_path,
+        "autofocus": autofocus,
+    }
+
+
+def _run(cmd, args):
+    return click.testing.CliRunner().invoke(cmd, args)
+
+
+class TestAutofocusOff:
+    """`voicemode autofocus off` creates the sentinel; --config persists env var."""
+
+    def test_creates_sentinel_when_absent(self, tmp_voicemode_dir):
+        af = tmp_voicemode_dir["autofocus"]
+        assert not tmp_voicemode_dir["sentinel"].exists()
+
+        result = _run(af.autofocus, ["off"])
+        assert result.exit_code == 0
+        assert tmp_voicemode_dir["sentinel"].exists()
+        assert "disabled" in result.output.lower()
+
+    def test_idempotent_when_sentinel_present(self, tmp_voicemode_dir):
+        af = tmp_voicemode_dir["autofocus"]
+        tmp_voicemode_dir["sentinel"].parent.mkdir(parents=True, exist_ok=True)
+        tmp_voicemode_dir["sentinel"].touch()
+
+        result = _run(af.autofocus, ["off"])
+        assert result.exit_code == 0
+        assert tmp_voicemode_dir["sentinel"].exists()
+        assert "already disabled" in result.output.lower()
+
+    def test_config_flag_writes_env_file(self, tmp_voicemode_dir):
+        af = tmp_voicemode_dir["autofocus"]
+        result = _run(af.autofocus, ["off", "--config"])
+        assert result.exit_code == 0
+        contents = tmp_voicemode_dir["env_file"].read_text()
+        assert "VOICEMODE_AUTO_FOCUS_PANE=false" in contents
+
+
+class TestAutofocusOn:
+    """`voicemode autofocus on` removes the sentinel; --config flips env var to true."""
+
+    def test_removes_sentinel_when_present(self, tmp_voicemode_dir):
+        af = tmp_voicemode_dir["autofocus"]
+        tmp_voicemode_dir["sentinel"].parent.mkdir(parents=True, exist_ok=True)
+        tmp_voicemode_dir["sentinel"].touch()
+
+        result = _run(af.autofocus, ["on"])
+        assert result.exit_code == 0
+        assert not tmp_voicemode_dir["sentinel"].exists()
+        assert "enabled" in result.output.lower()
+
+    def test_idempotent_when_sentinel_absent_and_env_false(self, tmp_voicemode_dir):
+        af = tmp_voicemode_dir["autofocus"]
+        result = _run(af.autofocus, ["on"])
+        assert result.exit_code == 0
+        # No sentinel removed, no change made. The "default is false" hint should
+        # fire (env var is unset, so autofocus won't actually run without --config).
+        assert "auto-focus" in result.output.lower()
+        assert "voicemode_auto_focus_pane" in result.output.lower()
+
+    def test_config_flag_writes_env_file_true(self, tmp_voicemode_dir):
+        af = tmp_voicemode_dir["autofocus"]
+        result = _run(af.autofocus, ["on", "--config"])
+        assert result.exit_code == 0
+        contents = tmp_voicemode_dir["env_file"].read_text()
+        assert "VOICEMODE_AUTO_FOCUS_PANE=true" in contents
+
+
+class TestAutofocusStatus:
+    """`voicemode autofocus status` reports the four canonical states."""
+
+    def test_disabled_default_when_nothing_set(self, tmp_voicemode_dir):
+        af = tmp_voicemode_dir["autofocus"]
+        result = _run(af.autofocus, ["status"])
+        assert result.exit_code == 0
+        assert "disabled" in result.output.lower()
+        assert "default" in result.output.lower()
+
+    def test_enabled_when_env_true_in_file(self, tmp_voicemode_dir):
+        af = tmp_voicemode_dir["autofocus"]
+        env = tmp_voicemode_dir["env_file"]
+        env.parent.mkdir(parents=True, exist_ok=True)
+        env.write_text("VOICEMODE_AUTO_FOCUS_PANE=true\n")
+
+        result = _run(af.autofocus, ["status"])
+        assert result.exit_code == 0
+        assert "enabled" in result.output.lower()
+        assert "voicemode_auto_focus_pane=true" in result.output.lower()
+
+    def test_disabled_quick_toggle_when_sentinel_present(self, tmp_voicemode_dir):
+        af = tmp_voicemode_dir["autofocus"]
+        tmp_voicemode_dir["sentinel"].parent.mkdir(parents=True, exist_ok=True)
+        tmp_voicemode_dir["sentinel"].touch()
+
+        result = _run(af.autofocus, ["status"])
+        assert result.exit_code == 0
+        assert "disabled" in result.output.lower()
+        assert "quick toggle" in result.output.lower()
+
+    def test_sentinel_overrides_env_true(self, tmp_voicemode_dir):
+        """Sentinel forces off even when env var would have enabled it."""
+        af = tmp_voicemode_dir["autofocus"]
+        env = tmp_voicemode_dir["env_file"]
+        env.parent.mkdir(parents=True, exist_ok=True)
+        env.write_text("VOICEMODE_AUTO_FOCUS_PANE=true\n")
+        tmp_voicemode_dir["sentinel"].parent.mkdir(parents=True, exist_ok=True)
+        tmp_voicemode_dir["sentinel"].touch()
+
+        result = _run(af.autofocus, ["status"])
+        assert result.exit_code == 0
+        out = result.output.lower()
+        assert "disabled (quick toggle)" in out
+        assert "overridden" in out
+
+
+class TestIsAutofocusDisabledBySentinel:
+    """The helper consumed by focus_tmux_pane() in converse.py."""
+
+    def test_false_when_sentinel_absent(self, tmp_voicemode_dir):
+        af = tmp_voicemode_dir["autofocus"]
+        assert af.is_autofocus_disabled_by_sentinel() is False
+
+    def test_true_when_sentinel_present(self, tmp_voicemode_dir):
+        af = tmp_voicemode_dir["autofocus"]
+        tmp_voicemode_dir["sentinel"].parent.mkdir(parents=True, exist_ok=True)
+        tmp_voicemode_dir["sentinel"].touch()
+        assert af.is_autofocus_disabled_by_sentinel() is True

--- a/voice_mode/cli.py
+++ b/voice_mode/cli.py
@@ -1854,6 +1854,7 @@ from voice_mode.cli_commands import transcribe as transcribe_cmd
 from voice_mode.cli_commands import status as status_cmd
 from voice_mode.cli_commands import claude as claude_cmd
 from voice_mode.cli_commands import soundfonts as soundfonts_cmd
+from voice_mode.cli_commands import autofocus as autofocus_cmd
 
 # Add subcommands to legacy CLI
 cli.add_command(exchanges_cmd.exchanges)
@@ -1869,6 +1870,9 @@ voice_mode_main_cli.add_command(claude_cmd.claude)
 
 # Add soundfonts toggle commands
 voice_mode_main_cli.add_command(soundfonts_cmd.soundfonts)
+
+# Add autofocus toggle commands
+voice_mode_main_cli.add_command(autofocus_cmd.autofocus)
 
 # Note: We'll add these commands after the groups are defined
 # audio group will get transcribe and play commands

--- a/voice_mode/cli_commands/autofocus.py
+++ b/voice_mode/cli_commands/autofocus.py
@@ -1,0 +1,263 @@
+"""CLI commands for tmux autofocus toggle.
+
+Provides `voicemode autofocus on/off/status` commands for enabling
+and disabling auto-focus of the agent's tmux pane on converse.
+
+Two mechanisms control auto-focus:
+1. Sentinel file (~/.voicemode/autofocus-disabled) — quick toggle / circuit breaker
+2. Env var (VOICEMODE_AUTO_FOCUS_PANE) — persistent config in voicemode.env
+
+The sentinel file forces-disable when present, regardless of the env var.
+When the sentinel is absent, the env var decides. Default (neither set) is
+disabled (consistent with VOICEMODE_AUTO_FOCUS_PANE defaulting to false in
+voice_mode/config.py).
+
+Mirrors the soundfonts toggle pattern (voice_mode/cli_commands/soundfonts.py)
+so users have one mental model for "quick toggle" feature switches.
+"""
+
+import os
+from pathlib import Path
+
+import click
+
+
+SENTINEL_FILE = Path.home() / '.voicemode' / 'autofocus-disabled'
+VOICEMODE_ENV_FILE = Path.home() / '.voicemode' / 'voicemode.env'
+
+
+def is_autofocus_disabled_by_sentinel() -> bool:
+    """Return True if the quick-toggle sentinel file exists.
+
+    Called from focus_tmux_pane() in voice_mode/tools/converse.py to
+    short-circuit auto-focus regardless of VOICEMODE_AUTO_FOCUS_PANE.
+    """
+    return SENTINEL_FILE.exists()
+
+
+def _get_env_var_state() -> tuple:
+    """Check VOICEMODE_AUTO_FOCUS_PANE from config file and env.
+
+    Returns:
+        (enabled: bool | None, source: str | None)
+        source is 'file' (voicemode.env), 'env' (shell only), or None (not set)
+    """
+    # Check voicemode.env file first — more actionable source
+    file_val = None
+    if VOICEMODE_ENV_FILE.exists():
+        for line in VOICEMODE_ENV_FILE.read_text().splitlines():
+            stripped = line.strip()
+            if stripped.startswith('#'):
+                continue
+            if stripped.startswith('VOICEMODE_AUTO_FOCUS_PANE='):
+                val = stripped.split('=', 1)[1].strip().strip('"').strip("'")
+                file_val = val.lower() in ('true', '1', 'yes', 'on')
+                break
+
+    # Check shell environment
+    env_val = os.environ.get('VOICEMODE_AUTO_FOCUS_PANE')
+
+    if file_val is not None:
+        # File value exists — report it as the source
+        return file_val, 'file'
+
+    if env_val is not None:
+        # Only in shell env (not from our file) — less common
+        return env_val.lower() in ('true', '1', 'yes', 'on'), 'env'
+
+    # Not set anywhere — default is false
+    return None, None
+
+
+def _update_env_file(enabled: bool) -> None:
+    """Update VOICEMODE_AUTO_FOCUS_PANE in ~/.voicemode/voicemode.env.
+
+    Also syncs os.environ so the current process sees the new value
+    (voicemode's config.py loads voicemode.env into os.environ at startup,
+    which can leave stale values if we only update the file).
+    """
+    value = 'true' if enabled else 'false'
+    os.environ['VOICEMODE_AUTO_FOCUS_PANE'] = value
+    env_file = VOICEMODE_ENV_FILE
+
+    if not env_file.exists():
+        env_file.parent.mkdir(parents=True, exist_ok=True)
+        env_file.write_text(f'VOICEMODE_AUTO_FOCUS_PANE={value}\n')
+        return
+
+    lines = env_file.read_text().splitlines()
+    found = False
+    for i, line in enumerate(lines):
+        stripped = line.strip()
+        if stripped.startswith('#'):
+            continue
+        if stripped.startswith('VOICEMODE_AUTO_FOCUS_PANE='):
+            lines[i] = f'VOICEMODE_AUTO_FOCUS_PANE={value}'
+            found = True
+            break
+
+    if not found:
+        lines.append(f'VOICEMODE_AUTO_FOCUS_PANE={value}')
+
+    env_file.write_text('\n'.join(lines) + '\n')
+
+
+def _hint_env_var_off() -> None:
+    """Print a hint if the env var would keep autofocus off after removing sentinel."""
+    enabled, source = _get_env_var_state()
+    if enabled is not True:
+        click.echo()
+        click.echo("Note: VOICEMODE_AUTO_FOCUS_PANE is not set to true.")
+        if source == 'file':
+            click.echo(f"  Currently: false in {VOICEMODE_ENV_FILE}")
+        elif source == 'env':
+            click.echo("  Currently: false in shell environment")
+        else:
+            click.echo("  Currently: unset (default is false)")
+        click.echo("  Auto-focus will only run when VOICEMODE_AUTO_FOCUS_PANE=true.")
+        click.echo("  Persist with: voicemode autofocus on --config")
+
+
+@click.group(name='autofocus')
+@click.help_option('-h', '--help', help='Show this message and exit')
+def autofocus():
+    """Toggle tmux auto-focus on converse.
+
+    When auto-focus is enabled, voicemode brings the agent's tmux pane into
+    view as it speaks (without stealing your active pane). Useful in multi-
+    agent setups where you want to see who's talking.
+
+    Quick toggle (session-scoped via sentinel file):
+        voicemode autofocus off        # Disable immediately
+        voicemode autofocus on         # Remove sentinel
+
+    Persistent config change (~/.voicemode/voicemode.env):
+        voicemode autofocus on --config    # Enable + update voicemode.env
+        voicemode autofocus off --config   # Disable + update voicemode.env
+    """
+    pass
+
+
+@autofocus.command('on')
+@click.option('--config', is_flag=True,
+              help='Also update VOICEMODE_AUTO_FOCUS_PANE in voicemode.env')
+def autofocus_on(config):
+    """Enable tmux auto-focus.
+
+    Removes the quick-toggle sentinel file. Use --config to also
+    set VOICEMODE_AUTO_FOCUS_PANE=true in ~/.voicemode/voicemode.env
+    for persistent enablement (the underlying feature is off by
+    default, so without --config you may also need to set the env
+    var manually).
+    """
+    had_sentinel = SENTINEL_FILE.exists()
+
+    if had_sentinel:
+        SENTINEL_FILE.unlink()
+
+    if config:
+        env_enabled, _ = _get_env_var_state()
+        config_changed = env_enabled is not True  # None (unset) or False
+        if config_changed:
+            _update_env_file(True)
+
+        if had_sentinel and config_changed:
+            click.echo("Auto-focus enabled.")
+            click.echo("  Removed sentinel file.")
+            click.echo(f"  Updated {VOICEMODE_ENV_FILE}: VOICEMODE_AUTO_FOCUS_PANE=true")
+        elif had_sentinel:
+            click.echo("Auto-focus enabled.")
+            click.echo("  Removed sentinel file.")
+        elif config_changed:
+            click.echo("Auto-focus enabled.")
+            click.echo(f"  Updated {VOICEMODE_ENV_FILE}: VOICEMODE_AUTO_FOCUS_PANE=true")
+        else:
+            click.echo("Auto-focus is already enabled.")
+            return
+
+    elif had_sentinel:
+        click.echo("Auto-focus enabled.")
+        _hint_env_var_off()
+    else:
+        env_enabled, _ = _get_env_var_state()
+        if env_enabled is True:
+            click.echo("Auto-focus is already enabled.")
+        else:
+            click.echo("Auto-focus is already enabled (no quick toggle active).")
+            _hint_env_var_off()
+
+
+@autofocus.command('off')
+@click.option('--config', is_flag=True,
+              help='Also update VOICEMODE_AUTO_FOCUS_PANE in voicemode.env')
+def autofocus_off(config):
+    """Disable tmux auto-focus.
+
+    Creates a sentinel file that converse.py checks before focusing
+    the tmux pane. Use --config to also set VOICEMODE_AUTO_FOCUS_PANE=false
+    in ~/.voicemode/voicemode.env for persistent disablement.
+    """
+    had_sentinel = SENTINEL_FILE.exists()
+
+    if not had_sentinel:
+        SENTINEL_FILE.parent.mkdir(parents=True, exist_ok=True)
+        SENTINEL_FILE.touch()
+
+    if config:
+        env_enabled, _ = _get_env_var_state()
+        config_changed = env_enabled is not False  # None (unset) or True
+        if config_changed:
+            _update_env_file(False)
+
+        if had_sentinel and config_changed:
+            click.echo("Auto-focus disabled.")
+            click.echo(f"  Updated {VOICEMODE_ENV_FILE}: VOICEMODE_AUTO_FOCUS_PANE=false")
+        elif had_sentinel:
+            click.echo("Auto-focus is already disabled.")
+        elif config_changed:
+            click.echo("Auto-focus disabled.")
+            click.echo(f"  Updated {VOICEMODE_ENV_FILE}: VOICEMODE_AUTO_FOCUS_PANE=false")
+        else:
+            click.echo("Auto-focus is already disabled.")
+    elif had_sentinel:
+        click.echo("Auto-focus is already disabled.")
+    else:
+        click.echo("Auto-focus disabled (this session).")
+        click.echo("  Re-enable with: voicemode autofocus on")
+
+
+@autofocus.command('status')
+def autofocus_status():
+    """Show whether tmux auto-focus is enabled or disabled.
+
+    Checks both the quick-toggle sentinel file and the
+    VOICEMODE_AUTO_FOCUS_PANE configuration.
+    """
+    sentinel_exists = SENTINEL_FILE.exists()
+    env_enabled, env_source = _get_env_var_state()
+
+    if sentinel_exists:
+        # Sentinel forces off regardless of env var
+        click.echo("Auto-focus: disabled (quick toggle)")
+        click.echo(f"  Sentinel file: {SENTINEL_FILE}")
+        if env_enabled is True:
+            click.echo("  Note: VOICEMODE_AUTO_FOCUS_PANE=true is being overridden by the sentinel.")
+        click.echo("  Re-enable with: voicemode autofocus on")
+    elif env_enabled is True:
+        click.echo("Auto-focus: enabled")
+        if env_source == 'file':
+            click.echo(f"  VOICEMODE_AUTO_FOCUS_PANE=true in {VOICEMODE_ENV_FILE}")
+        else:
+            click.echo("  VOICEMODE_AUTO_FOCUS_PANE=true in shell environment")
+    elif env_enabled is False:
+        click.echo("Auto-focus: disabled (by config)")
+        if env_source == 'file':
+            click.echo(f"  VOICEMODE_AUTO_FOCUS_PANE=false in {VOICEMODE_ENV_FILE}")
+        else:
+            click.echo("  VOICEMODE_AUTO_FOCUS_PANE=false in shell environment")
+        click.echo("  Enable with: voicemode autofocus on --config")
+    else:
+        # Not set anywhere — feature defaults off
+        click.echo("Auto-focus: disabled (default)")
+        click.echo("  VOICEMODE_AUTO_FOCUS_PANE is unset (default is false).")
+        click.echo("  Enable with: voicemode autofocus on --config")

--- a/voice_mode/config.py
+++ b/voice_mode/config.py
@@ -420,6 +420,11 @@ TTS \\bAPI\\b A P I # API as individual letters
 # Auto-focus tmux pane when speaking (for multi-agent setups)
 # Switches tmux focus to the agent's pane after conch acquisition
 # VOICEMODE_AUTO_FOCUS_PANE=false
+#
+# Quick toggle (sentinel file ~/.voicemode/autofocus-disabled):
+#   voicemode autofocus off   # disable immediately, overrides env var
+#   voicemode autofocus on    # remove sentinel
+#   voicemode autofocus status
 
 #############
 # Credential Storage

--- a/voice_mode/tools/converse.py
+++ b/voice_mode/tools/converse.py
@@ -134,10 +134,11 @@ def focus_tmux_pane() -> None:
     """Make the agent's tmux window visible, and optionally switch a client.
 
     Steps:
-    1. Check focus-hold sentinel — skip if another tool recently took focus
-    2. select-window: make the agent's window current (without changing active pane)
-    3. Check if any client is already showing this session — if so, stop
-    4. If no client is showing the session, switch the focused client to it
+    1. Check autofocus-disabled sentinel — skip if user has toggled autofocus off
+    2. Check focus-hold sentinel — skip if another tool recently took focus
+    3. select-window: make the agent's window current (without changing active pane)
+    4. Check if any client is already showing this session — if so, stop
+    5. If no client is showing the session, switch the focused client to it
 
     Deliberately does NOT call select-pane — this avoids stealing focus from
     whichever pane the user is currently working in.  The window becomes
@@ -150,6 +151,12 @@ def focus_tmux_pane() -> None:
 
     tmux_pane = os.environ.get("TMUX_PANE", "")
     if not tmux_pane:
+        return
+
+    # Respect the autofocus quick-toggle sentinel — user disabled via
+    # `voicemode autofocus off`. Overrides VOICEMODE_AUTO_FOCUS_PANE.
+    from voice_mode.cli_commands.autofocus import is_autofocus_disabled_by_sentinel
+    if is_autofocus_disabled_by_sentinel():
         return
 
     # Respect the visual conch — another tool recently took focus


### PR DESCRIPTION
## Summary

- New `voicemode autofocus on|off|status` CLI command mirroring `voicemode soundfonts`.
- Quick-toggle sentinel at `~/.voicemode/autofocus-disabled`; presence forces auto-focus off regardless of `VOICEMODE_AUTO_FOCUS_PANE`.
- `--config` flag also persists `VOICEMODE_AUTO_FOCUS_PANE` to `voicemode.env`.
- `focus_tmux_pane()` consults the sentinel before `_is_focus_held()` so the user-toggled "off" wins over transient visual-conch holds too.
- Ships VM-1024's `off` semantics only. `gentle` is the existing behaviour; `aggressive` is deferred.

## Deprecation note — VM-1412

Parallel research on **VM-1412** ("Named config profiles") recommends collapsing per-feature sentinels (soundfonts, autofocus, future ones) into a single `config_set` / `config_get` model with the CLI commands becoming thin wrappers.

When that work lands, this should migrate:

1. Add `VOICEMODE_AUTO_FOCUS_MODE` as a tri-valued config var (off / gentle / aggressive).
2. `voicemode autofocus off` becomes sugar for `config_set(VOICEMODE_AUTO_FOCUS_MODE=off, config_key=…)`.
3. Delete `is_autofocus_disabled_by_sentinel()` and rewire `focus_tmux_pane()` to read the profile-aware resolver.

Mike has explicitly chosen to ship this stopgap now with the migration target documented at the call site.

## Files

- `voice_mode/cli_commands/autofocus.py` (new) — the CLI group + `is_autofocus_disabled_by_sentinel()` helper consumed by converse.
- `voice_mode/cli.py` — registers the autofocus command alongside soundfonts.
- `voice_mode/tools/converse.py` — short-circuit check in `focus_tmux_pane()` before tmux work begins.
- `voice_mode/config.py` — env-var doc-comment points users at the new toggle.
- `tests/test_autofocus_cli.py` (new) — CLI on/off/status + sentinel helper.
- `tests/test_auto_focus_pane.py` — adds one test that `focus_tmux_pane` honours the autofocus-disabled sentinel.

## Test plan

- [x] `uv run pytest tests/test_autofocus_cli.py tests/test_auto_focus_pane.py` — 27 passed
- [x] Full suite (excluding pre-existing failure in `test_unified_service.py::test_start_whisper_missing_binary`) — 1056 passed
- [x] Smoke: `voicemode autofocus --help`, `voicemode autofocus status` work as expected on Mike's real env (currently reports "enabled" because his env var is true)
- [ ] Manual: `voicemode autofocus off`, talk to an agent, confirm tmux pane does not flip; `voicemode autofocus on`, confirm it flips again