### PR TITLE
VM-1724: bind macOS media keys to VoiceMode control channel (Hammerspoon)

### DIFF
--- a/docs/reference/control-channel.md
+++ b/docs/reference/control-channel.md
@@ -265,6 +265,13 @@ never delayed by the control command.
 > the media app when VoiceMode should own it, re-check that Accessibility is
 > granted and the menubar shows `VM⌨︎`.
 
+> **Keyboard key names vary.** Some keyboards — notably the **Logitech MX Keys
+> Mini** — report the next/previous-track keys as `FAST`/`REWIND` rather than
+> `NEXT`/`PREVIOUS`. The config normalises both, so next-track barges and
+> previous-track replays regardless of which name your keyboard emits (verified
+> live on an MX Keys Mini, VM-1724). If a media key seems to do nothing, open the
+> Hammerspoon Console and check the `systemKey` name it reports.
+
 **Verify:**
 
 - The Hammerspoon Console logs `[voicemode-media-keys] started (...)` on load and

--- a/docs/reference/control-channel.md
+++ b/docs/reference/control-channel.md
@@ -194,9 +194,98 @@ If your Stream Deck plugin needs an absolute path, find it with `which voicemode
 
 ### Media keys
 
-Map a media key (or a Bluetooth headset's play/pause) to the CLI with whatever
-key-binding tool you use. For example with [`skhd`](https://github.com/koekeishiya/skhd)
-on macOS:
+The keyboard's transport keys (▶❙❙ / ⏭ / ⏮ — and a Bluetooth headset's
+play/pause) make a natural control surface. There are two ways to wire them,
+depending on how much you want VoiceMode to share the keys with your music.
+
+#### Hammerspoon — ownership-aware (recommended on macOS)
+
+macOS routes the media keys (NSSystemDefined events) straight to Music/Spotify,
+so to use them for VoiceMode you need an interceptor that wins *first* — but you
+almost certainly don't want VoiceMode stealing play/pause during normal
+listening. [Hammerspoon](https://www.hammerspoon.org/) handles both: its
+`hs.eventtap` can pass an event through to the media app *or* swallow it,
+**per-event**, based on whether a converse is live.
+
+The reusable config ships in the repo:
+[`scripts/hammerspoon/voicemode-media-keys.lua`](https://github.com/mbailey/voicemode/blob/master/scripts/hammerspoon/voicemode-media-keys.lua).
+
+**Ownership model — "polite spot-instance".** VoiceMode only grabs the media keys
+while a converse is *live*; otherwise every key passes straight through to your
+media app, unchanged:
+
+| Key | No converse live | Converse live (VoiceMode owns) |
+|-----|------------------|--------------------------------|
+| **Play/Pause** | toggles music (pass-through) | "pause everything" — pauses/resumes **both** VoiceMode *and* music |
+| **Next** | next track | **barge** — cuts the utterance (`control stop`); music does **not** skip |
+| **Previous** | previous track | replay last utterance — **stub** today (no-op + notice), pending VM-1685 |
+
+Play/Pause is always "do-both / pass-through" (one press quiets the room),
+because the two actions don't conflict. Next/Previous *do* conflict (barge vs
+skip-track), so they route to whichever side owns the keys for that event.
+
+**Manual override.** A menubar item (`VM⌨︎:auto`) and a hotkey
+(<kbd>⌘</kbd><kbd>⌥</kbd><kbd>⌃</kbd><kbd>M</kbd>) cycle ownership
+`auto → always-me → always-music`. `always-me` forces VoiceMode to own
+Next/Previous even when no converse is live; `always-music` forces pass-through
+even mid-utterance. (Play/Pause stays do-both in every mode.)
+
+**Setup:**
+
+1. **Enable the channel** (server side, once): `VOICEMODE_CONTROL_CHANNEL_ENABLED=true`
+   in `~/.voicemode/voicemode.env`. Without it the socket is never bound and the
+   config can never see a converse as "live".
+2. **Install Hammerspoon:** `brew install --cask hammerspoon`.
+3. **Load the config** from `~/.hammerspoon/init.lua` (point the path at your
+   checkout):
+
+    ```lua
+    -- ~/.hammerspoon/init.lua
+    -- Optional config (all keys have sane defaults):
+    -- _G.voicemodeMediaKeys = { voicemodePath = "/opt/homebrew/bin/voicemode" }
+    dofile(os.getenv("HOME") .. "/Code/voicemode/scripts/hammerspoon/voicemode-media-keys.lua")
+    ```
+
+    Then **Reload Config** from the Hammerspoon menubar (or run `hs.reload()`).
+4. **Grant Accessibility** — this is the load-bearing permission. System Settings
+   → **Privacy & Security → Accessibility** → enable **Hammerspoon**. The event
+   tap cannot see (or swallow) key events until you do; Hammerspoon prompts on
+   first run. Some setups also need **Input Monitoring**.
+
+The config resolves an absolute `voicemode` path at load (media-key handlers
+don't inherit your shell `PATH`) and shells out non-blocking, so a keypress is
+never delayed by the control command.
+
+> **Music/Spotify pre-emption gotcha.** Because Play/Pause is *passed through* to
+> the frontmost media app, that app toggles regardless of its own state. If music
+> is **paused** and you press Play to quiet a VoiceMode utterance, the music will
+> **start** (the key is a single toggle; pass-through can't know which direction
+> you meant). Next/Previous don't have this problem — when VoiceMode owns them the
+> event is fully *swallowed*, so the media app never skips. If a key still reaches
+> the media app when VoiceMode should own it, re-check that Accessibility is
+> granted and the menubar shows `VM⌨︎`.
+
+**Verify:**
+
+- The Hammerspoon Console logs `[voicemode-media-keys] started (...)` on load and
+  a line for each action (`barge`, `pause`, `resume`).
+- **No converse running:** media keys behave exactly as before — music only.
+- **Converse live** (start one, let VoiceMode speak): **Next** cuts it (barge),
+  **Play/Pause** pauses both, **Previous** shows the replay-not-yet stub.
+- Offline logic test (no Hammerspoon needed):
+  `luajit scripts/hammerspoon/test_voicemode_media_keys.lua`.
+
+> **Liveness signal.** "Is a converse live?" is answered by the presence of the
+> control socket `~/.voicemode/control.sock`, which the server binds for the whole
+> converse turn (speaking *and* listening). The config stats it on each key event
+> — cheap, no subprocess. A socket left stale by a server that crashed
+> mid-utterance is the only false-positive; it clears on the next converse.
+
+#### Simple, unconditional bindings (skhd / xbindkeys / Karabiner)
+
+If you want a key wired *straight* to one command (no ownership logic, no
+pass-through to music), bind it to the CLI with any key-binding tool. For example
+with [`skhd`](https://github.com/koekeishiya/skhd) on macOS:
 
 ```
 # ~/.skhdrc — F8 stops, F7 pauses, F9 resumes
@@ -206,7 +295,9 @@ on macOS:
 ```
 
 The same idea works with `xbindkeys` on Linux, Karabiner-Elements, or any tool
-that can bind a key to a shell command.
+that can bind a key to a shell command. Note these bind a *dedicated* key — they
+don't share the transport keys with your music the way the Hammerspoon recipe
+does.
 
 ### Spoken keyword
 

--- a/docs/reference/control-channel.md
+++ b/docs/reference/control-channel.md
@@ -216,19 +216,24 @@ media app, unchanged:
 
 | Key | No converse live | Converse live (VoiceMode owns) |
 |-----|------------------|--------------------------------|
-| **Play/Pause** | toggles music (pass-through) | "pause everything" — pauses/resumes **both** VoiceMode *and* music |
+| **Play/Pause** | toggles music (pass-through) | pauses/resumes **VoiceMode only** — key swallowed, media untouched *(default)*; set `pauseEverything = true` to also toggle music |
 | **Next** | next track | **barge** — cuts the utterance (`control stop`); music does **not** skip |
 | **Previous** | previous track | replay last utterance — **stub** today (no-op + notice), pending VM-1685 |
 
-Play/Pause is always "do-both / pass-through" (one press quiets the room),
-because the two actions don't conflict. Next/Previous *do* conflict (barge vs
-skip-track), so they route to whichever side owns the keys for that event.
+**Play/Pause scope (`pauseEverything`).** By default, while a converse is live
+Play/Pause controls **only VoiceMode** and the key is *swallowed*, so your media
+app is left alone (it won't start a paused track). Set `pauseEverything = true`
+to restore "pause everything" — the key also passes through so the media app
+toggles too (one press quiets both). Either way, when no converse is live
+Play/Pause passes straight through to your media app. Next/Previous *do* conflict
+(barge vs skip-track), so they route to whichever side owns the keys.
 
 **Manual override.** A menubar item (`VM⌨︎:auto`) and a hotkey
 (<kbd>⌘</kbd><kbd>⌥</kbd><kbd>⌃</kbd><kbd>M</kbd>) cycle ownership
 `auto → always-me → always-music`. `always-me` forces VoiceMode to own
 Next/Previous even when no converse is live; `always-music` forces pass-through
-even mid-utterance. (Play/Pause stays do-both in every mode.)
+even mid-utterance. (The override governs Next/Previous; Play/Pause scope is set
+by `pauseEverything`.)
 
 **Setup:**
 
@@ -242,7 +247,10 @@ even mid-utterance. (Play/Pause stays do-both in every mode.)
     ```lua
     -- ~/.hammerspoon/init.lua
     -- Optional config (all keys have sane defaults):
-    -- _G.voicemodeMediaKeys = { voicemodePath = "/opt/homebrew/bin/voicemode" }
+    -- _G.voicemodeMediaKeys = {
+    --   voicemodePath   = "/opt/homebrew/bin/voicemode",
+    --   pauseEverything = true,   -- Play/Pause also toggles your media app (default false)
+    -- }
     dofile(os.getenv("HOME") .. "/Code/voicemode/scripts/hammerspoon/voicemode-media-keys.lua")
     ```
 
@@ -256,14 +264,16 @@ The config resolves an absolute `voicemode` path at load (media-key handlers
 don't inherit your shell `PATH`) and shells out non-blocking, so a keypress is
 never delayed by the control command.
 
-> **Music/Spotify pre-emption gotcha.** Because Play/Pause is *passed through* to
-> the frontmost media app, that app toggles regardless of its own state. If music
-> is **paused** and you press Play to quiet a VoiceMode utterance, the music will
-> **start** (the key is a single toggle; pass-through can't know which direction
-> you meant). Next/Previous don't have this problem — when VoiceMode owns them the
-> event is fully *swallowed*, so the media app never skips. If a key still reaches
-> the media app when VoiceMode should own it, re-check that Accessibility is
-> granted and the menubar shows `VM⌨︎`.
+> **Music/Spotify pre-emption gotcha (`pauseEverything = true` only).** With
+> `pauseEverything` enabled, Play/Pause is *passed through* to the frontmost media
+> app, which toggles regardless of its own state — so if music is **paused** and
+> you press Play to quiet a VoiceMode utterance, the music will **start** (a single
+> toggle can't know which direction you meant). The **default**
+> (`pauseEverything = false`) avoids this: while a converse is live the key is
+> *swallowed* and only VoiceMode pauses. Next/Previous never have this problem —
+> when VoiceMode owns them the event is fully swallowed, so the media app never
+> skips. If a key still reaches the media app when VoiceMode should own it,
+> re-check that Accessibility is granted and the menubar shows `VM⌨︎`.
 
 > **Keyboard key names vary.** Some keyboards — notably the **Logitech MX Keys
 > Mini** — report the next/previous-track keys as `FAST`/`REWIND` rather than
@@ -278,7 +288,8 @@ never delayed by the control command.
   a line for each action (`barge`, `pause`, `resume`).
 - **No converse running:** media keys behave exactly as before — music only.
 - **Converse live** (start one, let VoiceMode speak): **Next** cuts it (barge),
-  **Play/Pause** pauses both, **Previous** shows the replay-not-yet stub.
+  **Play/Pause** pauses VoiceMode (and your media app too if `pauseEverything =
+  true`), **Previous** shows the replay-not-yet stub.
 - Offline logic test (no Hammerspoon needed):
   `luajit scripts/hammerspoon/test_voicemode_media_keys.lua`.
 

--- a/scripts/hammerspoon/test_voicemode_media_keys.lua
+++ b/scripts/hammerspoon/test_voicemode_media_keys.lua
@@ -232,6 +232,35 @@ M.cycleOwnership(); eq(M.ownership, "always-music", "cycle: always-me -> always-
 M.cycleOwnership(); eq(M.ownership, "auto", "cycle: always-music -> auto")
 
 -- ---------------------------------------------------------------------------
+-- 9. Hardware key aliases: FAST -> NEXT, REWIND -> PREVIOUS
+--    Logitech MX Keys Mini (and others) emit FAST/REWIND for the next/previous-
+--    track keys rather than NEXT/PREVIOUS -- verified live (VM-1724). They must
+--    route identically to NEXT/PREVIOUS.
+-- ---------------------------------------------------------------------------
+
+M.setOwnership("auto")
+
+-- Live: FAST barges exactly like NEXT (swallow + control stop).
+stubState.live = true
+resetCaptured()
+eq(M._onSystemDefined(event("FAST", PRESS)), true, "live: FAST swallowed (alias of NEXT)")
+eq(stubState.controlCommands[1], "stop", "live: FAST -> control stop (barge)")
+
+-- Live: REWIND is the replay stub exactly like PREVIOUS (swallow, no command).
+resetCaptured()
+eq(M._onSystemDefined(event("REWIND", PRESS)), true, "live: REWIND swallowed (alias of PREVIOUS)")
+eq(#stubState.controlCommands, 0, "live: REWIND is a stub -> no control command (VM-1685)")
+
+-- Dead: both aliases pass through to the media app, firing nothing.
+stubState.live = false
+resetCaptured()
+eq(M._onSystemDefined(event("FAST", PRESS)), false, "dead: FAST passes through")
+eq(M._onSystemDefined(event("REWIND", PRESS)), false, "dead: REWIND passes through")
+eq(#stubState.controlCommands, 0, "dead: FAST/REWIND fire no control command")
+
+M.setOwnership("auto")
+
+-- ---------------------------------------------------------------------------
 -- Report
 -- ---------------------------------------------------------------------------
 

--- a/scripts/hammerspoon/test_voicemode_media_keys.lua
+++ b/scripts/hammerspoon/test_voicemode_media_keys.lua
@@ -181,30 +181,33 @@ eq(M._onSystemDefined(event("PREVIOUS", PRESS)), true, "live: PREVIOUS swallowed
 eq(#stubState.controlCommands, 0, "live: PREVIOUS is a stub -> no control command (VM-1685)")
 
 -- ---------------------------------------------------------------------------
--- 7. Play/Pause = do-both: always pass through, toggles VoiceMode when live
+-- 7. Play/Pause DEFAULT (pauseEverything=false): control ONLY VoiceMode when a
+--    converse is live, swallowing the key (media app untouched); pass through
+--    when no converse is live.
 -- ---------------------------------------------------------------------------
 
 stubState.live = true
 resetCaptured()
--- First press while live -> pause; passes through.
-eq(M._onSystemDefined(event("PLAY", PRESS)), false, "live: PLAY passes through (1)")
+-- First press while live -> pause; SWALLOWED (VoiceMode-only default).
+eq(M._onSystemDefined(event("PLAY", PRESS)), true, "live default: PLAY swallowed (1)")
 eq(stubState.controlCommands[1], "pause", "live: 1st PLAY -> pause")
 -- Second press -> resume.
-eq(M._onSystemDefined(event("PLAY", PRESS)), false, "live: PLAY passes through (2)")
+eq(M._onSystemDefined(event("PLAY", PRESS)), true, "live default: PLAY swallowed (2)")
 eq(stubState.controlCommands[2], "resume", "live: 2nd PLAY -> resume")
 -- Third press -> pause again (toggles back).
-eq(M._onSystemDefined(event("PLAY", PRESS)), false, "live: PLAY passes through (3)")
+eq(M._onSystemDefined(event("PLAY", PRESS)), true, "live default: PLAY swallowed (3)")
 eq(stubState.controlCommands[3], "pause", "live: 3rd PLAY -> pause")
 
--- Going not-live resets the toggle mirror: next live press pauses (not resumes).
-eq(M._onSystemDefined(event("PLAY", PRESS)), false, "transition: PLAY passes through")  -- still live=true here
+-- Going not-live: PLAY passes through to the media app and resets the toggle
+-- mirror, so the next live press pauses (not resumes).
+eq(M._onSystemDefined(event("PLAY", PRESS)), true, "transition: PLAY swallowed (still live)")
 stubState.live = false
 resetCaptured()
 eq(M._onSystemDefined(event("PLAY", PRESS)), false, "dead: PLAY passes through")
 eq(#stubState.controlCommands, 0, "dead: PLAY fires no control command")
 stubState.live = true
 resetCaptured()
-eq(M._onSystemDefined(event("PLAY", PRESS)), false, "relive: PLAY passes through")
+eq(M._onSystemDefined(event("PLAY", PRESS)), true, "relive: PLAY swallowed")
 eq(stubState.controlCommands[1], "pause", "relive: first PLAY after dead -> pause (mirror reset)")
 
 -- ---------------------------------------------------------------------------
@@ -259,6 +262,30 @@ eq(M._onSystemDefined(event("REWIND", PRESS)), false, "dead: REWIND passes throu
 eq(#stubState.controlCommands, 0, "dead: FAST/REWIND fire no control command")
 
 M.setOwnership("auto")
+
+-- ---------------------------------------------------------------------------
+-- 10. pauseEverything=true restores do-both: when live, Play/Pause toggles
+--     VoiceMode AND passes through so the media app toggles too.
+--     (Re-load the module with the opt-in config.)
+-- ---------------------------------------------------------------------------
+
+_G.voicemodeMediaKeys.pauseEverything = true
+local M2 = dofile(thisDir .. "/voicemode-media-keys.lua")
+
+stubState.live = true
+resetCaptured()
+eq(M2._onSystemDefined(event("PLAY", PRESS)), false, "pauseEverything+live: PLAY passes through (do-both)")
+eq(stubState.controlCommands[1], "pause", "pauseEverything+live: PLAY still toggles VoiceMode")
+eq(M2._onSystemDefined(event("PLAY", PRESS)), false, "pauseEverything+live: PLAY passes through (2)")
+eq(stubState.controlCommands[2], "resume", "pauseEverything+live: 2nd PLAY -> resume")
+
+-- Dead behaves the same in both modes: pass through, no command.
+stubState.live = false
+resetCaptured()
+eq(M2._onSystemDefined(event("PLAY", PRESS)), false, "pauseEverything+dead: PLAY passes through")
+eq(#stubState.controlCommands, 0, "pauseEverything+dead: no control command")
+
+_G.voicemodeMediaKeys.pauseEverything = false
 
 -- ---------------------------------------------------------------------------
 -- Report

--- a/scripts/hammerspoon/test_voicemode_media_keys.lua
+++ b/scripts/hammerspoon/test_voicemode_media_keys.lua
@@ -1,0 +1,239 @@
+--- Offline self-test for voicemode-media-keys.lua.
+---
+--- Hammerspoon is not available in CI and the real event tap needs macOS
+--- Accessibility + physical key presses (a human-in-the-loop step — see
+--- docs/reference/control-channel.md). This test instead stubs the `hs` API and
+--- drives the *pure decision logic* — liveness, ownership resolution, and the
+--- swallow-vs-pass-through verdict for every key × owner combination, plus the
+--- side effects (which `voicemode control` commands fire).
+---
+--- Run with the same runtime Hammerspoon uses:
+---     luajit scripts/hammerspoon/test_voicemode_media_keys.lua
+--- (plain `lua` also works.)
+
+-- ---------------------------------------------------------------------------
+-- Test harness
+-- ---------------------------------------------------------------------------
+
+local passed, failed = 0, 0
+
+local function check(cond, msg)
+    if cond then
+        passed = passed + 1
+    else
+        failed = failed + 1
+        io.stderr:write("  FAIL: " .. msg .. "\n")
+    end
+end
+
+local function eq(got, want, msg)
+    check(got == want, string.format("%s (got %s, want %s)", msg, tostring(got), tostring(want)))
+end
+
+-- ---------------------------------------------------------------------------
+-- `hs` stub
+-- ---------------------------------------------------------------------------
+
+local HOME = os.getenv("HOME") or "/tmp"
+local SOCKET = HOME .. "/.voicemode/control.sock"
+
+-- Mutable test state.
+local stubState = {
+    live = false,            -- is the control socket "bound"?
+    controlCommands = {},    -- captured `voicemode control <cmd>` invocations
+}
+
+local function resetCaptured() stubState.controlCommands = {} end
+
+hs = {
+    fs = {
+        attributes = function(path)
+            if path == SOCKET then
+                return stubState.live and { mode = "socket" } or nil
+            end
+            -- Pretend the configured voicemode binary exists so it resolves.
+            if path == "/fake/bin/voicemode" then return { mode = "file" } end
+            return nil
+        end,
+    },
+    task = {
+        new = function(_path, _cb, args)
+            return {
+                start = function()
+                    -- args == { "control", "<command>" }
+                    table.insert(stubState.controlCommands, args[2])
+                end,
+            }
+        end,
+    },
+    eventtap = {
+        event = { types = { systemDefined = "systemDefined" } },
+        new = function(_types, _cb) return { start = function() end, stop = function() end } end,
+    },
+    hotkey = {
+        bind = function(_mods, _key, _fn) return { delete = function() end } end,
+    },
+    menubar = {
+        new = function()
+            return {
+                setTitle = function() end, setTooltip = function() end,
+                setMenu = function() end, delete = function() end,
+            }
+        end,
+    },
+    alert = { show = function() end },
+    execute = function() return "" end,
+    printf = function() end,
+}
+
+-- ---------------------------------------------------------------------------
+-- Load the module under test (config: deterministic path, no menubar/alerts)
+-- ---------------------------------------------------------------------------
+
+_G.voicemodeMediaKeys = {
+    voicemodePath = "/fake/bin/voicemode",
+    showMenubar = false,
+    alertOnAction = false,
+}
+
+-- Resolve path to the module relative to this test file.
+local thisDir = (arg[0] or ""):match("^(.*)[/\\]") or "."
+local M = dofile(thisDir .. "/voicemode-media-keys.lua")
+
+-- Build a fake NSSystemDefined event.
+local function event(key, down, isRepeat)
+    return {
+        systemKey = function()
+            return { key = key, down = down, ["repeat"] = isRepeat or false }
+        end,
+    }
+end
+
+local PRESS, RELEASE = true, false
+
+-- ---------------------------------------------------------------------------
+-- 1. Liveness signal tracks socket presence
+-- ---------------------------------------------------------------------------
+
+stubState.live = false
+eq(M.isConverseLive(), false, "no socket -> not live")
+stubState.live = true
+eq(M.isConverseLive(), true, "socket present -> live")
+
+-- ---------------------------------------------------------------------------
+-- 2. Ownership resolution: override wins, else follow liveness
+-- ---------------------------------------------------------------------------
+
+M.ownership = "auto"
+stubState.live = true;  eq(M._resolveOwner(), "voicemode", "auto + live -> voicemode")
+stubState.live = false; eq(M._resolveOwner(), "music", "auto + dead -> music")
+
+M.ownership = "always-me"
+stubState.live = false; eq(M._resolveOwner(), "voicemode", "always-me overrides dead")
+M.ownership = "always-music"
+stubState.live = true;  eq(M._resolveOwner(), "music", "always-music overrides live")
+M.ownership = "auto"
+
+-- ---------------------------------------------------------------------------
+-- 3. Non-media systemDefined keys always pass through (return false)
+-- ---------------------------------------------------------------------------
+
+stubState.live = true
+eq(M._onSystemDefined(event("SOUND_UP", PRESS)), false, "volume key passes through")
+eq(M._onSystemDefined(event("MUTE", PRESS)), false, "mute key passes through")
+
+-- ---------------------------------------------------------------------------
+-- 4. No converse live: every media key passes through (music owns)
+-- ---------------------------------------------------------------------------
+
+stubState.live = false
+resetCaptured()
+eq(M._onSystemDefined(event("NEXT", PRESS)), false, "dead: NEXT passes through")
+eq(M._onSystemDefined(event("PREVIOUS", PRESS)), false, "dead: PREVIOUS passes through")
+eq(M._onSystemDefined(event("PLAY", PRESS)), false, "dead: PLAY passes through")
+eq(#stubState.controlCommands, 0, "dead: no control commands fired")
+
+-- ---------------------------------------------------------------------------
+-- 5. Converse live + Next = barge (swallow + `voicemode control stop`)
+-- ---------------------------------------------------------------------------
+
+stubState.live = true
+resetCaptured()
+eq(M._onSystemDefined(event("NEXT", PRESS)), true, "live: NEXT swallowed")
+eq(#stubState.controlCommands, 1, "live: NEXT fires one command")
+eq(stubState.controlCommands[1], "stop", "live: NEXT -> control stop (barge)")
+-- The matching key-up is also swallowed but fires nothing.
+resetCaptured()
+eq(M._onSystemDefined(event("NEXT", RELEASE)), true, "live: NEXT release swallowed")
+eq(#stubState.controlCommands, 0, "live: NEXT release fires nothing")
+-- Auto-repeat is swallowed but does not re-fire.
+resetCaptured()
+eq(M._onSystemDefined(event("NEXT", PRESS, true)), true, "live: NEXT repeat swallowed")
+eq(#stubState.controlCommands, 0, "live: NEXT repeat fires nothing")
+
+-- ---------------------------------------------------------------------------
+-- 6. Converse live + Previous = replay STUB (swallow, no control command)
+-- ---------------------------------------------------------------------------
+
+stubState.live = true
+resetCaptured()
+eq(M._onSystemDefined(event("PREVIOUS", PRESS)), true, "live: PREVIOUS swallowed")
+eq(#stubState.controlCommands, 0, "live: PREVIOUS is a stub -> no control command (VM-1685)")
+
+-- ---------------------------------------------------------------------------
+-- 7. Play/Pause = do-both: always pass through, toggles VoiceMode when live
+-- ---------------------------------------------------------------------------
+
+stubState.live = true
+resetCaptured()
+-- First press while live -> pause; passes through.
+eq(M._onSystemDefined(event("PLAY", PRESS)), false, "live: PLAY passes through (1)")
+eq(stubState.controlCommands[1], "pause", "live: 1st PLAY -> pause")
+-- Second press -> resume.
+eq(M._onSystemDefined(event("PLAY", PRESS)), false, "live: PLAY passes through (2)")
+eq(stubState.controlCommands[2], "resume", "live: 2nd PLAY -> resume")
+-- Third press -> pause again (toggles back).
+eq(M._onSystemDefined(event("PLAY", PRESS)), false, "live: PLAY passes through (3)")
+eq(stubState.controlCommands[3], "pause", "live: 3rd PLAY -> pause")
+
+-- Going not-live resets the toggle mirror: next live press pauses (not resumes).
+eq(M._onSystemDefined(event("PLAY", PRESS)), false, "transition: PLAY passes through")  -- still live=true here
+stubState.live = false
+resetCaptured()
+eq(M._onSystemDefined(event("PLAY", PRESS)), false, "dead: PLAY passes through")
+eq(#stubState.controlCommands, 0, "dead: PLAY fires no control command")
+stubState.live = true
+resetCaptured()
+eq(M._onSystemDefined(event("PLAY", PRESS)), false, "relive: PLAY passes through")
+eq(stubState.controlCommands[1], "pause", "relive: first PLAY after dead -> pause (mirror reset)")
+
+-- ---------------------------------------------------------------------------
+-- 8. Manual override changes Next/Previous routing regardless of liveness
+-- ---------------------------------------------------------------------------
+
+-- always-music: even when live, Next passes through to music.
+M.setOwnership("always-music")
+stubState.live = true
+resetCaptured()
+eq(M._onSystemDefined(event("NEXT", PRESS)), false, "always-music: NEXT passes through despite live")
+eq(#stubState.controlCommands, 0, "always-music: NEXT fires no control command")
+
+-- always-me: even when dead, Next barges.
+M.setOwnership("always-me")
+stubState.live = false
+resetCaptured()
+eq(M._onSystemDefined(event("NEXT", PRESS)), true, "always-me: NEXT swallowed despite dead")
+eq(stubState.controlCommands[1], "stop", "always-me: NEXT -> control stop despite dead")
+
+-- cycleOwnership walks auto -> always-me -> always-music -> auto.
+M.setOwnership("auto")
+M.cycleOwnership(); eq(M.ownership, "always-me", "cycle: auto -> always-me")
+M.cycleOwnership(); eq(M.ownership, "always-music", "cycle: always-me -> always-music")
+M.cycleOwnership(); eq(M.ownership, "auto", "cycle: always-music -> auto")
+
+-- ---------------------------------------------------------------------------
+-- Report
+-- ---------------------------------------------------------------------------
+
+print(string.format("voicemode-media-keys self-test: %d passed, %d failed", passed, failed))
+if failed > 0 then os.exit(1) end

--- a/scripts/hammerspoon/voicemode-media-keys.lua
+++ b/scripts/hammerspoon/voicemode-media-keys.lua
@@ -45,12 +45,23 @@
 ---
 --- Optional config before loading (all have sane defaults):
 ---     _G.voicemodeMediaKeys = {
----       voicemodePath = "/custom/bin/voicemode",   -- else auto-resolved
----       socketPath    = "~/.voicemode/control.sock",
----       toggleHotkey  = { mods = {"cmd","alt","ctrl"}, key = "M" },
----       showMenubar   = true,
----       alertOnAction = true,                      -- brief hs.alert on barge/pause
+---       voicemodePath  = "/custom/bin/voicemode",   -- else auto-resolved
+---       socketPath     = "~/.voicemode/control.sock",
+---       toggleHotkey   = { mods = {"cmd","alt","ctrl"}, key = "M" },
+---       showMenubar    = true,
+---       alertOnAction  = true,                      -- brief hs.alert on barge/pause
+---       pauseEverything = false,                    -- Play/Pause scope when a converse
+---                                                   -- is live (see below)
 ---     }
+---
+--- `pauseEverything` controls what Play/Pause does WHILE A CONVERSE IS LIVE:
+---   • false (default) — pause/resume *only* VoiceMode; the key is swallowed so the
+---     media app is left untouched (it won't start a paused track). Clean "pause me".
+---   • true — the original "pause everything": also pass the key through so the media
+---     app toggles too. One press quiets both, but a *paused* media source will
+---     START (a stateless toggle can't know which way you meant).
+--- When NO converse is live, Play/Pause always passes straight through to the media
+--- app in both modes (VoiceMode never steals it during normal listening).
 
 local M = {}
 
@@ -110,6 +121,9 @@ local SOCKET_PATH = expanduser(
 
 local ALERT_ON_ACTION = userCfg.alertOnAction ~= false  -- default true
 local SHOW_MENUBAR = userCfg.showMenubar ~= false        -- default true
+-- Play/Pause scope while a converse is live: default false = pause VoiceMode only
+-- (swallow the key); true = do-both "pause everything" (also pass through to media).
+local PAUSE_EVERYTHING = userCfg.pauseEverything == true
 
 -- ---------------------------------------------------------------------------
 -- State
@@ -172,11 +186,11 @@ end
 -- Key behaviours
 -- ---------------------------------------------------------------------------
 
---- Play/Pause — "pause everything". Toggle VoiceMode if it is speaking, and always
---- let the event pass through so the media app toggles too. The handler never
---- swallows the key; the caller passes it through.
-local function handle_play()
-    if is_converse_live() then
+--- Play/Pause side effect: toggle VoiceMode pause/resume when a converse is live.
+--- `live` is computed once by the caller, which also owns the swallow-vs-pass-through
+--- decision (see on_system_defined / `pauseEverything`).
+local function handle_play(live)
+    if live then
         if vmPaused then
             voicemode_control("resume"); vmPaused = false
             alert("VoiceMode ▶ resume")
@@ -235,9 +249,14 @@ local function on_system_defined(event)
     local isPressEdge = t.down and not t["repeat"]
 
     if key == "PLAY" then
-        -- do-both: maybe toggle VoiceMode, ALWAYS pass through to the media app.
-        if isPressEdge then handle_play() end
-        return false
+        -- Toggle VoiceMode on the press edge. The swallow decision depends on mode:
+        --   * live + default (pauseEverything=false): control ONLY VoiceMode and
+        --     SWALLOW the key so the media app is untouched (no surprise un-pausing).
+        --   * live + pauseEverything=true: also pass through -> "pause everything".
+        --   * no converse live: always pass through (never steal it during listening).
+        local live = is_converse_live()
+        if isPressEdge then handle_play(live) end
+        return live and not PAUSE_EVERYTHING
     end
 
     -- NEXT / PREVIOUS route to a single owner.

--- a/scripts/hammerspoon/voicemode-media-keys.lua
+++ b/scripts/hammerspoon/voicemode-media-keys.lua
@@ -11,10 +11,12 @@
 ---   VoiceMode only grabs the media keys when a converse is *live*; otherwise every
 ---   key passes straight through to the active media app, unchanged.
 ---
----   • Play/Pause = "pause everything." One press quiets the room: it pauses
----     VoiceMode (if it is speaking) AND lets the event through so the media app
----     toggles too. Press again to resume. Coherent whether or not a converse is
----     live. (do-both / pass-through)
+---   • Play/Pause = pause/resume VoiceMode when a converse is live. By DEFAULT
+---     (pauseEverything=false) the key is SWALLOWED, so only VoiceMode pauses and
+---     the media app is left untouched (no surprise un-pausing). Set
+---     pauseEverything=true for the original "pause everything": also pass the key
+---     through so the media app toggles too. When no converse is live the key
+---     always passes straight through to the media app. (See pauseEverything below.)
 ---   • Next / Previous route to the *active owner* (they can't be both — barge vs
 ---     music-skip conflict):
 ---       – converse live (or override=always-me) → VoiceMode owns:

--- a/scripts/hammerspoon/voicemode-media-keys.lua
+++ b/scripts/hammerspoon/voicemode-media-keys.lua
@@ -218,6 +218,14 @@ local function on_system_defined(event)
     if not t or not t.key then return false end
 
     local key = t.key
+    -- Some keyboards (e.g. Logitech MX Keys Mini) report the next/previous-track
+    -- keys as FAST/REWIND rather than NEXT/PREVIOUS (verified live, VM-1724).
+    -- Normalise them so the routing below is hardware-independent.
+    if key == "FAST" then
+        key = "NEXT"
+    elseif key == "REWIND" then
+        key = "PREVIOUS"
+    end
     if key ~= "PLAY" and key ~= "NEXT" and key ~= "PREVIOUS" then
         return false  -- volume / brightness / etc. — never ours
     end

--- a/scripts/hammerspoon/voicemode-media-keys.lua
+++ b/scripts/hammerspoon/voicemode-media-keys.lua
@@ -1,0 +1,347 @@
+--- voicemode-media-keys.lua — bind the macOS media keys to VoiceMode's control channel.
+---
+--- VoiceMode (VM-1676) exposes a "control channel": a Unix-domain socket
+--- (`~/.voicemode/control.sock`) bound by the running server *for the duration of
+--- a converse turn*, driven by the `voicemode control pause|resume|stop` CLI. This
+--- Hammerspoon config turns the keyboard's media keys (Logitech MX Keys Mini and
+--- friends) into a control surface for that channel — WITHOUT permanently stealing
+--- the keys from Spotify/Music.
+---
+--- Ownership model — "polite spot-instance" (VM-1724, Mike's decision 2026-06-27):
+---   VoiceMode only grabs the media keys when a converse is *live*; otherwise every
+---   key passes straight through to the active media app, unchanged.
+---
+---   • Play/Pause = "pause everything." One press quiets the room: it pauses
+---     VoiceMode (if it is speaking) AND lets the event through so the media app
+---     toggles too. Press again to resume. Coherent whether or not a converse is
+---     live. (do-both / pass-through)
+---   • Next / Previous route to the *active owner* (they can't be both — barge vs
+---     music-skip conflict):
+---       – converse live (or override=always-me) → VoiceMode owns:
+---           Next = barge (`voicemode control stop`); Previous = replay (STUB,
+---           pending VM-1685) — the event is swallowed so music never sees it.
+---       – no converse (or override=always-music) → pass through to the media app
+---           (normal next / previous track).
+---   • Manual override toggle (auto / always-me / always-music) forces ownership
+---     either direction regardless of converse state. Cycle it with the hotkey
+---     below or the menubar item.
+---
+--- Liveness signal: the control socket is bound for the whole converse turn
+--- (speaking AND listening — see voice_mode/tools/converse.py
+--- `_control_listener_scope`), so the *presence* of `~/.voicemode/control.sock`
+--- is the precise "is a converse live?" answer, and it is exactly the precondition
+--- for a `voicemode control` command to land. We stat it synchronously on each key
+--- event (cheap — no CLI spawn). The only false-positive is a socket left stale by
+--- a server that crashed mid-utterance; it self-heals on the next converse, and the
+--- worst case is a single Next/Previous that is swallowed and no-ops.
+---
+--- Requires macOS Accessibility permission for Hammerspoon (System Settings →
+--- Privacy & Security → Accessibility). See docs/reference/control-channel.md.
+---
+--- Load from ~/.hammerspoon/init.lua:
+---     local vmkeys = dofile(os.getenv("HOME") .. "/path/to/voicemode-media-keys.lua")
+---   or, if this file is on the Lua path:
+---     require("voicemode-media-keys")
+---
+--- Optional config before loading (all have sane defaults):
+---     _G.voicemodeMediaKeys = {
+---       voicemodePath = "/custom/bin/voicemode",   -- else auto-resolved
+---       socketPath    = "~/.voicemode/control.sock",
+---       toggleHotkey  = { mods = {"cmd","alt","ctrl"}, key = "M" },
+---       showMenubar   = true,
+---       alertOnAction = true,                      -- brief hs.alert on barge/pause
+---     }
+
+local M = {}
+
+-- ---------------------------------------------------------------------------
+-- Configuration & path resolution (resolved once, at load time)
+-- ---------------------------------------------------------------------------
+
+local userCfg = (type(_G.voicemodeMediaKeys) == "table") and _G.voicemodeMediaKeys or {}
+
+local HOME = os.getenv("HOME") or ""
+
+--- Expand a leading "~" to $HOME (Lua has no tilde expansion).
+local function expanduser(p)
+    if type(p) ~= "string" then return p end
+    if p:sub(1, 1) == "~" then
+        return HOME .. p:sub(2)
+    end
+    return p
+end
+
+--- True if a filesystem path exists (any type).
+local function path_exists(p)
+    return p ~= nil and p ~= "" and hs.fs.attributes(p) ~= nil
+end
+
+--- Resolve an absolute `voicemode` executable. Media-key handlers do NOT inherit
+--- an interactive shell PATH, so we must hand `hs.task` an absolute path.
+--- Order: explicit override → common install locations → a login-shell `command -v`.
+local function resolve_voicemode_path()
+    if userCfg.voicemodePath and path_exists(expanduser(userCfg.voicemodePath)) then
+        return expanduser(userCfg.voicemodePath)
+    end
+    local candidates = {
+        HOME .. "/.local/bin/voicemode",
+        "/opt/homebrew/bin/voicemode",
+        "/usr/local/bin/voicemode",
+    }
+    for _, p in ipairs(candidates) do
+        if path_exists(p) then return p end
+    end
+    -- Last resort: ask the user's login shell (loads their profile/PATH).
+    local out = hs.execute("command -v voicemode", true)
+    if out then
+        out = out:gsub("%s+$", "")
+        if out ~= "" and path_exists(out) then return out end
+    end
+    return nil
+end
+
+local VOICEMODE_PATH = resolve_voicemode_path()
+
+local SOCKET_PATH = expanduser(
+    userCfg.socketPath
+    or os.getenv("VOICEMODE_CONTROL_SOCKET")
+    or "~/.voicemode/control.sock"
+)
+
+local ALERT_ON_ACTION = userCfg.alertOnAction ~= false  -- default true
+local SHOW_MENUBAR = userCfg.showMenubar ~= false        -- default true
+
+-- ---------------------------------------------------------------------------
+-- State
+-- ---------------------------------------------------------------------------
+
+-- Manual ownership override: "auto" | "always-me" | "always-music".
+M.ownership = "auto"
+
+-- Local mirror of whether *we* last told VoiceMode to pause (drives the Play/Pause
+-- toggle). Reset whenever no converse is live so each new turn starts un-paused;
+-- any drift only ever costs one no-op pause/resume server-side.
+local vmPaused = false
+
+-- ---------------------------------------------------------------------------
+-- Liveness
+-- ---------------------------------------------------------------------------
+
+--- Is a converse live right now? True iff the control socket is currently bound.
+--- Synchronous single stat — safe to call inside the eventtap callback.
+local function is_converse_live()
+    local attrs = hs.fs.attributes(SOCKET_PATH)
+    return attrs ~= nil and attrs.mode == "socket"
+end
+M.isConverseLive = is_converse_live
+
+--- Who owns Next/Previous for this event? Override wins; else follow liveness.
+local function resolve_owner()
+    if M.ownership == "always-me" then return "voicemode" end
+    if M.ownership == "always-music" then return "music" end
+    return is_converse_live() and "voicemode" or "music"
+end
+
+-- ---------------------------------------------------------------------------
+-- Shelling out to `voicemode control` (non-blocking)
+-- ---------------------------------------------------------------------------
+
+--- Fire a `voicemode control <command>` without blocking the event tap.
+--- A failure (e.g. nothing listening) is logged at debug and otherwise ignored —
+--- the control channel is a convenience, never load-bearing for the keypress.
+local function voicemode_control(command)
+    if not VOICEMODE_PATH then
+        hs.printf("[voicemode-media-keys] voicemode not found on PATH; skipping `control %s`", command)
+        return
+    end
+    local task = hs.task.new(VOICEMODE_PATH, function(exitCode, _stdout, stderr)
+        if exitCode ~= 0 then
+            -- Non-zero is normal when nothing is speaking (socket not bound).
+            hs.printf("[voicemode-media-keys] `voicemode control %s` exit=%s %s",
+                command, tostring(exitCode), (stderr or ""):gsub("%s+$", ""))
+        end
+    end, { "control", command })
+    task:start()
+end
+
+local function alert(msg)
+    if ALERT_ON_ACTION then hs.alert.show(msg, 0.8) end
+end
+
+-- ---------------------------------------------------------------------------
+-- Key behaviours
+-- ---------------------------------------------------------------------------
+
+--- Play/Pause — "pause everything". Toggle VoiceMode if it is speaking, and always
+--- let the event pass through so the media app toggles too. The handler never
+--- swallows the key; the caller passes it through.
+local function handle_play()
+    if is_converse_live() then
+        if vmPaused then
+            voicemode_control("resume"); vmPaused = false
+            alert("VoiceMode ▶ resume")
+        else
+            voicemode_control("pause"); vmPaused = true
+            alert("VoiceMode ⏸ pause")
+        end
+    else
+        -- Nothing speaking: keep the toggle mirror clean so the next live turn
+        -- starts from "not paused". Music still toggles via pass-through.
+        vmPaused = false
+    end
+end
+
+--- Next, with VoiceMode owning → barge (cut the current utterance).
+local function handle_next_voicemode()
+    voicemode_control("stop")
+    alert("VoiceMode ⏭ barge")
+end
+
+--- Previous, with VoiceMode owning → replay last utterance. STUB: there is no
+--- `replay` control command yet — it is owned by VM-1685. Swallow the key and
+--- tell the user, so it does not silently skip the music track. Swap the body for
+--- `voicemode_control("replay")` (or similar) when VM-1685 lands.
+local function handle_previous_voicemode()
+    -- TODO(VM-1685): replace with the real replay/skip-back control command.
+    hs.printf("[voicemode-media-keys] Previous: replay not yet available (VM-1685 stub)")
+    hs.alert.show("VoiceMode ⏮ replay not yet available (VM-1685)", 1.2)
+end
+
+-- ---------------------------------------------------------------------------
+-- The event tap
+-- ---------------------------------------------------------------------------
+
+--- Callback for every NSSystemDefined event. Returns `true` to swallow the event
+--- (so the media app never sees it) or `false` to pass it through.
+local function on_system_defined(event)
+    local t = event:systemKey()
+    if not t or not t.key then return false end
+
+    local key = t.key
+    if key ~= "PLAY" and key ~= "NEXT" and key ~= "PREVIOUS" then
+        return false  -- volume / brightness / etc. — never ours
+    end
+
+    -- Act only on the press (down) edge, ignoring auto-repeat, so a held key
+    -- fires the side effect once. `t.down == false` is the matching key-up.
+    local isPressEdge = t.down and not t["repeat"]
+
+    if key == "PLAY" then
+        -- do-both: maybe toggle VoiceMode, ALWAYS pass through to the media app.
+        if isPressEdge then handle_play() end
+        return false
+    end
+
+    -- NEXT / PREVIOUS route to a single owner.
+    if resolve_owner() == "music" then
+        return false  -- pass the whole key (down/up/repeat) to the media app
+    end
+
+    -- VoiceMode owns: swallow the key entirely so music never skips, and fire the
+    -- behaviour once on the press edge.
+    if isPressEdge then
+        if key == "NEXT" then
+            handle_next_voicemode()
+        else
+            handle_previous_voicemode()
+        end
+    end
+    return true
+end
+
+-- Exposed for the offline self-test (scripts/hammerspoon/test_voicemode_media_keys.lua),
+-- which stubs `hs` and drives the decision logic without Hammerspoon.
+M._resolveOwner = resolve_owner
+M._onSystemDefined = on_system_defined
+
+-- ---------------------------------------------------------------------------
+-- Override toggle: hotkey + menubar
+-- ---------------------------------------------------------------------------
+
+local OWNERSHIP_NEXT = {
+    ["auto"] = "always-me",
+    ["always-me"] = "always-music",
+    ["always-music"] = "auto",
+}
+
+local MENUBAR_TITLE = {
+    ["auto"] = "VM⌨︎:auto",
+    ["always-me"] = "VM⌨︎:me",
+    ["always-music"] = "VM⌨︎:music",
+}
+
+local function refresh_menubar()
+    if not M.menubar then return end
+    M.menubar:setTitle(MENUBAR_TITLE[M.ownership] or "VM⌨︎")
+    M.menubar:setTooltip("VoiceMode media-key ownership")
+    M.menubar:setMenu({
+        { title = "Media-key ownership", disabled = true },
+        { title = "auto — follow converse", checked = M.ownership == "auto",
+          fn = function() M.setOwnership("auto") end },
+        { title = "always VoiceMode (always-me)", checked = M.ownership == "always-me",
+          fn = function() M.setOwnership("always-me") end },
+        { title = "always Music (always-music)", checked = M.ownership == "always-music",
+          fn = function() M.setOwnership("always-music") end },
+        { title = "-" },
+        { title = "Converse live: " .. (is_converse_live() and "yes" or "no"), disabled = true },
+        { title = "voicemode: " .. (VOICEMODE_PATH or "NOT FOUND"), disabled = true },
+    })
+end
+
+--- Set the ownership mode and surface it (alert + menubar).
+function M.setOwnership(mode)
+    if not OWNERSHIP_NEXT[mode] then return end
+    M.ownership = mode
+    refresh_menubar()
+    hs.alert.show("VoiceMode keys → " .. mode, 1.0)
+end
+
+--- Cycle auto → always-me → always-music → auto.
+function M.cycleOwnership()
+    M.setOwnership(OWNERSHIP_NEXT[M.ownership])
+end
+
+-- ---------------------------------------------------------------------------
+-- Lifecycle
+-- ---------------------------------------------------------------------------
+
+--- Tear down a previous instance (idempotent — safe to call on reload).
+function M.stop()
+    if M.tap then M.tap:stop(); M.tap = nil end
+    if M.hotkey then M.hotkey:delete(); M.hotkey = nil end
+    if M.menubar then M.menubar:delete(); M.menubar = nil end
+end
+
+--- Start the event tap, the override hotkey, and the menubar.
+function M.start()
+    M.stop()  -- clean slate on reload
+
+    M.tap = hs.eventtap.new({ hs.eventtap.event.types.systemDefined }, on_system_defined)
+    M.tap:start()
+
+    local hk = userCfg.toggleHotkey or { mods = { "cmd", "alt", "ctrl" }, key = "M" }
+    M.hotkey = hs.hotkey.bind(hk.mods, hk.key, M.cycleOwnership)
+
+    if SHOW_MENUBAR then
+        M.menubar = hs.menubar.new()
+        refresh_menubar()
+    end
+
+    if not VOICEMODE_PATH then
+        hs.printf("[voicemode-media-keys] WARNING: `voicemode` not found — pass-through still works, "
+            .. "but VoiceMode commands will be skipped. Set voicemodePath in _G.voicemodeMediaKeys.")
+    end
+    hs.printf("[voicemode-media-keys] started (ownership=%s, socket=%s, voicemode=%s)",
+        M.ownership, SOCKET_PATH, VOICEMODE_PATH or "NOT FOUND")
+    return M
+end
+
+-- Re-loading this file should not leak a previous tap/hotkey/menubar.
+if _G.__voicemodeMediaKeys and _G.__voicemodeMediaKeys.stop then
+    _G.__voicemodeMediaKeys.stop()
+end
+_G.__voicemodeMediaKeys = M
+
+M.start()
+
+return M


### PR DESCRIPTION
## VM-1724 — bind macOS media keys to VoiceMode's control channel

Turns the keyboard's transport keys (▶❙❙ / ⏭ / ⏮ — and a Bluetooth headset's
play/pause) into a control surface for VoiceMode's control channel
(`~/.voicemode/control.sock`, VM-1676) via [Hammerspoon](https://www.hammerspoon.org/).
It calls the existing `voicemode control pause|resume|stop` CLI — clean
separation, no new server-side surface.

### Ownership model — "polite spot-instance"

VoiceMode only grabs the media keys **while a converse is live**; otherwise every
key passes straight through to your music app, unchanged.

| Key | No converse live | Converse live (VoiceMode owns) |
|-----|------------------|--------------------------------|
| **Play/Pause** | toggles music (pass-through) | pauses/resumes **VoiceMode only** — key swallowed, media untouched *(default)*; `pauseEverything = true` also toggles music |
| **Next** | next track | **barge** — cuts the utterance (`control stop`); music does not skip |
| **Previous** | previous track | replay last utterance — **stub today** (no-op + notice), pending VM-1685 |

Liveness = presence of the control socket (bound for the whole converse turn);
stat'd per key event, no subprocess. A manual menubar/hotkey override cycles
`auto → always-me → always-music`.

### What's included

- `scripts/hammerspoon/voicemode-media-keys.lua` — the reusable config (sane
  defaults, override toggle, MX Keys Mini `FAST`/`REWIND` name handling).
- `scripts/hammerspoon/test_voicemode_media_keys.lua` — offline logic test
  (`luajit test_voicemode_media_keys.lua`, no Hammerspoon needed).
- `docs/reference/control-channel.md` — user-facing setup, behaviour table,
  verify steps, and gotchas.

### Enabling (opt-in extra)

1. `VOICEMODE_CONTROL_CHANNEL_ENABLED=true` in `~/.voicemode/voicemode.env`.
2. `brew install --cask hammerspoon`.
3. `dofile` the lua from `~/.hammerspoon/init.lua`.
4. Grant Hammerspoon **Accessibility** (load-bearing).

### Known limitation

- **Previous = replay is a stub** (no-op + notice) pending **VM-1685**. Next
  (barge) and Play/Pause (pause/resume) are fully working and verified live on a
  Logitech MX Keys Mini.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
