### PR TITLE
feat: hold_conch — exclusive voice access across turns + pause_conversation tool

### DIFF
--- a/voice_mode/conch.py
+++ b/voice_mode/conch.py
@@ -53,6 +53,7 @@ class Conch:
     """
 
     LOCK_FILE = Path.home() / ".voicemode" / "conch"
+    HOLD_FILE = Path.home() / ".voicemode" / "conch_hold"
 
     def __init__(self, agent_name: Optional[str] = None):
         """Initialize Conch with optional agent name.
@@ -105,6 +106,10 @@ class Conch:
         """
         if self._acquired:
             return True  # Already holding it
+
+        # Check if another process has a hold on the conch
+        if self.is_held_by_other():
+            return False
 
         agent = agent_name or self.agent_name or "unknown"
         self.LOCK_FILE.parent.mkdir(parents=True, exist_ok=True)
@@ -327,3 +332,44 @@ class Conch:
         """Context manager exit - release the lock."""
         self.release()
         return False  # Don't suppress exceptions
+
+    @classmethod
+    def set_hold(cls, agent_name: str = "unknown") -> None:
+        """Set a hold on the conch for the current process.
+
+        While a hold is active, other processes' try_acquire will fail
+        even when the conch lock file is not held (between turns).
+        """
+        cls.HOLD_FILE.parent.mkdir(parents=True, exist_ok=True)
+        data = {"pid": os.getpid(), "agent": agent_name}
+        cls.HOLD_FILE.write_text(json.dumps(data))
+
+    @classmethod
+    def release_hold(cls) -> None:
+        """Release the hold, allowing other agents to acquire the conch."""
+        try:
+            if cls.HOLD_FILE.exists():
+                data = json.loads(cls.HOLD_FILE.read_text())
+                if data.get("pid") == os.getpid():
+                    cls.HOLD_FILE.unlink()
+        except (json.JSONDecodeError, OSError):
+            pass
+
+    @classmethod
+    def is_held_by_other(cls) -> bool:
+        """Check if another process has a hold on the conch.
+
+        Returns:
+            True if another live process holds the conch, False otherwise
+        """
+        if not cls.HOLD_FILE.exists():
+            return False
+        try:
+            data = json.loads(cls.HOLD_FILE.read_text())
+            pid = data.get("pid")
+            if pid is None or pid == os.getpid():
+                return False
+            os.kill(pid, 0)  # Check if process is alive
+            return True
+        except (json.JSONDecodeError, ProcessLookupError, PermissionError, OSError):
+            return False

--- a/voice_mode/tools/converse.py
+++ b/voice_mode/tools/converse.py
@@ -7,7 +7,7 @@ import time
 import traceback
 from typing import Optional, Literal, Tuple, Dict, Union
 from pathlib import Path
-from datetime import datetime
+from datetime import datetime, timedelta
 
 import numpy as np
 import sounddevice as sd
@@ -1239,6 +1239,7 @@ async def converse(
     chime_trailing_silence: Optional[float] = None,
     metrics_level: Optional[Literal["minimal", "summary", "verbose"]] = None,
     wait_for_conch: Union[bool, str] = False,
+    hold_conch: Union[bool, str] = False,
     skip_conch: Union[bool, str] = False,
     ref_text: Optional[str] = None,
 ) -> str:
@@ -1291,6 +1292,11 @@ KEY PARAMETERS:
 • wait_for_conch (bool, default: false): Multi-agent coordination
   - false: If another agent is speaking, return status immediately
   - true: Wait until the other agent finishes, then speak
+• hold_conch (bool, default: false): Retain exclusive access across turns
+  - false: Release the conch fully after each turn
+  - true: Set a hold between turns so other agents queue rather than speak
+    while you are processing. Release the hold by calling converse again
+    with hold_conch=false, or let it expire when your process exits.
 • skip_conch (bool, default: false): Bypass conch entirely
   - false: Honour the conch lock (default multi-agent coordination)
   - true: Don't try to acquire or release the conch -- speak immediately
@@ -1339,6 +1345,8 @@ consult the MCP resources listed above.
         skip_tts = skip_tts.lower() in ('true', '1', 'yes', 'on')
     if isinstance(wait_for_conch, str):
         wait_for_conch = wait_for_conch.lower() in ('true', '1', 'yes', 'on')
+    if isinstance(hold_conch, str):
+        hold_conch = hold_conch.lower() in ('true', '1', 'yes', 'on')
     if isinstance(skip_conch, str):
         skip_conch = skip_conch.lower() in ('true', '1', 'yes', 'on')
 
@@ -2182,10 +2190,15 @@ consult the MCP resources listed above.
         # Release the conch to signal voice conversation has ended
         if CONCH_ENABLED and conch._acquired:
             held_seconds = conch.release()
+            if hold_conch:
+                Conch.set_hold(conch.agent_name or "converse")
+            else:
+                Conch.release_hold()
             if event_logger:
                 event_logger.log_event("CONCH_RELEASE", {
                     "pid": os.getpid(),
-                    "held_seconds": held_seconds
+                    "held_seconds": held_seconds,
+                    "hold_active": hold_conch
                 })
         else:
             # Don't call release() when not acquired — it would delete the lock
@@ -2218,4 +2231,40 @@ consult the MCP resources listed above.
 
 
 
+@mcp.tool()
+async def pause_conversation(
+    seconds: float,
+    message: Optional[str] = None,
+) -> str:
+    """Pause the conversation for a specified duration, maintaining the conch hold.
 
+    While paused, other agents queued with wait_for_conch will continue to wait.
+    This is useful for pausing a conversation while doing background work, then
+    resuming without losing your turn.
+
+    Args:
+        seconds: Duration to pause in seconds.
+        message: Optional note visible in the tool call display while pausing.
+                 Calculate the resume time before calling and pass it here so
+                 it is visible during the pause, e.g. "Resuming at 22:09:45"
+                 or "Resuming at 22:09:45 — waiting for background task".
+
+    Returns:
+        A message indicating the pause has completed.
+    """
+    end_time = datetime.now() + timedelta(seconds=seconds)
+    end_str = end_time.strftime("%H:%M:%S")
+    logger.info(f"Pause started: {seconds:.0f}s, resuming at {end_str}")
+    Conch.set_hold("pause_conversation")
+    try:
+        interval = min(10.0, seconds)
+        elapsed = 0.0
+        while elapsed < seconds:
+            chunk = min(interval, seconds - elapsed)
+            await asyncio.sleep(chunk)
+            elapsed += chunk
+            if elapsed < seconds:
+                logger.info(f"Pause: {elapsed:.0f}s / {seconds:.0f}s elapsed, resuming at {end_str}")
+    finally:
+        Conch.release_hold()
+    return f"Pause complete. Resumed at {end_str} (after {seconds:.0f}s)."


### PR DESCRIPTION
## Summary

Adds two related features for multi-agent voice coordination:

### 1. `hold_conch` parameter on `converse`

A new `hold_conch: bool` parameter that, when `True`, sets a hold between turns so other agents queue rather than speak while the holding agent is processing.

**How it works:**
- After each `converse` call with `hold_conch=True`, a `conch_hold` file is written to `~/.voicemode/conch_hold` with the holding process's PID
- Other agents calling `try_acquire()` check `is_held_by_other()` and return `False` immediately if a hold is active
- The hold is released on the next `converse` call with `hold_conch=False` (the default), or automatically when the holding process exits (dead PID check)

**New `Conch` class methods:**
- `Conch.set_hold(agent_name)` — write the hold file
- `Conch.release_hold()` — remove it (PID-checked, won't clobber another agent's hold)
- `Conch.is_held_by_other()` — returns `True` if another live process holds

### 2. `pause_conversation(seconds, message=None)` MCP tool

A new tool that sleeps for a specified duration while holding the conch, blocking other agents for the full duration.

- Calculates resume time at call time and logs it immediately (e.g. `Pause started: 30s, resuming at 22:09:45`)
- `message` parameter should be set to the calculated resume time (e.g. `"Resuming at 22:09:45"`) — it appears in the tool call display in the client UI while the pause is running, giving the user visibility without any streaming
- Returns `"Pause complete. Resumed at HH:MM:SS (after Xs)."` when done
- Max safe duration ~5 min due to MCP client timeouts

## Testing

Tested with two concurrent agents (Agent A holding, Agent B queuing) in a live multi-agent session:

1. Agent A calls `converse(..., hold_conch=True)` — speaks and sets the hold
2. Agent B calls `converse(..., wait_for_conch=True)` — correctly queues and does not speak
3. Agent A calls `pause_conversation(seconds=30, message="Resuming at HH:MM:SS")` — hold is maintained for the full 30s; Agent B continues waiting throughout
4. Agent A calls `converse(..., hold_conch=False)` — releases hold; Agent B acquires and speaks

## Known limitations / discussion points for maintainer

### ⚠️ `skip_conch=True` overrides `hold_conch` — observed in testing

**Observed behaviour:** When Agent B timed out waiting (`CONCH_TIMEOUT` default 60s) while Agent A held the conch, Agent B fell back to calling `converse(skip_conch=True)` and successfully spoke over Agent A's held conversation. The hold was completely bypassed.

`skip_conch=True` skips the hold file check entirely — it does not call `try_acquire()` or `is_held_by_other()`. So a held conversation is not protected against agents using `skip_conch`.

The current `skip_conch` docstring describes this as intentional: *"speak immediately regardless of whether another agent holds it"*. But this makes `hold_conch` not truly exclusive. A possible alternative semantics: `skip_conch` jumps the queue but still respects an active hold. Left for the maintainer to decide — raising it here for visibility.

### ⚠️ `CONCH_TIMEOUT` (default 60s) interacts poorly with long holds

**Observed behaviour:** Agent B with `wait_for_conch=True` timed out after 60s while Agent A held across a `pause_conversation(seconds=180)`. After timeout, Agent B had no coordination option left other than `skip_conch`.

With `hold_conch` now enabling intentional holds longer than 60s, the default timeout may need revisiting — or agents should be instructed to use a longer timeout when they know a long hold is in progress.

### Stale hold file — no permanent lockout risk

If the holding process dies without calling `release_hold()`, the hold file is left on disk. However, `is_held_by_other()` always verifies liveness via `os.kill(pid, 0)` before returning `True`. A dead PID raises `ProcessLookupError`, which is caught, and `is_held_by_other()` returns `False` — so other agents can always proceed past a stale hold. **There is no risk of a permanent lockout.**

The orphaned file is harmless but does accumulate. Active cleanup (same pattern as `_check_and_clear_stale_lock`) could be added to `is_held_by_other()` or `release_hold()` if desired.