### PR TITLE
fix: detect Sony WH/WF-series headphones as Bluetooth for chime amplitude

### DIFF
--- a/voice_mode/core.py
+++ b/voice_mode/core.py
@@ -835,8 +835,11 @@ def generate_chime(
         if default_output is not None:
             devices = sd.query_devices()
             device_name = devices[default_output]['name'].lower()
-            # Check for Bluetooth devices (AirPods, Bluetooth headphones, etc)
-            if 'airpod' in device_name or 'bluetooth' in device_name or 'bt' in device_name:
+            # Check for Bluetooth devices (AirPods, Bluetooth headphones, etc).
+            # macOS reports many Bluetooth headphones by model name only,
+            # e.g. Sony "WH-1000XM4" / "WF-1000XM5", so match those prefixes too.
+            if ('airpod' in device_name or 'bluetooth' in device_name or 'bt' in device_name
+                    or 'wh-' in device_name or 'wf-' in device_name):
                 amplitude = 0.15  # Higher amplitude for Bluetooth devices
                 logger.debug(f"Bluetooth device detected ({devices[default_output]['name']}), using amplitude {amplitude}")
             else:


### PR DESCRIPTION
## Problem

On macOS, CoreAudio reports many Bluetooth headphones by bare model name — e.g. Sony's flagship headphones show up as just `WH-1000XM4`. The chime amplitude check in `generate_chime()` only matches `airpod` / `bluetooth` / `bt` in the device name, so these get misclassified as built-in speakers:

```
DEBUG:voicemode:Built-in speaker detected (WH-1000XM4), using amplitude 0.075
```

The chime then plays at half the intended Bluetooth amplitude (0.075 vs 0.15). In practice this made the listen chime inaudible on WH-1000XM4s — compounded by the chime overlapping the A2DP→HFP profile switch when the mic opens (mitigable via `VOICEMODE_CHIME_LEADING_SILENCE`, but the low amplitude makes even a well-timed chime hard to hear).

## Fix

Match the `wh-` / `wf-` name prefixes — Sony's WH (over-ear) and WF (earbud) lines — alongside the existing checks.

## Testing

Verified on macOS 26 with WH-1000XM4 as default output:

```
DEBUG:voicemode:Bluetooth device detected (WH-1000XM4), using amplitude 0.15
```

Chime is now clearly audible; `voicemode converse` round-trip works end-to-end.

A name-prefix allowlist will never cover every device — longer term, querying the device transport type from CoreAudio would be more robust — but this makes a very common headphone line work today with a two-line change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)