### PR TITLE
fix(VM-1466): X-Forwarded-For IP allowlist bypass (GHSA-2qvv-vjq9-g5r4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Security
+
+- **Fixed X-Forwarded-For IP allowlist bypass in `voicemode serve` ([GHSA-2qvv-vjq9-g5r4](https://github.com/mbailey/voicemode/security/advisories/GHSA-2qvv-vjq9-g5r4), VM-1466)** — `IPAllowlistMiddleware` previously trusted the client-supplied `X-Forwarded-For` header unconditionally, so a remote unauthenticated attacker could send `X-Forwarded-For: 127.0.0.1` (or any allowed IP) to bypass the IP allowlist entirely and reach all HTTP MCP endpoints, including microphone recording and transcription (CVSS 8.6, High). The allowlist now decides on the **direct TCP peer**, and `X-Forwarded-For` is only honored when the peer is a configured trusted proxy. Affected `voice-mode <= 8.6.2`.
+
+  **Migration (only if you run `voicemode serve` behind a reverse proxy):** if you rely on forwarded client IPs — e.g. Tailscale Funnel or another reverse proxy in front of `voicemode serve` — you must now declare the proxy's address so its `X-Forwarded-For` is trusted, via `--trust-proxy <CIDR>` (repeatable) or `VOICEMODE_SERVE_TRUSTED_PROXIES=<comma-separated CIDRs>`. When trusted, the forwarded chain is parsed right-to-left (skipping trusted hops) instead of blindly taking the leftmost, spoofable entry. Direct (non-proxied) deployments need no changes.
+
 ### Added
 
 - **`install.sh` now detects system capability and offers mlx-audio on Apple Silicon (VM-1330)** — The `curl | bash` installer (`https://getvoicemode.com/install.sh`) assesses the host (Apple Silicon → excellent, other → good/limited) and, on Apple Silicon, offers to install and configure **mlx-audio** as the local voice engine — *even when whisper.cpp + Kokoro are already present*. The flow is **status-first**: it reports what's already installed and skips the prompt entirely when voice services are already satisfied. mlx-audio stays **opt-in** (whisper.cpp + Kokoro remain the cross-platform fallback; Intel Macs / Linux / Windows are unaffected). Reworded prompts and a de-emojified banner round out the pass. The large orange VoiceMode ASCII banner is restored (24-bit truecolor) after a regression to a compact 3-line version (VM-1324). Part of the installer overhaul for the mlx-audio release (epic VM-1322).

--- a/tests/test_serve_middleware.py
+++ b/tests/test_serve_middleware.py
@@ -9,6 +9,7 @@ Tests for:
 
 import pytest
 from starlette.applications import Starlette
+from starlette.requests import Request
 from starlette.responses import PlainTextResponse
 from starlette.routing import Route
 from starlette.testclient import TestClient
@@ -35,9 +36,34 @@ def homepage(request):
 
 
 def echo_ip(request):
-    """Handler that echoes the client IP."""
+    """Handler that echoes the client IP (no trusted proxies)."""
     client_ip = get_client_ip(request)
     return PlainTextResponse(f"IP: {client_ip}")
+
+
+def make_request(client_host, headers=None):
+    """Build a minimal Starlette Request for get_client_ip unit tests.
+
+    Args:
+        client_host: The direct TCP peer host, or None for no client.
+        headers: Optional dict of header name -> value.
+
+    Returns:
+        A starlette.requests.Request with the given peer and headers.
+    """
+    headers = headers or {}
+    raw_headers = [
+        (k.lower().encode("latin-1"), v.encode("latin-1"))
+        for k, v in headers.items()
+    ]
+    scope = {
+        "type": "http",
+        "method": "GET",
+        "path": "/",
+        "headers": raw_headers,
+        "client": (client_host, 12345) if client_host else None,
+    }
+    return Request(scope)
 
 
 def create_app_with_middleware(middleware_class, routes=None, **kwargs):
@@ -173,50 +199,75 @@ class TestIpInCidrs:
 
 
 class TestGetClientIp:
-    """Tests for the get_client_ip helper function."""
+    """Tests for the get_client_ip helper function.
 
-    def test_x_forwarded_for_single_ip(self):
-        """Test X-Forwarded-For header with single IP."""
-        app = Starlette(routes=[Route("/", echo_ip)])
-        client = TestClient(app)
+    Security model (GHSA-2qvv-vjq9-g5r4): X-Forwarded-For is only honored
+    when the direct TCP peer is within trusted_proxies. Otherwise the direct
+    peer is returned and the header is ignored.
+    """
 
-        response = client.get("/", headers={"X-Forwarded-For": "203.0.113.50"})
-        assert response.text == "IP: 203.0.113.50"
+    # --- Without trusted proxies: header must be ignored -----------------
 
-    def test_x_forwarded_for_multiple_ips(self):
-        """Test X-Forwarded-For header with multiple IPs (chain)."""
-        app = Starlette(routes=[Route("/", echo_ip)])
-        client = TestClient(app)
+    def test_xff_ignored_when_no_trusted_proxies(self):
+        """X-Forwarded-For is ignored entirely without trusted_proxies."""
+        request = make_request("8.8.8.8", {"X-Forwarded-For": "127.0.0.1"})
+        assert get_client_ip(request) == "8.8.8.8"
+        assert get_client_ip(request, trusted_proxies=[]) == "8.8.8.8"
 
-        # First IP should be used (the original client)
-        response = client.get(
-            "/",
-            headers={"X-Forwarded-For": "203.0.113.50, 70.41.3.18, 150.172.238.178"}
+    def test_direct_peer_used_when_no_header(self):
+        """Direct peer is returned when no X-Forwarded-For is present."""
+        request = make_request("203.0.113.50")
+        assert get_client_ip(request) == "203.0.113.50"
+
+    def test_no_client_falls_back_to_zero(self):
+        """Missing request.client yields the 0.0.0.0 fallback."""
+        request = make_request(None, {"X-Forwarded-For": "127.0.0.1"})
+        assert get_client_ip(request) == "0.0.0.0"
+
+    def test_spoofed_xff_does_not_override_peer(self):
+        """A spoofed allowed IP in XFF does not override an untrusted peer."""
+        request = make_request("8.8.8.8", {"X-Forwarded-For": "10.0.0.5"})
+        # Peer is untrusted, so the real peer wins regardless of the header.
+        assert get_client_ip(request, trusted_proxies=["127.0.0.1/32"]) == "8.8.8.8"
+
+    # --- With trusted proxies: header honored for trusted peers ----------
+
+    def test_xff_honored_from_trusted_proxy(self):
+        """XFF is honored when the direct peer is a trusted proxy."""
+        request = make_request("127.0.0.1", {"X-Forwarded-For": "203.0.113.50"})
+        assert get_client_ip(request, trusted_proxies=["127.0.0.1/32"]) == "203.0.113.50"
+
+    def test_xff_chain_walks_right_to_left(self):
+        """The first untrusted hop (from the right) is the real client."""
+        # client, then two trusted proxies appended on the way in.
+        request = make_request(
+            "127.0.0.1",
+            {"X-Forwarded-For": "203.0.113.50, 127.0.0.2, 127.0.0.3"},
         )
-        assert response.text == "IP: 203.0.113.50"
+        proxies = ["127.0.0.0/8"]
+        # Peer 127.0.0.1 trusted; walk right skipping 127.* hops -> 203.0.113.50
+        assert get_client_ip(request, trusted_proxies=proxies) == "203.0.113.50"
 
-    def test_x_forwarded_for_with_spaces(self):
-        """Test X-Forwarded-For header with extra spaces."""
-        app = Starlette(routes=[Route("/", echo_ip)])
-        client = TestClient(app)
-
-        response = client.get(
-            "/",
-            headers={"X-Forwarded-For": "  203.0.113.50  ,  70.41.3.18  "}
+    def test_xff_with_spaces_trusted(self):
+        """Whitespace in the chain is stripped when peer is trusted."""
+        request = make_request(
+            "127.0.0.1",
+            {"X-Forwarded-For": "  203.0.113.50  ,  127.0.0.2  "},
         )
-        assert response.text == "IP: 203.0.113.50"
+        assert get_client_ip(request, trusted_proxies=["127.0.0.0/8"]) == "203.0.113.50"
 
-    def test_fallback_to_request_client(self):
-        """Test fallback to request.client when no X-Forwarded-For."""
-        app = Starlette(routes=[Route("/", echo_ip)])
-        client = TestClient(app)
+    def test_all_trusted_chain_falls_back_to_peer(self):
+        """If every hop is trusted, fall back to the direct peer."""
+        request = make_request(
+            "127.0.0.1",
+            {"X-Forwarded-For": "127.0.0.2, 127.0.0.3"},
+        )
+        assert get_client_ip(request, trusted_proxies=["127.0.0.0/8"]) == "127.0.0.1"
 
-        # TestClient uses testclient as the client, which results in a specific host
-        response = client.get("/")
-        # The exact IP depends on TestClient implementation, but it should not be empty
-        assert "IP:" in response.text
-        # Should NOT be 0.0.0.0 since TestClient provides a client
-        assert response.text != "IP: 0.0.0.0"
+    def test_trusted_peer_without_header_uses_peer(self):
+        """Trusted peer but no XFF header returns the peer itself."""
+        request = make_request("127.0.0.1")
+        assert get_client_ip(request, trusted_proxies=["127.0.0.1/32"]) == "127.0.0.1"
 
 
 # =============================================================================
@@ -224,133 +275,127 @@ class TestGetClientIp:
 # =============================================================================
 
 
+def allowlist_client(allowed_cidrs, peer, trusted_proxies=None):
+    """Build a TestClient whose direct TCP peer is `peer`."""
+    app = create_app_with_middleware(
+        IPAllowlistMiddleware,
+        allowed_cidrs=allowed_cidrs,
+        trusted_proxies=trusted_proxies or [],
+    )
+    return TestClient(app, client=(peer, 12345))
+
+
 class TestIPAllowlistMiddleware:
-    """Tests for IP allowlist middleware."""
+    """Tests for IP allowlist middleware (decides on the direct TCP peer)."""
 
     def test_allowed_ip_passes_through(self):
-        """Test that allowed IP addresses pass through."""
-        app = create_app_with_middleware(
-            IPAllowlistMiddleware,
-            allowed_cidrs=["203.0.113.0/24"]
-        )
-        client = TestClient(app)
-
-        response = client.get("/", headers={"X-Forwarded-For": "203.0.113.50"})
+        """Test that an allowed direct peer passes through."""
+        client = allowlist_client(["203.0.113.0/24"], peer="203.0.113.50")
+        response = client.get("/")
         assert response.status_code == 200
         assert response.text == "OK"
 
     def test_denied_ip_returns_403(self):
-        """Test that denied IP addresses get 403 response."""
-        app = create_app_with_middleware(
-            IPAllowlistMiddleware,
-            allowed_cidrs=["192.168.0.0/16"]
-        )
-        client = TestClient(app)
-
-        response = client.get("/", headers={"X-Forwarded-For": "8.8.8.8"})
+        """Test that a denied direct peer gets a 403 response."""
+        client = allowlist_client(["192.168.0.0/16"], peer="8.8.8.8")
+        response = client.get("/")
         assert response.status_code == 403
         assert "Forbidden" in response.text
         assert "8.8.8.8" in response.text
 
     def test_localhost_allowed(self):
-        """Test localhost IP in LOCAL_CIDRS."""
-        app = create_app_with_middleware(
-            IPAllowlistMiddleware,
-            allowed_cidrs=LOCAL_CIDRS
-        )
-        client = TestClient(app)
-
-        response = client.get("/", headers={"X-Forwarded-For": "127.0.0.1"})
-        assert response.status_code == 200
+        """Test localhost peer in LOCAL_CIDRS."""
+        client = allowlist_client(LOCAL_CIDRS, peer="127.0.0.1")
+        assert client.get("/").status_code == 200
 
     def test_cidr_range_allows_multiple_ips(self):
-        """Test that CIDR range allows all IPs in the range."""
-        app = create_app_with_middleware(
-            IPAllowlistMiddleware,
-            allowed_cidrs=["10.0.0.0/8"]
-        )
-        client = TestClient(app)
-
-        # All these should be allowed
+        """Test that CIDR range allows all peers in the range."""
         for ip in ["10.0.0.1", "10.255.255.255", "10.128.64.32"]:
-            response = client.get("/", headers={"X-Forwarded-For": ip})
-            assert response.status_code == 200, f"IP {ip} should be allowed"
+            client = allowlist_client(["10.0.0.0/8"], peer=ip)
+            assert client.get("/").status_code == 200, f"IP {ip} should be allowed"
 
     def test_ipv6_allowed(self):
-        """Test IPv6 address in allowlist."""
-        app = create_app_with_middleware(
-            IPAllowlistMiddleware,
-            allowed_cidrs=["::1/128", "2001:db8::/32"]
-        )
-        client = TestClient(app)
+        """Test IPv6 peer in allowlist."""
+        client = allowlist_client(["::1/128", "2001:db8::/32"], peer="::1")
+        assert client.get("/").status_code == 200
 
-        response = client.get("/", headers={"X-Forwarded-For": "::1"})
-        assert response.status_code == 200
-
-        response = client.get("/", headers={"X-Forwarded-For": "2001:db8::1"})
-        assert response.status_code == 200
+        client = allowlist_client(["::1/128", "2001:db8::/32"], peer="2001:db8::1")
+        assert client.get("/").status_code == 200
 
     def test_ipv6_denied(self):
-        """Test IPv6 address not in allowlist."""
-        app = create_app_with_middleware(
-            IPAllowlistMiddleware,
-            allowed_cidrs=["::1/128"]
-        )
-        client = TestClient(app)
-
-        response = client.get("/", headers={"X-Forwarded-For": "2001:db8::1"})
-        assert response.status_code == 403
+        """Test IPv6 peer not in allowlist."""
+        client = allowlist_client(["::1/128"], peer="2001:db8::1")
+        assert client.get("/").status_code == 403
 
     def test_empty_allowlist_denies_all(self):
-        """Test that empty allowlist denies all IPs."""
-        app = create_app_with_middleware(
-            IPAllowlistMiddleware,
-            allowed_cidrs=[]
-        )
-        client = TestClient(app)
-
+        """Test that empty allowlist denies all peers."""
         for ip in ["127.0.0.1", "192.168.1.1", "8.8.8.8"]:
-            response = client.get("/", headers={"X-Forwarded-For": ip})
-            assert response.status_code == 403, f"IP {ip} should be denied with empty allowlist"
+            client = allowlist_client([], peer=ip)
+            assert client.get("/").status_code == 403, f"IP {ip} should be denied"
 
     def test_anthropic_cidrs_allowed(self):
-        """Test that Anthropic CIDRs work correctly."""
-        app = create_app_with_middleware(
-            IPAllowlistMiddleware,
-            allowed_cidrs=ANTHROPIC_CIDRS
-        )
-        client = TestClient(app)
+        """Test that Anthropic CIDRs work correctly on the direct peer."""
+        client = allowlist_client(ANTHROPIC_CIDRS, peer="160.79.104.100")
+        assert client.get("/").status_code == 200
 
-        # IP in Anthropic's primary range
-        response = client.get("/", headers={"X-Forwarded-For": "160.79.104.100"})
-        assert response.status_code == 200
+        client = allowlist_client(ANTHROPIC_CIDRS, peer="35.193.26.195")
+        assert client.get("/").status_code == 200
 
-        # Legacy Anthropic IP
-        response = client.get("/", headers={"X-Forwarded-For": "35.193.26.195"})
-        assert response.status_code == 200
-
-        # Not an Anthropic IP
-        response = client.get("/", headers={"X-Forwarded-For": "8.8.8.8"})
-        assert response.status_code == 403
+        client = allowlist_client(ANTHROPIC_CIDRS, peer="8.8.8.8")
+        assert client.get("/").status_code == 403
 
     def test_combined_local_and_anthropic_cidrs(self):
         """Test combined LOCAL_CIDRS and ANTHROPIC_CIDRS."""
-        app = create_app_with_middleware(
-            IPAllowlistMiddleware,
-            allowed_cidrs=LOCAL_CIDRS + ANTHROPIC_CIDRS
+        cidrs = LOCAL_CIDRS + ANTHROPIC_CIDRS
+        assert allowlist_client(cidrs, peer="192.168.1.100").get("/").status_code == 200
+        assert allowlist_client(cidrs, peer="160.79.105.50").get("/").status_code == 200
+        assert allowlist_client(cidrs, peer="8.8.8.8").get("/").status_code == 403
+
+    # --- Regression tests for GHSA-2qvv-vjq9-g5r4 (XFF allowlist bypass) ---
+
+    def test_spoofed_xff_does_not_bypass_allowlist(self):
+        """A spoofed X-Forwarded-For from an untrusted peer must NOT bypass.
+
+        This is the core vulnerability: an attacker at 8.8.8.8 sends
+        X-Forwarded-For: 127.0.0.1 (an allowed IP) hoping to be let in.
+        With no trusted proxies, the header is ignored and the real peer
+        (8.8.8.8) is denied.
+        """
+        client = allowlist_client(LOCAL_CIDRS, peer="8.8.8.8")
+        response = client.get("/", headers={"X-Forwarded-For": "127.0.0.1"})
+        assert response.status_code == 403
+        assert "8.8.8.8" in response.text
+
+    def test_spoofed_xff_with_allowed_cidr_denied(self):
+        """Spoofing an IP inside an allowed CIDR from an untrusted peer fails."""
+        client = allowlist_client(["10.0.0.0/8"], peer="203.0.113.99")
+        response = client.get("/", headers={"X-Forwarded-For": "10.1.2.3"})
+        assert response.status_code == 403
+
+    def test_xff_honored_from_trusted_proxy(self):
+        """Behind a trusted proxy, an allowed forwarded client is permitted."""
+        client = allowlist_client(
+            ["203.0.113.0/24"], peer="127.0.0.1", trusted_proxies=["127.0.0.1/32"]
         )
-        client = TestClient(app)
-
-        # Local IP
-        response = client.get("/", headers={"X-Forwarded-For": "192.168.1.100"})
+        response = client.get("/", headers={"X-Forwarded-For": "203.0.113.50"})
         assert response.status_code == 200
 
-        # Anthropic IP
-        response = client.get("/", headers={"X-Forwarded-For": "160.79.105.50"})
-        assert response.status_code == 200
-
-        # External IP
+    def test_xff_from_trusted_proxy_disallowed_client_denied(self):
+        """Behind a trusted proxy, a disallowed forwarded client is denied."""
+        client = allowlist_client(
+            ["203.0.113.0/24"], peer="127.0.0.1", trusted_proxies=["127.0.0.1/32"]
+        )
         response = client.get("/", headers={"X-Forwarded-For": "8.8.8.8"})
+        assert response.status_code == 403
+        assert "8.8.8.8" in response.text
+
+    def test_untrusted_peer_cannot_forge_even_with_trusted_proxies_set(self):
+        """An untrusted peer's XFF is ignored even when trusted_proxies exist."""
+        # Trusted proxy is 127.0.0.1, but the attacker connects from 8.8.8.8.
+        client = allowlist_client(
+            ["203.0.113.0/24"], peer="8.8.8.8", trusted_proxies=["127.0.0.1/32"]
+        )
+        response = client.get("/", headers={"X-Forwarded-For": "203.0.113.50"})
         assert response.status_code == 403
 
 
@@ -612,16 +657,10 @@ class TestMiddlewareCombinations:
             (IPAllowlistMiddleware, {"allowed_cidrs": ["192.168.0.0/16"]}),
             (TokenAuthMiddleware, {"token": "my-token"}),
         ])
-        client = TestClient(app)
+        client = TestClient(app, client=("192.168.1.100", 12345))
 
         # Both valid - should work
-        response = client.get(
-            "/",
-            headers={
-                "X-Forwarded-For": "192.168.1.100",
-                "Authorization": "Bearer my-token"
-            }
-        )
+        response = client.get("/", headers={"Authorization": "Bearer my-token"})
         assert response.status_code == 200
 
     def test_ip_allowed_but_token_invalid(self):
@@ -630,15 +669,9 @@ class TestMiddlewareCombinations:
             (IPAllowlistMiddleware, {"allowed_cidrs": ["192.168.0.0/16"]}),
             (TokenAuthMiddleware, {"token": "correct-token"}),
         ])
-        client = TestClient(app)
+        client = TestClient(app, client=("192.168.1.100", 12345))
 
-        response = client.get(
-            "/",
-            headers={
-                "X-Forwarded-For": "192.168.1.100",
-                "Authorization": "Bearer wrong-token"
-            }
-        )
+        response = client.get("/", headers={"Authorization": "Bearer wrong-token"})
         assert response.status_code == 401
 
     def test_token_valid_but_ip_denied(self):
@@ -647,81 +680,46 @@ class TestMiddlewareCombinations:
             (IPAllowlistMiddleware, {"allowed_cidrs": ["192.168.0.0/16"]}),
             (TokenAuthMiddleware, {"token": "my-token"}),
         ])
-        client = TestClient(app)
+        client = TestClient(app, client=("8.8.8.8", 12345))  # Not in allowlist
 
-        response = client.get(
-            "/",
-            headers={
-                "X-Forwarded-For": "8.8.8.8",  # Not in allowlist
-                "Authorization": "Bearer my-token"
-            }
-        )
+        response = client.get("/", headers={"Authorization": "Bearer my-token"})
         assert response.status_code == 403
 
     def test_ip_allowlist_and_secret_path(self):
         """Test IP allowlist combined with secret path."""
-        app = create_app_with_multiple_middleware([
-            (IPAllowlistMiddleware, {"allowed_cidrs": ["10.0.0.0/8"]}),
-            (SecretPathMiddleware, {"secret": "my-secret", "base_path": "/sse"}),
-        ])
-        client = TestClient(app)
+        def make_client(peer):
+            app = create_app_with_multiple_middleware([
+                (IPAllowlistMiddleware, {"allowed_cidrs": ["10.0.0.0/8"]}),
+                (SecretPathMiddleware, {"secret": "my-secret", "base_path": "/sse"}),
+            ])
+            return TestClient(app, client=(peer, 12345))
 
         # Both valid
-        response = client.get(
-            "/sse/my-secret",
-            headers={"X-Forwarded-For": "10.1.2.3"}
-        )
-        assert response.status_code == 200
+        assert make_client("10.1.2.3").get("/sse/my-secret").status_code == 200
 
         # IP valid, wrong secret
-        response = client.get(
-            "/sse/wrong-secret",
-            headers={"X-Forwarded-For": "10.1.2.3"}
-        )
-        assert response.status_code == 404
+        assert make_client("10.1.2.3").get("/sse/wrong-secret").status_code == 404
 
         # Secret valid, IP denied
-        response = client.get(
-            "/sse/my-secret",
-            headers={"X-Forwarded-For": "8.8.8.8"}
-        )
-        assert response.status_code == 403
+        assert make_client("8.8.8.8").get("/sse/my-secret").status_code == 403
 
     def test_all_three_middlewares(self):
         """Test all three middlewares together."""
-        app = create_app_with_multiple_middleware([
-            (IPAllowlistMiddleware, {"allowed_cidrs": LOCAL_CIDRS}),
-            (SecretPathMiddleware, {"secret": "secret123", "base_path": "/sse"}),
-            (TokenAuthMiddleware, {"token": "token456"}),
-        ])
-        client = TestClient(app)
+        def make_client(peer):
+            app = create_app_with_multiple_middleware([
+                (IPAllowlistMiddleware, {"allowed_cidrs": LOCAL_CIDRS}),
+                (SecretPathMiddleware, {"secret": "secret123", "base_path": "/sse"}),
+                (TokenAuthMiddleware, {"token": "token456"}),
+            ])
+            return TestClient(app, client=(peer, 12345))
+
+        auth = {"Authorization": "Bearer token456"}
 
         # All valid
-        response = client.get(
-            "/sse/secret123",
-            headers={
-                "X-Forwarded-For": "127.0.0.1",
-                "Authorization": "Bearer token456"
-            }
-        )
-        assert response.status_code == 200
+        assert make_client("127.0.0.1").get("/sse/secret123", headers=auth).status_code == 200
 
         # Non-protected path still needs IP and token
-        response = client.get(
-            "/",
-            headers={
-                "X-Forwarded-For": "127.0.0.1",
-                "Authorization": "Bearer token456"
-            }
-        )
-        assert response.status_code == 200
+        assert make_client("127.0.0.1").get("/", headers=auth).status_code == 200
 
         # Protected path without secret
-        response = client.get(
-            "/sse",
-            headers={
-                "X-Forwarded-For": "127.0.0.1",
-                "Authorization": "Bearer token456"
-            }
-        )
-        assert response.status_code == 404
+        assert make_client("127.0.0.1").get("/sse", headers=auth).status_code == 404

--- a/voice_mode/cli.py
+++ b/voice_mode/cli.py
@@ -25,6 +25,7 @@ from voice_mode.config import (
     SERVE_ALLOW_ANTHROPIC,
     SERVE_ALLOW_TAILSCALE,
     SERVE_ALLOWED_IPS,
+    SERVE_TRUSTED_PROXIES,
     SERVE_SECRET,
     SERVE_TOKEN,
     SERVE_TRANSPORT,
@@ -2120,6 +2121,10 @@ def converse(message_args, message, wait, skip_stt, duration, min_duration, voic
               help='Allow connections from Tailscale IP range (100.64.0.0/10)')
 @click.option('--allow-ip', multiple=True,
               help='Allow connections from custom CIDR ranges (can be specified multiple times)')
+@click.option('--trust-proxy', multiple=True,
+              help='Trust X-Forwarded-For from these reverse-proxy CIDRs (can be repeated). '
+                   'Required for the IP allowlist to honor forwarded client IPs behind a proxy. '
+                   'Leave unset unless you control the proxy (GHSA-2qvv-vjq9-g5r4).')
 @click.option('--allow-local/--no-allow-local', default=None,
               help='Allow connections from local/private IP ranges (default: enabled)')
 @click.option('--secret', default=None,
@@ -2127,7 +2132,7 @@ def converse(message_args, message, wait, skip_stt, duration, min_duration, voic
 @click.option('--token', default=None,
               help='Require Bearer token authentication via Authorization header')
 def serve(host: str, port: int, transport: str, log_level: str, allow_anthropic: bool | None,
-          allow_tailscale: bool | None, allow_ip: tuple, allow_local: bool | None,
+          allow_tailscale: bool | None, allow_ip: tuple, trust_proxy: tuple, allow_local: bool | None,
           secret: str | None, token: str | None):
     """Start VoiceMode as an HTTP/SSE server for remote access.
 
@@ -2161,6 +2166,9 @@ def serve(host: str, port: int, transport: str, log_level: str, allow_anthropic:
 
         # Add custom IP allowlist
         voicemode serve --allow-ip 10.0.0.0/8 --allow-ip 192.168.1.100/32
+
+        # Behind a trusted reverse proxy (honor X-Forwarded-For from it)
+        voicemode serve --allow-ip 203.0.113.0/24 --trust-proxy 127.0.0.1/32
 
         # Use secret path for authentication
         voicemode serve --secret my-secret-uuid
@@ -2208,6 +2216,9 @@ def serve(host: str, port: int, transport: str, log_level: str, allow_anthropic:
     if not allow_ip and SERVE_ALLOWED_IPS:
         # Parse comma-separated CIDRs from config
         allow_ip = tuple(cidr.strip() for cidr in SERVE_ALLOWED_IPS.split(',') if cidr.strip())
+    if not trust_proxy and SERVE_TRUSTED_PROXIES:
+        # Parse comma-separated trusted-proxy CIDRs from config
+        trust_proxy = tuple(cidr.strip() for cidr in SERVE_TRUSTED_PROXIES.split(',') if cidr.strip())
     if secret is None and SERVE_SECRET:
         secret = SERVE_SECRET
     if token is None and SERVE_TOKEN:
@@ -2223,6 +2234,9 @@ def serve(host: str, port: int, transport: str, log_level: str, allow_anthropic:
         allowed_cidrs.extend(TAILSCALE_CIDRS)
     if allow_ip:
         allowed_cidrs.extend(allow_ip)
+
+    # Trusted reverse-proxy CIDRs whose X-Forwarded-For header is honored.
+    trusted_proxies: list[str] = list(trust_proxy) if trust_proxy else []
 
     # Determine if any security is enabled
     has_ip_allowlist = bool(allowed_cidrs) and (allow_anthropic or allow_tailscale or allow_ip or not allow_local)
@@ -2267,6 +2281,10 @@ def serve(host: str, port: int, transport: str, log_level: str, allow_anthropic:
             if allow_ip:
                 ip_parts.append(f"custom ({len(allow_ip)} CIDRs)")
             click.echo(f"  IP allowlist: {' + '.join(ip_parts)}")
+            if trusted_proxies:
+                click.echo(f"  Trusted proxies (X-Forwarded-For honored): {', '.join(trusted_proxies)}")
+            else:
+                click.echo("  Trusted proxies: none (X-Forwarded-For ignored for allowlist)")
         else:
             click.echo("  IP allowlist: disabled (--no-allow-local)")
 
@@ -2319,7 +2337,11 @@ def serve(host: str, port: int, transport: str, log_level: str, allow_anthropic:
 
     # Add IP allowlist middleware (checked first)
     if allowed_cidrs:
-        app.add_middleware(IPAllowlistMiddleware, allowed_cidrs=allowed_cidrs)
+        app.add_middleware(
+            IPAllowlistMiddleware,
+            allowed_cidrs=allowed_cidrs,
+            trusted_proxies=trusted_proxies,
+        )
 
     # Add access logging middleware (runs first, logs all requests)
     app.add_middleware(AccessLogMiddleware)

--- a/voice_mode/config.py
+++ b/voice_mode/config.py
@@ -379,6 +379,12 @@ TTS \\bAPI\\b A P I # API as individual letters
 # Security: Additional allowed CIDR ranges (comma-separated)
 # VOICEMODE_SERVE_ALLOWED_IPS=
 
+# Security: Trusted reverse-proxy CIDRs (comma-separated). Only requests whose
+# direct TCP peer is within these ranges have their X-Forwarded-For header
+# trusted for the IP allowlist. Leave empty unless VoiceMode sits behind a
+# proxy you control (e.g. Tailscale Funnel). See GHSA-2qvv-vjq9-g5r4.
+# VOICEMODE_SERVE_TRUSTED_PROXIES=
+
 # Authentication: URL secret path segment (e.g., /secret-path/mcp)
 # VOICEMODE_SERVE_SECRET=
 
@@ -1417,6 +1423,10 @@ SERVE_ALLOW_TAILSCALE = env_bool("VOICEMODE_SERVE_ALLOW_TAILSCALE", False)
 
 # Additional allowed CIDR ranges (comma-separated, default: empty)
 SERVE_ALLOWED_IPS = os.getenv("VOICEMODE_SERVE_ALLOWED_IPS", "")
+
+# Trusted reverse-proxy CIDRs whose X-Forwarded-For header is honored for the
+# IP allowlist (comma-separated, default: empty = header never trusted).
+SERVE_TRUSTED_PROXIES = os.getenv("VOICEMODE_SERVE_TRUSTED_PROXIES", "")
 
 # URL secret path segment for authentication (default: empty/disabled)
 SERVE_SECRET = os.getenv("VOICEMODE_SERVE_SECRET", "")

--- a/voice_mode/serve_middleware.py
+++ b/voice_mode/serve_middleware.py
@@ -3,8 +3,9 @@
 This module provides middleware to restrict access to the VoiceMode server:
 
 1. IPAllowlistMiddleware - Restrict access based on client IP addresses.
-   Supports CIDR notation for flexible IP range configuration and handles
-   X-Forwarded-For headers for proxied requests.
+   Supports CIDR notation for flexible IP range configuration. The allowlist
+   is checked against the direct TCP peer; X-Forwarded-For is only honored
+   when the peer is a configured trusted proxy (GHSA-2qvv-vjq9-g5r4).
 
 2. SecretPathMiddleware - Require a secret path segment for access.
    Provides simple authentication by requiring a pre-shared secret in the URL.
@@ -71,33 +72,52 @@ LOCAL_CIDRS: List[str] = [
 ]
 
 
-def get_client_ip(request: Request) -> str:
+def get_client_ip(
+    request: Request, trusted_proxies: Optional[List[str]] = None
+) -> str:
     """Extract the real client IP address from a request.
 
-    Handles X-Forwarded-For header for proxied requests (e.g., behind
-    Tailscale Funnel or other reverse proxies). Takes the first IP in
-    the chain, which is the original client IP.
+    Security (GHSA-2qvv-vjq9-g5r4): the ``X-Forwarded-For`` header is
+    attacker-controllable, so it is only honored when the *direct TCP peer*
+    is itself a configured trusted proxy. When ``trusted_proxies`` is empty
+    or the direct peer is not within it, the header is ignored entirely and
+    the direct peer address is returned. This prevents an unauthenticated
+    attacker from spoofing an allowed IP to bypass the IP allowlist.
+
+    When the direct peer *is* a trusted proxy, the forwarded chain is walked
+    from right to left, skipping any hops that are themselves trusted
+    proxies, and the first untrusted address is returned as the real client.
+    If the whole chain is trusted (or the header is absent/empty), the direct
+    peer is returned.
 
     Args:
         request: The Starlette request object.
+        trusted_proxies: CIDR ranges whose members are trusted to set
+            ``X-Forwarded-For``. Defaults to none (header never trusted).
 
     Returns:
         The client IP address as a string.
     """
-    # Check X-Forwarded-For header first (for proxied requests)
+    direct_peer = request.client.host if request.client else "0.0.0.0"
+
+    # Only trust forwarding headers when the immediate peer is a known proxy.
+    if not trusted_proxies or not ip_in_cidrs(direct_peer, trusted_proxies):
+        return direct_peer
+
     forwarded_for = request.headers.get("X-Forwarded-For")
-    if forwarded_for:
-        # X-Forwarded-For can contain multiple IPs: "client, proxy1, proxy2"
-        # The first IP is the original client
-        client_ip = forwarded_for.split(",")[0].strip()
-        return client_ip
+    if not forwarded_for:
+        return direct_peer
 
-    # Fall back to direct client IP
-    if request.client:
-        return request.client.host
+    # X-Forwarded-For is "client, proxy1, proxy2" (left = original client).
+    # The leftmost entries are attacker-controllable, so walk from the right
+    # and skip trusted-proxy hops; the first untrusted address is the client.
+    hops = [ip.strip() for ip in forwarded_for.split(",") if ip.strip()]
+    for ip in reversed(hops):
+        if not ip_in_cidrs(ip, trusted_proxies):
+            return ip
 
-    # Last resort fallback
-    return "0.0.0.0"
+    # Entire chain is trusted proxies (or empty) — fall back to direct peer.
+    return direct_peer
 
 
 def ip_in_cidrs(
@@ -204,14 +224,22 @@ class IPAllowlistMiddleware:
     Uses pure ASGI style instead of BaseHTTPMiddleware to support SSE
     streaming without response buffering issues.
 
+    The allowlist decision is made on the *direct TCP peer* by default.
+    ``X-Forwarded-For`` is only consulted when the peer is within
+    ``trusted_proxies`` (see :func:`get_client_ip`), so a spoofed header
+    cannot bypass the allowlist (GHSA-2qvv-vjq9-g5r4).
+
     Attributes:
         app: The wrapped ASGI application.
         allowed_cidrs: List of allowed CIDR notation strings.
+        trusted_proxies: CIDR ranges whose members are trusted to set
+            X-Forwarded-For (default: none).
 
     Example:
         app.add_middleware(
             IPAllowlistMiddleware,
-            allowed_cidrs=["127.0.0.0/8", "160.79.104.0/21"]
+            allowed_cidrs=["127.0.0.0/8", "160.79.104.0/21"],
+            trusted_proxies=["127.0.0.1/32"],  # e.g. local reverse proxy
         )
     """
 
@@ -219,15 +247,20 @@ class IPAllowlistMiddleware:
         self,
         app: ASGIApp,
         allowed_cidrs: List[str],
+        trusted_proxies: Optional[List[str]] = None,
     ) -> None:
         """Initialize the IP allowlist middleware.
 
         Args:
             app: The ASGI application to wrap.
             allowed_cidrs: List of allowed CIDR notation strings.
+            trusted_proxies: CIDR ranges whose members are trusted to set
+                X-Forwarded-For. When empty (default), the header is ignored
+                and the direct peer is used for the allowlist check.
         """
         self.app = app
         self.allowed_cidrs = allowed_cidrs
+        self.trusted_proxies = trusted_proxies or []
 
     async def __call__(
         self, scope: Scope, receive: Receive, send: Send
@@ -246,7 +279,7 @@ class IPAllowlistMiddleware:
 
         # Build a Request object to use get_client_ip helper
         request = Request(scope, receive, send)
-        client_ip = get_client_ip(request)
+        client_ip = get_client_ip(request, self.trusted_proxies)
 
         if not ip_in_cidrs(client_ip, self.allowed_cidrs):
             # Return 403 Forbidden


### PR DESCRIPTION
Fixes the High-severity advisory **[GHSA-2qvv-vjq9-g5r4](https://github.com/mbailey/voicemode/security/advisories/GHSA-2qvv-vjq9-g5r4)** (CVSS 8.6), reported by EQSTLab. Task: **VM-1466**.

## The vulnerability

`IPAllowlistMiddleware` trusted the client-supplied `X-Forwarded-For` header unconditionally. `get_client_ip()` took `forwarded_for.split(",")[0]` whenever the header was present, and the allowlist gate used that value. So any host that can reach `voicemode serve` could send:

```
curl -H 'X-Forwarded-For: 127.0.0.1' http://<host>:<port>/mcp
```

and bypass the IP allowlist entirely — full access to the HTTP MCP endpoints, including local microphone recording and transcription. Two compounding errors: trusting XFF without checking the peer, and taking the **leftmost** (most spoofable) IP.

## The fix

- **`get_client_ip(request, trusted_proxies=None)`** — decides on the **direct TCP peer** by default. `X-Forwarded-For` is only honored when the peer is within a configured `trusted_proxies` CIDR set, and then the chain is walked **right-to-left**, skipping trusted hops, returning the first untrusted address.
- **`IPAllowlistMiddleware`** gains a `trusted_proxies` param, used for its allowlist decision.
- **CLI/config wiring**: `--trust-proxy <CIDR>` (repeatable) and `VOICEMODE_SERVE_TRUSTED_PROXIES`. Secure default: empty ⇒ header ignored for the allowlist.
- `AccessLogMiddleware` still logs the raw `X-Forwarded-For` for debugging (logging untrusted data is fine; *deciding* on it is not).

## Migration (only behind a reverse proxy)

Direct deployments need no change. If you run `voicemode serve` behind a proxy you control (e.g. Tailscale Funnel) and rely on forwarded client IPs, declare the proxy: `--trust-proxy 127.0.0.1/32` or `VOICEMODE_SERVE_TRUSTED_PROXIES=127.0.0.1/32`.

## Tests

`tests/test_serve_middleware.py` rewritten to set the **direct peer** (`TestClient(client=...)`) rather than relying on XFF. New regression tests:

- spoofed `X-Forwarded-For` from an untrusted peer → **403** (the bypass is closed)
- spoofed allowed-CIDR in XFF from untrusted peer → 403
- trusted-proxy path: allowed forwarded client → 200, disallowed → 403
- untrusted peer can't forge even when `trusted_proxies` is set → 403
- `get_client_ip` unit tests for the right-to-left walk

`56 passed` in the middleware suite; the rest of the unaffected suite is green (pre-existing failures in `test_speed_parameter` / `test_unified_service` / `test_auto_focus_pane` are unrelated and don't import `serve_middleware`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)