### PR TITLE
fix: quote argument-hint in converse skill/command for strict YAML parsers

### DIFF
--- a/.claude/commands/converse.md
+++ b/.claude/commands/converse.md
@@ -1,6 +1,6 @@
 ---
 description: Start an ongoing voice conversation
-argument-hint: [voice] [message]
+argument-hint: "[voice] [message]"
 ---
 
 # /voicemode:converse

--- a/.claude/skills/converse/SKILL.md
+++ b/.claude/skills/converse/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: converse
 description: Start an ongoing voice conversation
-argument-hint: [voice] [message]
+argument-hint: "[voice] [message]"
 ---
 
 # /voicemode:converse


### PR DESCRIPTION
## Problem

The `converse` skill (`.claude/skills/converse/SKILL.md`) and command (`.claude/commands/converse.md`) both set:

```yaml
argument-hint: [voice] [message]
```

Claude Code's lenient front-matter parser accepts this, but **strict YAML parsers (e.g. GitHub Copilot CLI) reject it**:

```
expected <block end>, but found '['
```

YAML reads the leading `[voice]` as a flow sequence, then fails on the trailing `[message]`. Reported by **David Fevre** loading VoiceMode skills in Copilot CLI — "2 of the skills said the front matter wasn't valid yaml."

## Fix

Quote the value so YAML treats it as a plain string — same display hint, parses cleanly everywhere:

```yaml
argument-hint: "[voice] [message]"
```

Verified with PyYAML `safe_load` that all skill/command front matter in the repo now parses. These two were the only failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)