### PR TITLE
VMMT-120: debrand getvoicemode.com landing + canonical → voicemode.dev

### DIFF
--- a/docs/web/index.html
+++ b/docs/web/index.html
@@ -3,8 +3,9 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>VoiceMode MCP - Voice Mode for Claude Code</title>
-    <meta name="description" content="VoiceMode MCP enables natural voice conversations with Claude Code and other AI coding assistants. Simple setup, powerful features.">
+    <title>VoiceMode - Voice Mode for Claude Code</title>
+    <meta name="description" content="VoiceMode enables natural voice conversations with Claude Code and other AI coding assistants. Simple setup, powerful features.">
+    <link rel="canonical" href="https://voicemode.dev/">
     <style>
         :root {
             /* Enhanced color palette */
@@ -541,7 +542,7 @@
 <body>
     <div class="container">
         <header>
-            <h1>VoiceMode MCP</h1>
+            <h1>VoiceMode</h1>
             <p class="tagline">"Voice Mode for Claude Code (and other AI Coding Assistants)"</p>
             <a href="https://github.com/mbailey/voicemode" class="github-cta">
                 <svg width="20" height="20" viewBox="0 0 16 16" fill="currentColor">
@@ -558,7 +559,7 @@
         <section>
             <h2>Overview</h2>
             <p>
-                VoiceMode MCP brings natural voice conversations Claude Code and other AI coding assistants. 
+                VoiceMode brings natural voice conversations to Claude Code and other AI coding assistants.
                 Built on the Model Context Protocol (MCP), it provides a clean, reliable interface for adding voice capabilities 
                 to your AI workflows.
             </p>
@@ -569,7 +570,7 @@
             <div class="video-container">
                 <iframe 
                     src="https://www.youtube.com/embed/cYdwOD_-dQc" 
-                    title="VoiceMode MCP Demo" 
+                    title="VoiceMode Demo"
                     frameborder="0" 
                     allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" 
                     allowfullscreen>


### PR DESCRIPTION
**VMMT-120 Phase A / step A1** — interim SEO fix for getvoicemode.com's own page during the window before the Phase C domain-level 301.

### What
- Drop **"MCP"** from the brand string in `<title>`, `<meta description>`, `<h1>`, and the two prominent body brand strings (`docs/web/index.html`).
- Add `<link rel="canonical" href="https://voicemode.dev/">` so the property currently holding ranking authority points at the canonical.
- **Keep** "MCP" where it's a technically-accurate descriptor (install commands, "Built on the Model Context Protocol").

### Why
getvoicemode.com stays live + indexable for days/weeks until the Phase C 301 lands. Today its title/h1 say "VoiceMode MCP" — reinforcing the retired brand and the competitor exact-match domain `voicemode-mcp.com`. This stops it self-competing immediately. Cheap, reversible, ships via the existing Pages workflow.

> **Note:** the canonical becomes moot once the page is a 301 (Phase C) — expected; this is interim mitigation.

### Verify (after merge + Pages deploy)
\`\`\`bash
curl -s https://getvoicemode.com/ | grep -iE '<title|rel="canonical"|<h1'
# expect: title/h1 = "VoiceMode" (no MCP); canonical -> https://voicemode.dev/
\`\`\`

### Notes
- No package CHANGELOG entry: marketing-website SEO change, not a Python-package release note (deliberate — flag if you'd prefer one).
- Merge `--no-ff` at your discretion.

Runbook: `VMMT-120/RUNBOOK.md` (Phase A, A1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)