### PR TITLE
Fix shell completion producing no suggestions in zsh and fish

### DIFF
--- a/voice_mode/cli.py
+++ b/voice_mode/cli.py
@@ -2413,64 +2413,21 @@ def completions(shell, install):
         voicemode completions fish --install    # Install to ~/.config/fish/completions/
     """
     from pathlib import Path
-    
-    # Generate completion scripts based on shell type
-    if shell == 'bash':
-        completion_script = '''# bash completion for voicemode
-_voicemode_completion() {
-    local IFS=$'\\n'
-    local response
-    
-    response=$(env _VOICEMODE_COMPLETE=bash_complete COMP_WORDS="${COMP_WORDS[*]}" COMP_CWORD=$COMP_CWORD voicemode 2>/dev/null)
-    
-    for completion in $response; do
-        IFS=',' read type value <<< "$completion"
-        
-        if [[ $type == 'plain' ]]; then
-            COMPREPLY+=("$value")
-        elif [[ $type == 'file' ]]; then
-            COMPREPLY+=("$value")
-        elif [[ $type == 'dir' ]]; then
-            COMPREPLY+=("$value")
-        fi
-    done
-    
-    return 0
-}
+    from click.shell_completion import get_completion_class
 
-complete -o default -F _voicemode_completion voicemode
-'''
-    
-    elif shell == 'zsh':
-        completion_script = '''#compdef voicemode
-# zsh completion for voicemode
+    # Generate the completion script using Click's own machinery rather than
+    # hand-rolled templates. The previous inline scripts parsed the completion
+    # backend's output as comma-separated "type,value" pairs, but Click emits
+    # one item per group of newline-separated lines (type / value / help). That
+    # mismatch meant tab completion silently produced nothing. Delegating to
+    # Click guarantees the script always matches the installed Click version's
+    # completion protocol.
+    comp_cls = get_completion_class(shell)
+    if comp_cls is None:
+        raise click.ClickException(f"Shell completion is not supported for {shell!r}")
+    comp = comp_cls(voice_mode_main_cli, {}, 'voicemode', '_VOICEMODE_COMPLETE')
+    completion_script = comp.source()
 
-_voicemode() {
-    local -a response
-    response=(${(f)"$(env _VOICEMODE_COMPLETE=zsh_complete COMP_WORDS="${words[*]}" COMP_CWORD=$((CURRENT-1)) voicemode 2>/dev/null)"})
-    
-    for completion in $response; do
-        IFS=',' read type value <<< "$completion"
-        compadd -U -- "$value"
-    done
-}
-
-compdef _voicemode voicemode
-'''
-    
-    elif shell == 'fish':
-        completion_script = '''# fish completion for voicemode
-function __fish_voicemode_complete
-    set -l response (env _VOICEMODE_COMPLETE=fish_complete COMP_WORDS=(commandline -cp) COMP_CWORD=(commandline -t) voicemode 2>/dev/null)
-    
-    for completion in $response
-        echo $completion
-    end
-end
-
-complete -c voicemode -f -a '(__fish_voicemode_complete)'
-'''
-    
     if install:
         # Define installation locations for each shell
         locations = {


### PR DESCRIPTION
## Problem

`voicemode completions zsh` (and `fish`) install a completion script, but pressing <kbd>Tab</kbd> after `voicemode ` produces **no suggestions**.

The shipped scripts are hand-rolled and parse the completion backend's output with the wrong format:

- **zsh** — splits each response line on a comma into `type,value`, but the backend (`_VOICEMODE_COMPLETE=zsh_complete`) emits one candidate per *group* of newline-separated lines (`type` / `value` / `help`). Every `compadd` receives an empty value, so nothing is offered.
- **fish** — echoes each raw line instead of parsing the tab-separated `value\thelp` pairs fish expects.

The **bash** template happened to be correct, since Click's bash protocol genuinely is comma-separated `type,value`.

### Reproduce

```console
$ voicemode completions zsh > ~/.zfunc/_voicemode   # or source it
$ voicemode <TAB>          # nothing happens
```

You can see the mismatch directly — the backend emits triples, not comma-separated pairs:

```console
$ env _VOICEMODE_COMPLETE=zsh_complete COMP_WORDS="voicemode " COMP_CWORD=1 voicemode
plain
status
Show unified VoiceMode status.
plain
config
Manage voicemode configuration.
...
```

## Fix

Instead of re-fixing the templates by hand (and risking drift from Click again), generate the script with Click's own machinery:

```python
comp_cls = get_completion_class(shell)
comp = comp_cls(voice_mode_main_cli, {}, 'voicemode', '_VOICEMODE_COMPLETE')
completion_script = comp.source()
```

This guarantees the emitted script always matches the installed Click version's completion protocol, and removes ~40 lines of shell embedded in Python (net **−43 lines**).

## Verification

```console
$ voicemode completions zsh | head -1
#compdef voicemode
$ voicemode completions fish | head -1
function _voicemode_completion;
$ voicemode completions bash | head -1
_voicemode_completion() {
```

After installing the new zsh script, `voicemode <TAB>` lists all subcommands with descriptions (`status`, `config`, `converse`, …).

Notes:
- The "Bash versions older than 4.4" notice Click prints is written to **stderr**, so it does not corrupt a script captured via stdout redirection.
- The existing `--install` paths and post-install instructions are unchanged.