### PR TITLE
feat(conch): add awaiting_human_response priority-override state

### DIFF
--- a/tests/test_conch_awaiting_human_response.py
+++ b/tests/test_conch_awaiting_human_response.py
@@ -1,0 +1,584 @@
+"""Test suite for the `awaiting_human_response` Conch state
+(feat(conch): add awaiting_human_response priority-override state).
+
+Ported from Thessary's scratch-dir patch validation suite
+(docs/KB/phase2-3-4-design-2026-07-14.md section 2.1) onto the CURRENT
+upstream package structure -- adapted for real differences found by
+reading the actual current code rather than assuming the original
+scratch-copy API still applies:
+
+- The original scratch conch.py used `import fcntl` and was Unix-only;
+  this repo's current `voice_mode/conch.py` has since been made portable
+  (`psutil.pid_exists` + `voice_mode.file_lock.lock_exclusive`/`unlock`
+  instead of `fcntl`/`os.kill`), so this suite runs on native Windows
+  Python too, not just WSL/Linux -- no `import fcntl` requirement to work
+  around.
+- Imports the real installed `voice_mode.conch` module directly (it's a
+  real package in this repo/venv), rather than sys.path-inserting a
+  scratch copy.
+- `Conch.mark_awaiting_human_response`/`awaiting_human_response_active`/
+  `resolve_awaiting_human_response` and the module-level
+  `_process_start_time`/`_is_same_process` helpers match the scratch
+  design 1:1 (confirmed by direct diff review), so the test bodies below
+  are otherwise unchanged in intent from the original suite.
+- Fabricated "alive other process" scenarios use a real subprocess pid
+  rather than a hardcoded pid=1: `psutil.pid_exists(1)` is not guaranteed
+  true cross-platform (no pid 1 on native Windows), whereas the original
+  suite's own reasoning for pid=1 (a Unix `kill(1, 0)` PermissionError
+  quirk) no longer even applies here since `psutil.pid_exists` returns a
+  plain bool and never raises for a live-but-unsignalable pid.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+import tempfile
+import textwrap
+import time
+import unittest
+from datetime import datetime, timedelta
+from pathlib import Path
+
+import pytest
+
+from voice_mode.conch import (
+    Conch,
+    _hold_is_expired,
+    _response_deadline_passed,
+    _process_start_time,
+    _is_same_process,
+)
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+CONVERSE_PY = REPO_ROOT / "voice_mode" / "tools" / "converse.py"
+
+
+# ---------------------------------------------------------------------------
+# Shared harness: isolate Conch.LOCK_FILE to a scratch temp dir per test.
+# ---------------------------------------------------------------------------
+class ConchIsolationMixin:
+    def setUp(self):
+        self._orig_lock_file = Conch.LOCK_FILE
+        self._tmpdir = tempfile.mkdtemp(prefix="conch-ahr-test-")
+        Conch.LOCK_FILE = Path(self._tmpdir) / "conch"
+
+    def tearDown(self):
+        Conch.LOCK_FILE = self._orig_lock_file
+        import shutil
+        shutil.rmtree(self._tmpdir, ignore_errors=True)
+
+    def _read_raw(self) -> dict:
+        return json.loads(Conch.LOCK_FILE.read_text())
+
+    def _write_raw(self, data: dict) -> None:
+        Conch.LOCK_FILE.parent.mkdir(parents=True, exist_ok=True)
+        Conch.LOCK_FILE.write_text(json.dumps(data, indent=2))
+
+
+# ---------------------------------------------------------------------------
+# 1. Normal flock/hold behavior unaffected -- regression vs. today's
+#    two-state (held True/False) behavior.
+# ---------------------------------------------------------------------------
+class TestNormalBehaviorRegression(ConchIsolationMixin, unittest.TestCase):
+    def test_acquire_and_release_basic(self):
+        c = Conch(agent_name="tester")
+        self.assertTrue(c.try_acquire())
+        payload = self._read_raw()
+        self.assertEqual(payload["held"], False)
+        self.assertIsNone(payload.get("awaiting_human_response"))
+        c.release()
+        self.assertFalse(Conch.LOCK_FILE.exists())
+
+    def test_hold_then_same_process_reclaims(self):
+        c = Conch(agent_name="tester")
+        self.assertTrue(c.try_acquire())
+        c.release(hold=True)
+        payload = self._read_raw()
+        self.assertTrue(payload["held"])
+        self.assertIsNone(payload.get("awaiting_human_response"))
+        c2 = Conch(agent_name="tester")
+        self.assertTrue(c2.try_acquire())
+        c2.release()
+
+    def test_hold_marker_blocks_other_pid_until_idle_expiry(self):
+        # A real, genuinely-alive subprocess pid -- portable across
+        # Windows/Linux (unlike the original suite's pid=1 fabrication,
+        # which relied on Unix-only kill(1,0) PermissionError semantics
+        # that psutil.pid_exists no longer exhibits).
+        holder_proc = subprocess.Popen([sys.executable, "-c", "import time; time.sleep(5)"])
+        try:
+            time.sleep(0.2)
+            self._write_raw({
+                "pid": holder_proc.pid,
+                "agent": "other",
+                "session_id": None,
+                "project_path": None,
+                "voice": None,
+                "acquired": datetime.now().isoformat(),
+                "held": True,
+                "expires": None,
+            })
+            self.assertTrue(Conch._held_by_other())
+            c = Conch(agent_name="tester")
+            self.assertFalse(c.try_acquire())
+
+            # Now age it past the fallback 10s idle-expiry window.
+            self._write_raw({
+                "pid": holder_proc.pid,
+                "agent": "other",
+                "session_id": None,
+                "project_path": None,
+                "voice": None,
+                "acquired": (datetime.now() - timedelta(seconds=11)).isoformat(),
+                "held": True,
+                "expires": None,
+            })
+            self.assertFalse(Conch._held_by_other())
+            c2 = Conch(agent_name="tester")
+            self.assertTrue(c2.try_acquire())  # stale hold cleared, reacquire succeeds
+            c2.release()
+        finally:
+            holder_proc.kill()
+            holder_proc.wait(timeout=5)
+
+    def test_real_cross_process_active_lock_blocks_second_acquirer(self):
+        """Genuine cross-process regression check using the real
+        lock_exclusive/unlock (not fabricated JSON): a subprocess holds an
+        ACTIVE lock (held=False, real kernel/file lock taken) for a short
+        window; the parent process must be refused, unaffected by this
+        patch."""
+        holder_script = textwrap.dedent(f"""
+            import sys, time
+            from pathlib import Path
+            import voice_mode.conch as conch_mod
+            conch_mod.Conch.LOCK_FILE = Path({str(Conch.LOCK_FILE)!r})
+            c = conch_mod.Conch(agent_name="holder-proc")
+            assert c.try_acquire()
+            time.sleep(1.2)
+            c.release()
+        """)
+        proc = subprocess.Popen([sys.executable, "-c", holder_script])
+        try:
+            time.sleep(0.4)  # let the child actually acquire first
+            c = Conch(agent_name="parent")
+            self.assertFalse(c.try_acquire())
+        finally:
+            proc.wait(timeout=5)
+
+
+# ---------------------------------------------------------------------------
+# 2. The new awaiting_human_response state itself.
+# ---------------------------------------------------------------------------
+class TestAwaitingHumanResponseState(ConchIsolationMixin, unittest.TestCase):
+    def test_mark_creates_expected_fresh_payload(self):
+        before = datetime.now()
+        Conch.mark_awaiting_human_response(deadline_seconds=5)
+        payload = self._read_raw()
+        self.assertEqual(payload["pid"], os.getpid())
+        self.assertTrue(payload["held"])
+        self.assertTrue(payload["awaiting_human_response"])
+        self.assertIn("response_deadline", payload)
+        deadline = datetime.fromisoformat(payload["response_deadline"])
+        self.assertTrue(before + timedelta(seconds=4) < deadline < before + timedelta(seconds=6))
+        self.assertEqual(payload["expires"], payload["response_deadline"])
+
+    def test_mark_preserves_existing_holder_payload_fields(self):
+        c = Conch(agent_name="cora", session_id="sess-1", project_path="/proj", voice="nova")
+        self.assertTrue(c.try_acquire())
+        original_pid = self._read_raw()["pid"]
+
+        Conch.mark_awaiting_human_response(deadline_seconds=30)
+        payload = self._read_raw()
+        self.assertEqual(payload["agent"], "cora")
+        self.assertEqual(payload["session_id"], "sess-1")
+        self.assertEqual(payload["project_path"], "/proj")
+        self.assertEqual(payload["voice"], "nova")
+        self.assertEqual(payload["pid"], original_pid)
+        self.assertTrue(payload["held"])
+        self.assertTrue(payload["awaiting_human_response"])
+
+    def test_mark_with_no_prior_file_creates_minimal_marker(self):
+        self.assertFalse(Conch.LOCK_FILE.exists())
+        Conch.mark_awaiting_human_response(deadline_seconds=10)
+        payload = self._read_raw()
+        self.assertEqual(payload["agent"], "unknown")
+        self.assertTrue(payload["awaiting_human_response"])
+
+    def test_mark_derives_pid_start_time_from_the_preserved_pid_not_the_caller(self):
+        other_proc = subprocess.Popen([sys.executable, "-c", "import time; time.sleep(5)"])
+        try:
+            time.sleep(0.2)
+            other_pid = other_proc.pid
+            other_real_start = _process_start_time(other_pid)
+            if other_real_start is None:
+                self.skipTest("_process_start_time unavailable on this platform (non-Linux /proc)")
+            self._write_raw({
+                "pid": other_pid,
+                "agent": "other-real-holder",
+                "session_id": None,
+                "project_path": None,
+                "voice": None,
+                "acquired": datetime.now().isoformat(),
+                "held": True,
+                "expires": None,
+            })
+            Conch.mark_awaiting_human_response(deadline_seconds=60)
+            payload = self._read_raw()
+            self.assertEqual(payload["pid"], other_pid, "the original pid must be preserved")
+            self.assertEqual(
+                payload["pid_start_time"], other_real_start,
+                "must stamp the PRESERVED pid's own start-time, not the caller's",
+            )
+            self.assertNotEqual(payload["pid_start_time"], _process_start_time(os.getpid()))
+        finally:
+            other_proc.kill()
+            other_proc.wait(timeout=5)
+
+    def test_response_deadline_passed_missing_or_malformed_is_false(self):
+        self.assertFalse(_response_deadline_passed({}))
+        self.assertFalse(_response_deadline_passed({"response_deadline": None}))
+        self.assertFalse(_response_deadline_passed({"response_deadline": "not-a-date"}))
+
+    def _mark_awaiting_as_other_process(self, deadline_seconds: float, fake_pid: int = 999_996) -> None:
+        now = datetime.now()
+        deadline_iso = (now + timedelta(seconds=deadline_seconds)).isoformat()
+        self._write_raw({
+            "pid": fake_pid,
+            "agent": "other-agent",
+            "session_id": None,
+            "project_path": None,
+            "voice": None,
+            "acquired": now.isoformat(),
+            "held": True,
+            "expires": deadline_iso,
+            "awaiting_human_response": True,
+            "response_deadline": deadline_iso,
+        })
+
+    def test_new_state_blocks_second_acquirer_other_process(self):
+        self._mark_awaiting_as_other_process(deadline_seconds=60)
+        self.assertTrue(Conch._held_by_other())
+        c2 = Conch(agent_name="someone-else")
+        self.assertFalse(c2.try_acquire())
+
+    def test_same_process_can_resume_after_marking_awaiting_response(self):
+        Conch.mark_awaiting_human_response(deadline_seconds=60)  # stamps OUR OWN pid
+        self.assertFalse(Conch._held_by_other(), "own pid must be exempt from own awaiting_human_response")
+        c = Conch(agent_name="same-process-resuming")
+        self.assertTrue(c.try_acquire())
+        c.release()
+
+    def test_new_state_blocks_unconditionally_even_for_a_dead_pid(self):
+        self._write_raw({
+            "pid": 999_999_999,  # not a real pid
+            "agent": "dead-holder",
+            "session_id": None,
+            "project_path": None,
+            "voice": None,
+            "acquired": datetime.now().isoformat(),
+            "held": True,
+            "expires": (datetime.now() + timedelta(seconds=60)).isoformat(),
+            "awaiting_human_response": True,
+            "response_deadline": (datetime.now() + timedelta(seconds=60)).isoformat(),
+        })
+        self.assertTrue(Conch._held_by_other())
+        c = Conch(agent_name="someone-else")
+        self.assertFalse(c.try_acquire())
+
+    def test_check_and_clear_stale_lock_does_not_unlink_during_active_window(self):
+        self._write_raw({
+            "pid": 999_999_999,
+            "agent": "dead-holder",
+            "session_id": None,
+            "project_path": None,
+            "voice": None,
+            "acquired": datetime.now().isoformat(),
+            "held": True,
+            "expires": (datetime.now() + timedelta(seconds=60)).isoformat(),
+            "awaiting_human_response": True,
+            "response_deadline": (datetime.now() + timedelta(seconds=60)).isoformat(),
+        })
+        c = Conch(agent_name="someone-else")
+        c._check_and_clear_stale_lock()
+        self.assertTrue(Conch.LOCK_FILE.exists(), "marker was unlinked before its own response_deadline passed")
+
+    def test_block_expires_after_response_deadline(self):
+        self._mark_awaiting_as_other_process(deadline_seconds=0.3)
+        self.assertTrue(Conch._held_by_other())
+        c = Conch(agent_name="someone-else")
+        self.assertFalse(c.try_acquire())
+
+        time.sleep(0.45)
+        self.assertFalse(Conch._held_by_other())
+        c2 = Conch(agent_name="someone-else")
+        self.assertTrue(c2.try_acquire())
+        c2.release()
+
+    def test_old_two_state_shape_never_triggers_new_branches(self):
+        self._write_raw({
+            "pid": os.getpid(),
+            "agent": "me",
+            "session_id": None,
+            "project_path": None,
+            "voice": None,
+            "acquired": datetime.now().isoformat(),
+            "held": False,
+            "expires": None,
+        })
+        data = json.loads(Conch.LOCK_FILE.read_text())
+        self.assertFalse(bool(data.get("awaiting_human_response")))
+        self.assertFalse(_response_deadline_passed(data))
+        self.assertFalse(Conch._held_by_other())
+
+
+# ---------------------------------------------------------------------------
+# 3. converse.py's skip_conch guard -- extracted and exec'd, since the full
+#    4500+-line module can't be imported standalone in this stripped test
+#    environment (sounddevice, fastmcp, etc. would need to be mocked).
+# ---------------------------------------------------------------------------
+def _extract_skip_conch_guard_source() -> str:
+    src = CONVERSE_PY.read_text(encoding="utf-8")
+    start_marker = "        if CONCH_ENABLED and skip_conch:\n"
+    end_marker = "\n        # Try to acquire conch atomically"
+    start = src.index(start_marker)
+    end = src.index(end_marker, start)
+    snippet = src[start:end]
+    return textwrap.dedent(snippet)
+
+
+class TestConverseSkipConchGuard(ConchIsolationMixin, unittest.TestCase):
+    def setUp(self):
+        super().setUp()
+        self.snippet = _extract_skip_conch_guard_source()
+        self.assertIn("awaiting_human_response_active", self.snippet)
+        self.assertIn("skip_conch = False", self.snippet)
+
+    def _run_guard(self, *, conch_enabled: bool, skip_conch: bool) -> bool:
+        namespace = {
+            "CONCH_ENABLED": conch_enabled,
+            "skip_conch": skip_conch,
+            "Conch": Conch,
+        }
+        exec(compile(self.snippet, "<skip_conch_guard>", "exec"), namespace)
+        return namespace["skip_conch"]
+
+    def _mark_awaiting_as_other_process(self, deadline_seconds: float, fake_pid: int = 999999) -> None:
+        now = datetime.now()
+        deadline_iso = (now + timedelta(seconds=deadline_seconds)).isoformat()
+        self._write_raw({
+            "pid": fake_pid,
+            "agent": "other-agent",
+            "session_id": None,
+            "project_path": None,
+            "voice": None,
+            "acquired": now.isoformat(),
+            "held": True,
+            "expires": deadline_iso,
+            "awaiting_human_response": True,
+            "response_deadline": deadline_iso,
+        })
+
+    def test_skip_conch_hard_no_op_while_awaiting_human_response_active(self):
+        self._mark_awaiting_as_other_process(deadline_seconds=60)
+        result = self._run_guard(conch_enabled=True, skip_conch=True)
+        self.assertFalse(result, "skip_conch=True must be downgraded to False while active")
+
+    def test_skip_conch_behaves_normally_once_deadline_passed(self):
+        self._mark_awaiting_as_other_process(deadline_seconds=0.2)
+        time.sleep(0.3)
+        result = self._run_guard(conch_enabled=True, skip_conch=True)
+        self.assertTrue(result, "skip_conch=True must NOT be overridden once the deadline has passed")
+
+    def test_skip_conch_behaves_normally_with_no_holder_at_all(self):
+        self.assertFalse(Conch.LOCK_FILE.exists())
+        result = self._run_guard(conch_enabled=True, skip_conch=True)
+        self.assertTrue(result)
+
+    def test_skip_conch_behaves_normally_when_holder_not_awaiting_response(self):
+        c = Conch(agent_name="normal-holder")
+        self.assertTrue(c.try_acquire())
+        result = self._run_guard(conch_enabled=True, skip_conch=True)
+        self.assertTrue(result, "an ordinary active/held holder must not force skip_conch off")
+
+    def test_guard_is_noop_when_conch_disabled_entirely(self):
+        self._mark_awaiting_as_other_process(deadline_seconds=60)
+        result = self._run_guard(conch_enabled=False, skip_conch=True)
+        self.assertTrue(result, "CONCH_ENABLED=False must bypass the whole mechanism, unchanged")
+
+    def test_guard_is_noop_when_caller_did_not_request_skip(self):
+        self._mark_awaiting_as_other_process(deadline_seconds=60)
+        result = self._run_guard(conch_enabled=True, skip_conch=False)
+        self.assertFalse(result)
+
+    def test_guard_still_treats_own_pid_as_not_blocking(self):
+        Conch.mark_awaiting_human_response(deadline_seconds=60)  # stamps OUR OWN pid
+        result = self._run_guard(conch_enabled=True, skip_conch=True)
+        self.assertTrue(result, "the original holder's own process must not be blocked by its own state")
+
+    def test_guard_unaffected_by_short_conch_lock_expiry(self):
+        """Regression test for the (now-fixed) upstream CRITICAL finding:
+        an earlier draft used Conch.get_holder(), which goes stale as soon
+        as CONCH_LOCK_EXPIRY elapses OR the holder pid dies -- independent
+        of response_deadline. The shipped guard (awaiting_human_response_active())
+        must stay correct regardless of CONCH_LOCK_EXPIRY or pid liveness."""
+        import types
+        had_voice_mode_config = "voice_mode.config" in sys.modules
+        orig_config = sys.modules.get("voice_mode.config")
+        fake_config = types.ModuleType("voice_mode.config")
+        fake_config.CONCH_LOCK_EXPIRY = 0.2  # much shorter than our response_deadline below
+        fake_config.CONCH_HOLD_EXPIRY = 10.0
+        sys.modules["voice_mode.config"] = fake_config
+        try:
+            # A dead pid too, not just a live-but-expired one.
+            self._mark_awaiting_as_other_process(deadline_seconds=5.0, fake_pid=999998)
+            self.assertIsNone(Conch.get_holder(), "sanity: get_holder() DOES go stale on a dead pid")
+            result = self._run_guard(conch_enabled=True, skip_conch=True)
+            self.assertFalse(
+                result,
+                "the fixed guard must still block skip_conch even though get_holder() itself is stale",
+            )
+        finally:
+            if had_voice_mode_config:
+                sys.modules["voice_mode.config"] = orig_config
+            else:
+                sys.modules.pop("voice_mode.config", None)
+
+
+# ---------------------------------------------------------------------------
+# 4. Independent-audit findings: pid-reuse protection for the same-process
+#    exemption, and a precondition guard on resolve_awaiting_human_response().
+# ---------------------------------------------------------------------------
+class TestProcessStartTimeHelper(unittest.TestCase):
+    def test_returns_none_for_a_nonexistent_pid(self):
+        self.assertIsNone(_process_start_time(999_999_999))
+
+    def test_is_stable_across_repeated_calls_for_the_same_process(self):
+        first = _process_start_time(os.getpid())
+        second = _process_start_time(os.getpid())
+        self.assertEqual(first, second)
+
+    def test_returns_a_parseable_float_string_for_the_current_real_process(self):
+        """_process_start_time is now psutil.Process.create_time()-backed
+        (a float epoch-seconds value), portable across platforms -- unlike
+        the earlier Linux-only /proc/<pid>/stat tick-count implementation,
+        it should never legitimately return None for the current, real,
+        live process on any supported platform."""
+        result = _process_start_time(os.getpid())
+        self.assertIsNotNone(result)
+        float(result)  # must be parseable; raises ValueError if not
+
+
+class TestPidReuseProtection(ConchIsolationMixin, unittest.TestCase):
+    def test_matching_pid_but_wrong_start_time_is_not_treated_as_self(self):
+        real_start = _process_start_time(os.getpid())
+        if real_start is None:
+            self.skipTest("_process_start_time unavailable on this platform (non-Linux /proc)")
+        self._write_raw({
+            "pid": os.getpid(),
+            "pid_start_time": "not-our-real-start-time",
+            "agent": "someone-else-with-our-recycled-pid",
+            "session_id": None,
+            "project_path": None,
+            "voice": None,
+            "acquired": datetime.now().isoformat(),
+            "held": True,
+            "expires": (datetime.now() + timedelta(seconds=60)).isoformat(),
+            "awaiting_human_response": True,
+            "response_deadline": (datetime.now() + timedelta(seconds=60)).isoformat(),
+        })
+        self.assertTrue(
+            Conch._held_by_other(),
+            "a pid match with a mismatched start-time must NOT grant the same-process exemption",
+        )
+        c = Conch(agent_name="someone-else")
+        self.assertFalse(c.try_acquire())
+
+    def test_matching_pid_and_correct_start_time_is_treated_as_self(self):
+        real_start = _process_start_time(os.getpid())
+        if real_start is None:
+            self.skipTest("_process_start_time unavailable on this platform (non-Linux /proc)")
+        self._write_raw({
+            "pid": os.getpid(),
+            "pid_start_time": real_start,
+            "agent": "me",
+            "session_id": None,
+            "project_path": None,
+            "voice": None,
+            "acquired": datetime.now().isoformat(),
+            "held": True,
+            "expires": (datetime.now() + timedelta(seconds=60)).isoformat(),
+            "awaiting_human_response": True,
+            "response_deadline": (datetime.now() + timedelta(seconds=60)).isoformat(),
+        })
+        self.assertFalse(Conch._held_by_other(), "genuinely matching pid+start_time must be exempt")
+        self.assertIsNone(Conch.awaiting_human_response_active())
+
+    def test_missing_pid_start_time_in_payload_fails_closed(self):
+        # An older-shaped marker (pre-fix, no pid_start_time field at all)
+        # with our own real pid -- must fail CLOSED regardless of platform,
+        # since _is_same_process() requires BOTH own_start and the stamped
+        # pid_start_time to be non-None and equal.
+        self._write_raw({
+            "pid": os.getpid(),
+            "agent": "me-but-old-shape",
+            "session_id": None,
+            "project_path": None,
+            "voice": None,
+            "acquired": datetime.now().isoformat(),
+            "held": True,
+            "expires": (datetime.now() + timedelta(seconds=60)).isoformat(),
+            "awaiting_human_response": True,
+            "response_deadline": (datetime.now() + timedelta(seconds=60)).isoformat(),
+        })
+        self.assertTrue(
+            Conch._held_by_other(),
+            "a payload with no pid_start_time at all must fail closed (not exempted)",
+        )
+
+    def test_is_same_process_helper_directly(self):
+        real_start = _process_start_time(os.getpid())
+        self.assertFalse(_is_same_process({"pid": os.getpid(), "pid_start_time": "wrong"}))
+        self.assertFalse(_is_same_process({"pid": 999_999_999, "pid_start_time": real_start}))
+        self.assertFalse(_is_same_process({"pid": os.getpid()}))  # no pid_start_time at all
+        self.assertFalse(_is_same_process({}))
+        if real_start is not None:
+            self.assertTrue(_is_same_process({"pid": os.getpid(), "pid_start_time": real_start}))
+
+
+class TestResolveAwaitingHumanResponseGuard(ConchIsolationMixin, unittest.TestCase):
+    def test_does_not_unlink_an_unrelated_active_holder(self):
+        c = Conch(agent_name="normal-active-holder")
+        self.assertTrue(c.try_acquire())
+        self.assertTrue(Conch.LOCK_FILE.exists())
+        result = Conch.resolve_awaiting_human_response()
+        self.assertFalse(result, "must refuse to touch a lock file that isn't in the awaiting state")
+        self.assertTrue(Conch.LOCK_FILE.exists(), "the unrelated active holder's file must survive untouched")
+        c.release()
+
+    def test_does_not_unlink_a_normal_hold(self):
+        c = Conch(agent_name="normal-hold")
+        self.assertTrue(c.try_acquire())
+        c.release(hold=True)
+        self.assertTrue(Conch.LOCK_FILE.exists())
+        result = Conch.resolve_awaiting_human_response()
+        self.assertFalse(result)
+        self.assertTrue(Conch.LOCK_FILE.exists())
+
+    def test_unlinks_a_genuine_awaiting_human_response_marker(self):
+        Conch.mark_awaiting_human_response(deadline_seconds=60)
+        self.assertTrue(Conch.LOCK_FILE.exists())
+        result = Conch.resolve_awaiting_human_response()
+        self.assertTrue(result)
+        self.assertFalse(Conch.LOCK_FILE.exists())
+
+    def test_missing_file_returns_false_not_an_error(self):
+        self.assertFalse(Conch.LOCK_FILE.exists())
+        result = Conch.resolve_awaiting_human_response()
+        self.assertFalse(result)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/tests/test_conch_awaiting_human_response.py
+++ b/tests/test_conch_awaiting_human_response.py
@@ -1,32 +1,18 @@
 """Test suite for the `awaiting_human_response` Conch state
 (feat(conch): add awaiting_human_response priority-override state).
 
-Ported from Thessary's scratch-dir patch validation suite
-(docs/KB/phase2-3-4-design-2026-07-14.md section 2.1) onto the CURRENT
-upstream package structure -- adapted for real differences found by
-reading the actual current code rather than assuming the original
-scratch-copy API still applies:
+Covers the new `Conch.mark_awaiting_human_response`/
+`awaiting_human_response_active`/`resolve_awaiting_human_response`
+classmethods, the module-level `_process_start_time`/`_is_same_process`
+helpers, the new branches in `_held_by_other()`/`_check_and_clear_stale_lock()`,
+and the `skip_conch` hard-no-op guard in `converse.py`.
 
-- The original scratch conch.py used `import fcntl` and was Unix-only;
-  this repo's current `voice_mode/conch.py` has since been made portable
-  (`psutil.pid_exists` + `voice_mode.file_lock.lock_exclusive`/`unlock`
-  instead of `fcntl`/`os.kill`), so this suite runs on native Windows
-  Python too, not just WSL/Linux -- no `import fcntl` requirement to work
-  around.
-- Imports the real installed `voice_mode.conch` module directly (it's a
-  real package in this repo/venv), rather than sys.path-inserting a
-  scratch copy.
-- `Conch.mark_awaiting_human_response`/`awaiting_human_response_active`/
-  `resolve_awaiting_human_response` and the module-level
-  `_process_start_time`/`_is_same_process` helpers match the scratch
-  design 1:1 (confirmed by direct diff review), so the test bodies below
-  are otherwise unchanged in intent from the original suite.
-- Fabricated "alive other process" scenarios use a real subprocess pid
-  rather than a hardcoded pid=1: `psutil.pid_exists(1)` is not guaranteed
-  true cross-platform (no pid 1 on native Windows), whereas the original
-  suite's own reasoning for pid=1 (a Unix `kill(1, 0)` PermissionError
-  quirk) no longer even applies here since `psutil.pid_exists` returns a
-  plain bool and never raises for a live-but-unsignalable pid.
+Runs on native Windows Python as well as Linux/macOS: `voice_mode/conch.py`
+uses `psutil.pid_exists`/`psutil.Process.create_time()` and
+`voice_mode.file_lock.lock_exclusive`/`unlock` rather than `fcntl`/`os.kill`,
+so nothing here requires WSL. Fabricated "alive other process" scenarios
+use a real subprocess pid rather than a hardcoded pid=1, since a fixed pid
+number is not guaranteed to exist across platforms.
 """
 
 from __future__ import annotations
@@ -41,8 +27,6 @@ import time
 import unittest
 from datetime import datetime, timedelta
 from pathlib import Path
-
-import pytest
 
 from voice_mode.conch import (
     Conch,
@@ -206,6 +190,30 @@ class TestAwaitingHumanResponseState(ConchIsolationMixin, unittest.TestCase):
         payload = self._read_raw()
         self.assertEqual(payload["agent"], "unknown")
         self.assertTrue(payload["awaiting_human_response"])
+
+    def test_mark_again_while_already_awaiting_extends_deadline_without_corruption(self):
+        """Calling mark_awaiting_human_response() a second time while
+        already in the awaiting state (e.g. a fresh question arrives before
+        the first one's deadline) must extend the deadline cleanly --
+        preserving pid/pid_start_time/agent identity, not duplicating or
+        corrupting the payload."""
+        c = Conch(agent_name="cora", session_id="sess-1")
+        self.assertTrue(c.try_acquire())
+        Conch.mark_awaiting_human_response(deadline_seconds=5)
+        first = self._read_raw()
+
+        Conch.mark_awaiting_human_response(deadline_seconds=60)
+        second = self._read_raw()
+
+        self.assertEqual(second["pid"], first["pid"])
+        self.assertEqual(second["pid_start_time"], first["pid_start_time"])
+        self.assertEqual(second["agent"], "cora")
+        self.assertEqual(second["session_id"], "sess-1")
+        self.assertTrue(second["awaiting_human_response"])
+        second_deadline = datetime.fromisoformat(second["response_deadline"])
+        first_deadline = datetime.fromisoformat(first["response_deadline"])
+        self.assertGreater(second_deadline, first_deadline)
+        self.assertEqual(second["expires"], second["response_deadline"])
 
     def test_mark_derives_pid_start_time_from_the_preserved_pid_not_the_caller(self):
         other_proc = subprocess.Popen([sys.executable, "-c", "import time; time.sleep(5)"])

--- a/voice_mode/conch.py
+++ b/voice_mode/conch.py
@@ -99,6 +99,92 @@ def _hold_is_expired(data: dict) -> bool:
     return age > hold_expiry
 
 
+def _response_deadline_passed(data: dict) -> bool:
+    """True if an ``awaiting_human_response`` payload has passed its own
+    explicit ``response_deadline`` (Theme 8, added
+    docs/KB/phase2-3-4-design-2026-07-14.md §2.1).
+
+    Mirrors ``_hold_is_expired()`` above, but this new state has exactly
+    ONE timeout source -- the absolute ``response_deadline`` stamped by
+    ``Conch.mark_awaiting_human_response()`` -- deliberately NOT the normal
+    hold-expiry TTL (``CONCH_HOLD_EXPIRY``/``expires``) or the flock-lock
+    staleness window (``CONCH_LOCK_EXPIRY``). A SEPARATE function from
+    ``_hold_is_expired()`` on purpose, so a live safety-relevant wait for a
+    human reply is never accidentally coupled to the normal 10s hold-expiry
+    default -- that's the entire point of the new state (Theme 8: "exempt
+    from refresh-TTL").
+
+    Returns False (not passed / still live) when ``response_deadline`` is
+    missing or malformed -- same reasoning as ``_hold_is_expired()``: an
+    undecidable deadline is treated as still active rather than stolen.
+    """
+    deadline_str = data.get("response_deadline")
+    if not deadline_str:
+        return False
+    try:
+        return datetime.now() > datetime.fromisoformat(deadline_str)
+    except (ValueError, TypeError):
+        return False
+
+
+def _process_start_time(pid: int) -> Optional[str]:
+    """FIX (independent audit, round 3 -- MEDIUM finding): a pid NUMBER
+    alone is not a reliable process identity on Linux -- pids are reused.
+    Scenario the audit found: process A calls mark_awaiting_human_response()
+    then crashes; within the still-live response_deadline window (up to
+    300s by default), the OS reassigns A's old pid to a completely
+    unrelated process B; B's own awaiting_human_response_active()/
+    _held_by_other() check would then see ``pid == os.getpid()`` and
+    wrongly treat itself as "the original holder," silently exempting
+    itself from the very safety gate Theme 8/9 exist to enforce.
+
+    Reads /proc/<pid>/stat's ``starttime`` field (ticks since boot) as an
+    opaque, monotonically-assigned identity token that a pid alone can't
+    provide -- two DIFFERENT processes essentially never share both the
+    same pid AND the same start tick. Combined with the pid itself (see
+    call sites), this reliably distinguishes "truly the same process" from
+    "a different process that happens to have the inherited pid number."
+
+    Returns None if unavailable (process gone, /proc missing/malformed --
+    e.g. non-Linux, though this module already requires Unix via
+    ``import fcntl`` at the top of the file, so /proc is expected to exist
+    in practice). Callers MUST treat None as "cannot verify" and fail
+    CLOSED (i.e. do NOT grant a same-process exemption) rather than
+    silently falling back to a pid-only comparison, which is exactly the
+    weaker check this function exists to replace.
+    """
+    try:
+        with open(f"/proc/{pid}/stat", "r") as f:
+            content = f.read()
+        # comm (field 2) is parenthesized and may itself contain ')' or
+        # whitespace -- split on the LAST ')' to reliably locate the start
+        # of the remaining whitespace-separated fields (field 3 = state).
+        after_comm = content.rsplit(")", 1)[1]
+        fields = after_comm.split()
+        # fields[0] is field 3 (state); starttime is field 22, i.e. 19
+        # further along from state (3 + 19 = 22).
+        return fields[19]
+    except (OSError, IndexError, ValueError):
+        return None
+
+
+def _is_same_process(data: dict) -> bool:
+    """True only if ``data``'s stamped pid AND process-start-time both
+    match the CURRENT process -- see ``_process_start_time()`` above for
+    why pid alone is not sufficient. Fails CLOSED (returns False, meaning
+    "not confirmed the same process," i.e. no exemption granted) whenever
+    either side's start time can't be read -- an unverifiable identity must
+    never be treated as a match for a safety-relevant exemption.
+    """
+    pid = data.get("pid")
+    if pid is None or pid != os.getpid():
+        return False
+    own_start = _process_start_time(os.getpid())
+    if own_start is None:
+        return False
+    return data.get("pid_start_time") == own_start
+
+
 class Conch:
     """Simple lock file for voice conversation coordination.
 
@@ -221,6 +307,36 @@ class Conch:
             data = json.loads(cls.LOCK_FILE.read_text())
         except (json.JSONDecodeError, OSError, ValueError):
             return False
+        # A live awaiting_human_response state is a PRIORITY OVERRIDE (Theme
+        # 8): it blocks ALL OTHER processes' floor-acquisition attempts
+        # unconditionally -- regardless of ``held``, regardless of whether
+        # the original holder's pid is even still alive -- until its own
+        # explicit response_deadline passes. The ORIGINAL holder's own pid is
+        # exempt (see the check below) so it can resume the instant Mike
+        # answers, mirroring the normal ``held`` path's own pid exemption.
+        # Checked first, ahead of (and independent of) the normal held/pid-
+        # liveness path below: a dropped call's cleanup is the CALLER's job
+        # (Thessary's approval_queue.py expiry composes with this same
+        # deadline), not a pid-liveness check here (design doc §2.1 item 5)
+        # -- conch itself has no concept of Thessary's approval queue and
+        # shouldn't gain one.
+        # FIX (independent audit, round 2): exempt the ORIGINAL holder's own
+        # process from this block, mirroring the normal ``held`` path's own
+        # pid exemption immediately below. Without this, the same process
+        # that called mark_awaiting_human_response() could never re-acquire
+        # even the instant Mike answers -- there was no resume path at all.
+        # FIX (independent audit, round 3): "own process" is verified via
+        # _is_same_process() (pid + /proc start-time), NOT a bare pid
+        # comparison -- a bare `pid == os.getpid()` check is fooled by pid
+        # reuse (a crashed original holder's pid reassigned to an unrelated
+        # process within the still-live response_deadline window), which
+        # would silently exempt that unrelated process from the safety gate.
+        if (
+            data.get("awaiting_human_response")
+            and not _response_deadline_passed(data)
+            and not _is_same_process(data)
+        ):
+            return True
         if not data.get("held"):
             return False
         pid = data.get("pid")
@@ -278,6 +394,164 @@ class Conch:
             "expires": expires,
         }
         cls.LOCK_FILE.write_text(json.dumps(data, indent=2))
+
+    @classmethod
+    def mark_awaiting_human_response(cls, deadline_seconds: float = 300.0) -> None:
+        """Re-stamp the lock file into the ``awaiting_human_response`` state
+        (Theme 8, docs/KB/phase2-3-4-design-2026-07-14.md §2.1) -- a live,
+        safety-relevant decision is pending a human reply. Called by the
+        CURRENT flock holder just before it yields the floor to wait; mirrors
+        ``write_hold()`` above in that it does NOT take the kernel flock (same
+        reasoning: this must not self-deadlock the same process's own later
+        ``try_acquire``).
+
+        Unlike a normal between-turns hold, this state is deliberately EXEMPT
+        from the standard ``CONCH_HOLD_EXPIRY`` idle-refresh window (a real
+        decision can take longer than 10s) -- it carries its own, explicit,
+        absolute ``response_deadline`` (now + ``deadline_seconds``), read by
+        ``_response_deadline_passed()`` above, a SEPARATE staleness function
+        from ``_hold_is_expired()`` on purpose (Theme 8: "exempt from
+        refresh-TTL", never accidentally coupled to the normal hold default).
+
+        This RE-STAMPS the existing lock-file payload (preserving whatever
+        ``agent``/``session_id``/``project_path``/``voice``/``pid`` the
+        current holder already wrote via ``acquire()``/``_write_locked_payload``)
+        rather than building a fresh one from scratch -- unlike ``write_hold()``,
+        which is called with no pre-existing holder payload to preserve. If no
+        lock file exists yet (called without an active hold), a minimal
+        self-contained marker is created instead of raising.
+
+        Also re-stamps the EXISTING ``expires`` field to this same deadline
+        (belt-and-suspenders, not just the new ``response_deadline`` field):
+        ``_hold_is_expired()`` (used by ``_check_and_clear_stale_lock()``'s
+        pre-existing timestamp-based clearance) reads ``expires`` first and
+        would otherwise fall back to ``acquired`` + the global
+        ``CONCH_HOLD_EXPIRY`` (10s default) -- silently deleting this marker
+        after only 10s if ``expires`` were left stale or unset, defeating the
+        whole point of a longer, explicit deadline. Stamping both fields to
+        the same value keeps the pre-existing stale-lock-clearance code path
+        aligned with the new one instead of racing it.
+        """
+        cls.LOCK_FILE.parent.mkdir(parents=True, exist_ok=True)
+        try:
+            data = json.loads(cls.LOCK_FILE.read_text())
+        except (json.JSONDecodeError, OSError, ValueError):
+            data = {}
+        now = datetime.now()
+        ttl = deadline_seconds if deadline_seconds and deadline_seconds > 0 else 300.0
+        deadline_iso = (now + timedelta(seconds=ttl)).isoformat()
+        data["pid"] = data.get("pid", os.getpid())
+        # FIX (independent audit, round 3): stamp a process-identity token
+        # alongside the pid so later same-process checks can't be fooled by
+        # pid reuse -- see _process_start_time()/_is_same_process() above.
+        # Only stamped when this call is the one ESTABLISHING the pid (i.e.
+        # no pre-existing pid_start_time in the file) -- if a payload already
+        # existed with a pid, its own start-time (if any) is preserved
+        # rather than overwritten, so a later re-stamp by the SAME original
+        # holder doesn't clobber it.
+        #
+        # FIX (independent audit, round 3, second pass -- MEDIUM finding):
+        # derive the start-time from data["pid"] (the pid actually being
+        # kept -- possibly PRESERVED from an existing payload written by a
+        # different process, e.g. via write_hold()), NOT from os.getpid()
+        # unconditionally. The earlier draft of this fix always used our own
+        # start-time even when the preserved pid belonged to someone else,
+        # which would make that OTHER, genuine holder fail its own later
+        # _is_same_process() check and get wrongly locked out of resuming --
+        # reproducing the exact "genuine holder can't resume" failure this
+        # whole mechanism exists to prevent, just via a different path.
+        if "pid_start_time" not in data:
+            data["pid_start_time"] = _process_start_time(data["pid"])
+        data.setdefault("agent", "unknown")
+        data.setdefault("session_id", None)
+        data.setdefault("project_path", None)
+        data.setdefault("voice", None)
+        data["acquired"] = now.isoformat()
+        data["held"] = True
+        data["expires"] = deadline_iso  # keeps _hold_is_expired() aligned -- see docstring
+        data["awaiting_human_response"] = True
+        data["response_deadline"] = deadline_iso
+        cls.LOCK_FILE.write_text(json.dumps(data, indent=2))
+
+    @classmethod
+    def awaiting_human_response_active(cls) -> Optional[dict]:
+        """ADDED (independent audit, round 2 -- CRITICAL finding): the correct,
+        unconditional way for a CALLER (e.g. converse.py's skip_conch guard)
+        to check "is a live awaiting_human_response state in effect right
+        now," mirroring the exact same check ``_held_by_other()`` already
+        uses internally -- NOT via ``get_holder()``/``is_active()``, which
+        depend on the ORIGINAL holder's pid still being alive and on the
+        unrelated ``CONCH_LOCK_EXPIRY`` staleness window. A dead holder or an
+        elapsed CONCH_LOCK_EXPIRY must NOT clear this state (see
+        ``_check_and_clear_stale_lock()``'s own guard for this same
+        reasoning) -- so a check built on ``is_active()`` silently stops
+        seeing the block at exactly the moment (a crashed questioning
+        process, or a long wait outliving the lock-staleness window) Theme 8
+        most needs to hold. Returns the lock-file payload dict while the
+        state is genuinely active (deadline not yet passed), else None --
+        deliberately NOT gated on pid liveness, matching the priority-
+        override semantics ``_held_by_other()`` already documents.
+
+        Returns None (not blocking) if the CURRENT process is itself the
+        holder that set this state -- mirrors ``_held_by_other()``'s own
+        exemption (verified via ``_is_same_process()``, round 3 -- NOT a
+        bare pid comparison, which pid reuse can fool), so the original
+        holder can resume once Mike answers.
+        """
+        try:
+            data = json.loads(cls.LOCK_FILE.read_text())
+        except (json.JSONDecodeError, OSError, ValueError):
+            return None
+        if not data.get("awaiting_human_response"):
+            return None
+        if _response_deadline_passed(data):
+            return None
+        if _is_same_process(data):
+            return None
+        return data
+
+    @classmethod
+    def resolve_awaiting_human_response(cls) -> bool:
+        """ADDED (independent audit, round 2 -- HIGH finding): explicit resume
+        path for once Mike has actually answered. Without this, nothing in
+        the original patch ever cleared ``awaiting_human_response`` on the
+        early-approved path -- design doc §2.1 item 5 only specified the
+        TIMEOUT-denial case (the caller's approval_queue-expiry composition),
+        leaving no way to resume immediately after a real, on-time answer
+        other than waiting out the full response_deadline. Unlinks the lock
+        file entirely (same effect as a normal ``release()``) so the next
+        ``try_acquire()`` -- by the original holder resuming, or by any other
+        process -- starts clean. Best-effort: a missing file is not an error
+        (nothing to resolve). Returns True if a file was actually removed.
+
+        FIX (independent audit, round 3 -- MEDIUM finding): added a
+        precondition guard -- this must never unlink a lock file that ISN'T
+        currently in the awaiting_human_response state. Without this guard,
+        calling it while an unrelated, genuinely active conversation holds
+        the file (e.g. the original holder already auto-resumed and is now
+        speaking normally) would delete THAT live holder's entry out from
+        under it -- the exact "stale flock on an unlinked inode" foot-gun
+        ``release()`` itself already guards against via its own ownership
+        check. No caller currently invokes this method (confirmed via grep
+        across this patch and the real approval_queue.py -- wiring it into
+        the actual approve/resolve flow is a SEPARATE, future integration
+        step per design doc §2.3/§3, not part of this patch), so this guard
+        only matters once something does call it -- but it must be correct
+        from the moment it has its first real caller, not retrofitted later.
+        """
+        try:
+            data = json.loads(cls.LOCK_FILE.read_text())
+        except (json.JSONDecodeError, OSError, ValueError):
+            return False
+        if not data.get("awaiting_human_response"):
+            return False
+        try:
+            cls.LOCK_FILE.unlink()
+            return True
+        except FileNotFoundError:
+            return False
+        except OSError:
+            return False
 
     def acquire(
         self,
@@ -407,6 +681,24 @@ class Conch:
         try:
             data = json.loads(self.LOCK_FILE.read_text())
         except (json.JSONDecodeError, OSError):
+            return
+
+        # NECESSARY ADDITION (discovered during Theme 8 implementation, not
+        # one of the design doc's 4 literal patch items -- documented here
+        # and in the scratch-dir report): a live awaiting_human_response
+        # state must never be cleared by this method's pre-existing
+        # dead-pid-fast-fail or timestamp-based paths below, even though
+        # neither knows about the new field. Without this guard, the very
+        # "process died mid-wait" scenario Theme 8/9 exists to handle safely
+        # would instead hit the dead-pid fast-fail path a few lines down and
+        # get unlinked immediately -- silently defeating _held_by_other()'s
+        # new "unconditional... regardless of pid" branch above, since
+        # try_acquire() calls this method BEFORE it ever consults
+        # _held_by_other(). Deferring cleanup to the caller's own
+        # approval_queue-driven expiry (design doc §2.1 item 5) requires
+        # this method to also leave the marker alone until its own
+        # response_deadline passes.
+        if data.get("awaiting_human_response") and not _response_deadline_passed(data):
             return
 
         # Fast-fail on dead holder -- no need to wait for timestamp expiry.

--- a/voice_mode/conch.py
+++ b/voice_mode/conch.py
@@ -129,42 +129,39 @@ def _response_deadline_passed(data: dict) -> bool:
 
 def _process_start_time(pid: int) -> Optional[str]:
     """FIX (independent audit, round 3 -- MEDIUM finding): a pid NUMBER
-    alone is not a reliable process identity on Linux -- pids are reused.
-    Scenario the audit found: process A calls mark_awaiting_human_response()
-    then crashes; within the still-live response_deadline window (up to
-    300s by default), the OS reassigns A's old pid to a completely
-    unrelated process B; B's own awaiting_human_response_active()/
-    _held_by_other() check would then see ``pid == os.getpid()`` and
-    wrongly treat itself as "the original holder," silently exempting
-    itself from the very safety gate Theme 8/9 exist to enforce.
+    alone is not a reliable process identity -- pids are reused. Scenario
+    the audit found: process A calls mark_awaiting_human_response() then
+    crashes; within the still-live response_deadline window (up to 300s by
+    default), the OS reassigns A's old pid to a completely unrelated
+    process B; B's own awaiting_human_response_active()/_held_by_other()
+    check would then see ``pid == os.getpid()`` and wrongly treat itself as
+    "the original holder," silently exempting itself from the very safety
+    gate Theme 8/9 exist to enforce.
 
-    Reads /proc/<pid>/stat's ``starttime`` field (ticks since boot) as an
-    opaque, monotonically-assigned identity token that a pid alone can't
-    provide -- two DIFFERENT processes essentially never share both the
-    same pid AND the same start tick. Combined with the pid itself (see
-    call sites), this reliably distinguishes "truly the same process" from
-    "a different process that happens to have the inherited pid number."
+    Uses ``psutil.Process(pid).create_time()`` (seconds since epoch, at
+    float precision) as an opaque, monotonically-assigned identity token
+    that a pid alone can't provide -- two DIFFERENT processes essentially
+    never share both the same pid AND the same create_time. Combined with
+    the pid itself (see call sites), this reliably distinguishes "truly the
+    same process" from "a different process that happens to have the
+    inherited pid number." Portable across platforms (Windows/macOS/Linux),
+    matching this module's existing psutil-based liveness probes elsewhere
+    (``_held_by_other()``, ``_check_and_clear_stale_lock()``, ``is_active()``)
+    -- unlike an earlier draft of this function, which read Linux-only
+    ``/proc/<pid>/stat`` and silently returned None (failing the same-
+    process exemption closed) on every other platform, including the
+    Windows-native path this file's own liveness probes were already made
+    portable for.
 
-    Returns None if unavailable (process gone, /proc missing/malformed --
-    e.g. non-Linux, though this module already requires Unix via
-    ``import fcntl`` at the top of the file, so /proc is expected to exist
-    in practice). Callers MUST treat None as "cannot verify" and fail
-    CLOSED (i.e. do NOT grant a same-process exemption) rather than
+    Returns None if unavailable (process gone, permission denied, or a
+    malformed/negative pid). Callers MUST treat None as "cannot verify" and
+    fail CLOSED (i.e. do NOT grant a same-process exemption) rather than
     silently falling back to a pid-only comparison, which is exactly the
     weaker check this function exists to replace.
     """
     try:
-        with open(f"/proc/{pid}/stat", "r") as f:
-            content = f.read()
-        # comm (field 2) is parenthesized and may itself contain ')' or
-        # whitespace -- split on the LAST ')' to reliably locate the start
-        # of the remaining whitespace-separated fields (field 3 = state).
-        after_comm = content.rsplit(")", 1)[1]
-        fields = after_comm.split()
-        # fields[0] is field 3 (state); starttime is field 22, i.e. 19
-        # further along from state (3 + 19 = 22).
-        return fields[19]
-    except (OSError, IndexError, ValueError):
+        return str(psutil.Process(pid).create_time())
+    except (psutil.NoSuchProcess, psutil.AccessDenied, psutil.ZombieProcess, ValueError):
         return None
 
 

--- a/voice_mode/conch.py
+++ b/voice_mode/conch.py
@@ -101,18 +101,17 @@ def _hold_is_expired(data: dict) -> bool:
 
 def _response_deadline_passed(data: dict) -> bool:
     """True if an ``awaiting_human_response`` payload has passed its own
-    explicit ``response_deadline`` (Theme 8, added
-    docs/KB/phase2-3-4-design-2026-07-14.md §2.1).
+    explicit ``response_deadline``.
 
     Mirrors ``_hold_is_expired()`` above, but this new state has exactly
     ONE timeout source -- the absolute ``response_deadline`` stamped by
     ``Conch.mark_awaiting_human_response()`` -- deliberately NOT the normal
     hold-expiry TTL (``CONCH_HOLD_EXPIRY``/``expires``) or the flock-lock
     staleness window (``CONCH_LOCK_EXPIRY``). A SEPARATE function from
-    ``_hold_is_expired()`` on purpose, so a live safety-relevant wait for a
-    human reply is never accidentally coupled to the normal 10s hold-expiry
-    default -- that's the entire point of the new state (Theme 8: "exempt
-    from refresh-TTL").
+    ``_hold_is_expired()`` on purpose, so a live wait for a human reply is
+    never accidentally coupled to the normal 10s hold-expiry default -- the
+    whole state is exempt from that refresh-TTL, since a real human
+    decision can take much longer than a between-turns idle window.
 
     Returns False (not passed / still live) when ``response_deadline`` is
     missing or malformed -- same reasoning as ``_hold_is_expired()``: an
@@ -128,15 +127,15 @@ def _response_deadline_passed(data: dict) -> bool:
 
 
 def _process_start_time(pid: int) -> Optional[str]:
-    """FIX (independent audit, round 3 -- MEDIUM finding): a pid NUMBER
-    alone is not a reliable process identity -- pids are reused. Scenario
-    the audit found: process A calls mark_awaiting_human_response() then
-    crashes; within the still-live response_deadline window (up to 300s by
-    default), the OS reassigns A's old pid to a completely unrelated
-    process B; B's own awaiting_human_response_active()/_held_by_other()
-    check would then see ``pid == os.getpid()`` and wrongly treat itself as
-    "the original holder," silently exempting itself from the very safety
-    gate Theme 8/9 exist to enforce.
+    """A pid NUMBER alone is not a reliable process identity -- pids are
+    reused. Scenario this guards against: process A calls
+    mark_awaiting_human_response() then crashes; within the still-live
+    response_deadline window (up to 300s by default), the OS reassigns A's
+    old pid to a completely unrelated process B; B's own
+    awaiting_human_response_active()/_held_by_other() check would then see
+    ``pid == os.getpid()`` and wrongly treat itself as "the original
+    holder," silently exempting itself from the safety gate this state
+    exists to enforce.
 
     Uses ``psutil.Process(pid).create_time()`` (seconds since epoch, at
     float precision) as an opaque, monotonically-assigned identity token
@@ -304,30 +303,26 @@ class Conch:
             data = json.loads(cls.LOCK_FILE.read_text())
         except (json.JSONDecodeError, OSError, ValueError):
             return False
-        # A live awaiting_human_response state is a PRIORITY OVERRIDE (Theme
-        # 8): it blocks ALL OTHER processes' floor-acquisition attempts
+        # A live awaiting_human_response state is a PRIORITY OVERRIDE: it
+        # blocks ALL OTHER processes' floor-acquisition attempts
         # unconditionally -- regardless of ``held``, regardless of whether
         # the original holder's pid is even still alive -- until its own
-        # explicit response_deadline passes. The ORIGINAL holder's own pid is
-        # exempt (see the check below) so it can resume the instant Mike
-        # answers, mirroring the normal ``held`` path's own pid exemption.
-        # Checked first, ahead of (and independent of) the normal held/pid-
-        # liveness path below: a dropped call's cleanup is the CALLER's job
-        # (Thessary's approval_queue.py expiry composes with this same
-        # deadline), not a pid-liveness check here (design doc §2.1 item 5)
-        # -- conch itself has no concept of Thessary's approval queue and
-        # shouldn't gain one.
-        # FIX (independent audit, round 2): exempt the ORIGINAL holder's own
-        # process from this block, mirroring the normal ``held`` path's own
-        # pid exemption immediately below. Without this, the same process
-        # that called mark_awaiting_human_response() could never re-acquire
-        # even the instant Mike answers -- there was no resume path at all.
-        # FIX (independent audit, round 3): "own process" is verified via
-        # _is_same_process() (pid + /proc start-time), NOT a bare pid
-        # comparison -- a bare `pid == os.getpid()` check is fooled by pid
-        # reuse (a crashed original holder's pid reassigned to an unrelated
-        # process within the still-live response_deadline window), which
-        # would silently exempt that unrelated process from the safety gate.
+        # explicit response_deadline passes. The ORIGINAL holder's own
+        # process is exempt (see the check below) so it can resume the
+        # instant the human answers, mirroring the normal ``held`` path's
+        # own pid exemption. Checked first, ahead of (and independent of)
+        # the normal held/pid-liveness path below: a dropped call's cleanup
+        # is the CALLER's job (e.g. an external approval-queue's own
+        # expiry, composed via the same response_deadline value), not a
+        # pid-liveness check here -- conch itself has no concept of any
+        # particular caller's approval mechanism and shouldn't gain one.
+        #
+        # The "own process" exemption is verified via _is_same_process()
+        # (pid + process-start-time), NOT a bare pid comparison -- a bare
+        # `pid == os.getpid()` check is fooled by pid reuse (a crashed
+        # original holder's pid reassigned to an unrelated process within
+        # the still-live response_deadline window), which would silently
+        # exempt that unrelated process from the safety gate.
         if (
             data.get("awaiting_human_response")
             and not _response_deadline_passed(data)
@@ -394,21 +389,21 @@ class Conch:
 
     @classmethod
     def mark_awaiting_human_response(cls, deadline_seconds: float = 300.0) -> None:
-        """Re-stamp the lock file into the ``awaiting_human_response`` state
-        (Theme 8, docs/KB/phase2-3-4-design-2026-07-14.md §2.1) -- a live,
-        safety-relevant decision is pending a human reply. Called by the
-        CURRENT flock holder just before it yields the floor to wait; mirrors
-        ``write_hold()`` above in that it does NOT take the kernel flock (same
-        reasoning: this must not self-deadlock the same process's own later
-        ``try_acquire``).
+        """Re-stamp the lock file into the ``awaiting_human_response`` state --
+        a live decision is pending a human reply and must block other
+        acquirers unconditionally until it resolves or times out. Called by
+        the CURRENT flock holder just before it yields the floor to wait;
+        mirrors ``write_hold()`` above in that it does NOT take the kernel
+        flock (same reasoning: this must not self-deadlock the same
+        process's own later ``try_acquire``).
 
         Unlike a normal between-turns hold, this state is deliberately EXEMPT
         from the standard ``CONCH_HOLD_EXPIRY`` idle-refresh window (a real
         decision can take longer than 10s) -- it carries its own, explicit,
         absolute ``response_deadline`` (now + ``deadline_seconds``), read by
         ``_response_deadline_passed()`` above, a SEPARATE staleness function
-        from ``_hold_is_expired()`` on purpose (Theme 8: "exempt from
-        refresh-TTL", never accidentally coupled to the normal hold default).
+        from ``_hold_is_expired()`` on purpose so it's never accidentally
+        coupled to the normal hold default.
 
         This RE-STAMPS the existing lock-file payload (preserving whatever
         ``agent``/``session_id``/``project_path``/``voice``/``pid`` the
@@ -438,25 +433,21 @@ class Conch:
         ttl = deadline_seconds if deadline_seconds and deadline_seconds > 0 else 300.0
         deadline_iso = (now + timedelta(seconds=ttl)).isoformat()
         data["pid"] = data.get("pid", os.getpid())
-        # FIX (independent audit, round 3): stamp a process-identity token
-        # alongside the pid so later same-process checks can't be fooled by
-        # pid reuse -- see _process_start_time()/_is_same_process() above.
-        # Only stamped when this call is the one ESTABLISHING the pid (i.e.
-        # no pre-existing pid_start_time in the file) -- if a payload already
-        # existed with a pid, its own start-time (if any) is preserved
-        # rather than overwritten, so a later re-stamp by the SAME original
-        # holder doesn't clobber it.
+        # Stamp a process-identity token alongside the pid so later
+        # same-process checks can't be fooled by pid reuse -- see
+        # _process_start_time()/_is_same_process() above. Only stamped when
+        # this call is the one ESTABLISHING the pid (i.e. no pre-existing
+        # pid_start_time in the file) -- if a payload already existed with a
+        # pid, its own start-time (if any) is preserved rather than
+        # overwritten, so a later re-stamp by the SAME original holder
+        # doesn't clobber it.
         #
-        # FIX (independent audit, round 3, second pass -- MEDIUM finding):
-        # derive the start-time from data["pid"] (the pid actually being
-        # kept -- possibly PRESERVED from an existing payload written by a
-        # different process, e.g. via write_hold()), NOT from os.getpid()
-        # unconditionally. The earlier draft of this fix always used our own
-        # start-time even when the preserved pid belonged to someone else,
-        # which would make that OTHER, genuine holder fail its own later
-        # _is_same_process() check and get wrongly locked out of resuming --
-        # reproducing the exact "genuine holder can't resume" failure this
-        # whole mechanism exists to prevent, just via a different path.
+        # Derived from data["pid"] (the pid actually being kept -- possibly
+        # PRESERVED from an existing payload written by a different process,
+        # e.g. via write_hold()), NOT from os.getpid() unconditionally:
+        # always using our own start-time here would make that OTHER,
+        # genuine holder fail its own later _is_same_process() check and get
+        # wrongly locked out of resuming.
         if "pid_start_time" not in data:
             data["pid_start_time"] = _process_start_time(data["pid"])
         data.setdefault("agent", "unknown")
@@ -472,28 +463,28 @@ class Conch:
 
     @classmethod
     def awaiting_human_response_active(cls) -> Optional[dict]:
-        """ADDED (independent audit, round 2 -- CRITICAL finding): the correct,
-        unconditional way for a CALLER (e.g. converse.py's skip_conch guard)
-        to check "is a live awaiting_human_response state in effect right
-        now," mirroring the exact same check ``_held_by_other()`` already
-        uses internally -- NOT via ``get_holder()``/``is_active()``, which
-        depend on the ORIGINAL holder's pid still being alive and on the
-        unrelated ``CONCH_LOCK_EXPIRY`` staleness window. A dead holder or an
-        elapsed CONCH_LOCK_EXPIRY must NOT clear this state (see
+        """The correct, unconditional way for a CALLER (e.g. converse.py's
+        skip_conch guard) to check "is a live awaiting_human_response state
+        in effect right now" -- mirrors the exact same check
+        ``_held_by_other()`` already uses internally -- NOT via
+        ``get_holder()``/``is_active()``, which depend on the ORIGINAL
+        holder's pid still being alive and on the unrelated
+        ``CONCH_LOCK_EXPIRY`` staleness window. A dead holder or an elapsed
+        CONCH_LOCK_EXPIRY must NOT clear this state (see
         ``_check_and_clear_stale_lock()``'s own guard for this same
-        reasoning) -- so a check built on ``is_active()`` silently stops
-        seeing the block at exactly the moment (a crashed questioning
-        process, or a long wait outliving the lock-staleness window) Theme 8
-        most needs to hold. Returns the lock-file payload dict while the
-        state is genuinely active (deadline not yet passed), else None --
-        deliberately NOT gated on pid liveness, matching the priority-
+        reasoning) -- so a check built on ``is_active()`` would silently
+        stop seeing the block at exactly the moment (a crashed questioning
+        process, or a long wait outliving the lock-staleness window) this
+        state most needs to hold. Returns the lock-file payload dict while
+        the state is genuinely active (deadline not yet passed), else None
+        -- deliberately NOT gated on pid liveness, matching the priority-
         override semantics ``_held_by_other()`` already documents.
 
         Returns None (not blocking) if the CURRENT process is itself the
         holder that set this state -- mirrors ``_held_by_other()``'s own
-        exemption (verified via ``_is_same_process()``, round 3 -- NOT a
-        bare pid comparison, which pid reuse can fool), so the original
-        holder can resume once Mike answers.
+        exemption (verified via ``_is_same_process()``, NOT a bare pid
+        comparison, which pid reuse can fool), so the original holder can
+        resume once the human has answered.
         """
         try:
             data = json.loads(cls.LOCK_FILE.read_text())
@@ -509,32 +500,32 @@ class Conch:
 
     @classmethod
     def resolve_awaiting_human_response(cls) -> bool:
-        """ADDED (independent audit, round 2 -- HIGH finding): explicit resume
-        path for once Mike has actually answered. Without this, nothing in
-        the original patch ever cleared ``awaiting_human_response`` on the
-        early-approved path -- design doc §2.1 item 5 only specified the
-        TIMEOUT-denial case (the caller's approval_queue-expiry composition),
-        leaving no way to resume immediately after a real, on-time answer
-        other than waiting out the full response_deadline. Unlinks the lock
-        file entirely (same effect as a normal ``release()``) so the next
-        ``try_acquire()`` -- by the original holder resuming, or by any other
-        process -- starts clean. Best-effort: a missing file is not an error
-        (nothing to resolve). Returns True if a file was actually removed.
+        """Explicit resume path for once the human has actually answered
+        early. Without this, nothing clears ``awaiting_human_response`` on
+        an early-approved path -- the same-process exemption in
+        ``_held_by_other()`` only lets the ORIGINAL holder resume; a
+        caller that wants to resolve the state (e.g. so a DIFFERENT process
+        or a fresh acquirer can proceed immediately) needs an explicit
+        clear, rather than waiting out the full response_deadline. Unlinks
+        the lock file entirely (same effect as a normal ``release()``) so
+        the next ``try_acquire()`` -- by the original holder resuming, or by
+        any other process -- starts clean. Best-effort: a missing file is
+        not an error (nothing to resolve). Returns True if a file was
+        actually removed.
 
-        FIX (independent audit, round 3 -- MEDIUM finding): added a
-        precondition guard -- this must never unlink a lock file that ISN'T
-        currently in the awaiting_human_response state. Without this guard,
-        calling it while an unrelated, genuinely active conversation holds
-        the file (e.g. the original holder already auto-resumed and is now
-        speaking normally) would delete THAT live holder's entry out from
-        under it -- the exact "stale flock on an unlinked inode" foot-gun
-        ``release()`` itself already guards against via its own ownership
-        check. No caller currently invokes this method (confirmed via grep
-        across this patch and the real approval_queue.py -- wiring it into
-        the actual approve/resolve flow is a SEPARATE, future integration
-        step per design doc §2.3/§3, not part of this patch), so this guard
-        only matters once something does call it -- but it must be correct
-        from the moment it has its first real caller, not retrofitted later.
+        Guarded by a precondition: this must never unlink a lock file that
+        ISN'T currently in the awaiting_human_response state. Without this
+        guard, calling it while an unrelated, genuinely active conversation
+        holds the file (e.g. the original holder already auto-resumed and
+        is now speaking normally) would delete THAT live holder's entry out
+        from under it -- the exact "stale flock on an unlinked inode"
+        foot-gun ``release()`` itself already guards against via its own
+        ownership check.
+
+        No caller in this module invokes this method today -- it is a
+        primitive for whatever wires the human-response event (e.g. an
+        approval workflow) into conch, exposed here so that integration
+        doesn't need its own lock-file-unlink logic.
         """
         try:
             data = json.loads(cls.LOCK_FILE.read_text())
@@ -680,21 +671,17 @@ class Conch:
         except (json.JSONDecodeError, OSError):
             return
 
-        # NECESSARY ADDITION (discovered during Theme 8 implementation, not
-        # one of the design doc's 4 literal patch items -- documented here
-        # and in the scratch-dir report): a live awaiting_human_response
-        # state must never be cleared by this method's pre-existing
-        # dead-pid-fast-fail or timestamp-based paths below, even though
-        # neither knows about the new field. Without this guard, the very
-        # "process died mid-wait" scenario Theme 8/9 exists to handle safely
-        # would instead hit the dead-pid fast-fail path a few lines down and
-        # get unlinked immediately -- silently defeating _held_by_other()'s
-        # new "unconditional... regardless of pid" branch above, since
-        # try_acquire() calls this method BEFORE it ever consults
-        # _held_by_other(). Deferring cleanup to the caller's own
-        # approval_queue-driven expiry (design doc §2.1 item 5) requires
-        # this method to also leave the marker alone until its own
-        # response_deadline passes.
+        # A live awaiting_human_response state must never be cleared by this
+        # method's pre-existing dead-pid-fast-fail or timestamp-based paths
+        # below, even though neither knows about the new field. Without this
+        # guard, the "process died mid-wait" scenario this state exists to
+        # handle safely would instead hit the dead-pid fast-fail path a few
+        # lines down and get unlinked immediately -- silently defeating
+        # _held_by_other()'s "unconditional... regardless of pid" branch
+        # above, since try_acquire() calls this method BEFORE it ever
+        # consults _held_by_other(). Deferring cleanup to the caller's own
+        # response-driven expiry requires this method to also leave the
+        # marker alone until its own response_deadline passes.
         if data.get("awaiting_human_response") and not _response_deadline_passed(data):
             return
 

--- a/voice_mode/tools/converse.py
+++ b/voice_mode/tools/converse.py
@@ -3333,23 +3333,21 @@ consult the MCP resources listed above.
     wait_mode_registered = False
 
     try:
-        # Theme 8 (docs/KB/phase2-3-4-design-2026-07-14.md §2.1 item 4): a live
-        # awaiting_human_response state makes skip_conch a HARD no-op -- it
-        # must never be possible to talk over a pending safety confirmation,
-        # no matter what the caller passed.
+        # A live awaiting_human_response state makes skip_conch a HARD
+        # no-op -- it must never be possible to talk over a pending safety
+        # confirmation, no matter what the caller passed.
         #
-        # FIX (independent audit, round 2 -- CRITICAL finding): this
-        # previously checked via Conch.get_holder(), which depends on
-        # is_active()'s pid-liveness + CONCH_LOCK_EXPIRY staleness check --
-        # NEITHER of which the awaiting_human_response mechanism is supposed
-        # to be governed by (design doc §2.1: "exempt from refresh-TTL," and
-        # Theme 9's whole point is the dropped-call/crashed-process case).
-        # Empirically reproduced: a dead holder pid or an elapsed
-        # CONCH_LOCK_EXPIRY made get_holder() return None, silently letting
+        # This deliberately checks Conch.awaiting_human_response_active(),
+        # NOT Conch.get_holder(): get_holder() depends on is_active()'s
+        # pid-liveness + CONCH_LOCK_EXPIRY staleness check, neither of which
+        # the awaiting_human_response mechanism is governed by (it's exempt
+        # from the refresh-TTL, precisely to handle a dropped-call/crashed-
+        # process case). A dead holder pid or an elapsed CONCH_LOCK_EXPIRY
+        # would make get_holder() return None, silently letting
         # skip_conch=True bypass a still-live safety confirmation -- exactly
-        # backwards from the intent. Now checks via the dedicated, pid-
-        # liveness-independent Conch.awaiting_human_response_active(), which
-        # mirrors _held_by_other()'s own unconditional semantics exactly.
+        # backwards from the intent. awaiting_human_response_active() is
+        # pid-liveness-independent and mirrors _held_by_other()'s own
+        # unconditional semantics exactly.
         if CONCH_ENABLED and skip_conch:
             if Conch.awaiting_human_response_active() is not None:
                 skip_conch = False

--- a/voice_mode/tools/converse.py
+++ b/voice_mode/tools/converse.py
@@ -3333,6 +3333,27 @@ consult the MCP resources listed above.
     wait_mode_registered = False
 
     try:
+        # Theme 8 (docs/KB/phase2-3-4-design-2026-07-14.md §2.1 item 4): a live
+        # awaiting_human_response state makes skip_conch a HARD no-op -- it
+        # must never be possible to talk over a pending safety confirmation,
+        # no matter what the caller passed.
+        #
+        # FIX (independent audit, round 2 -- CRITICAL finding): this
+        # previously checked via Conch.get_holder(), which depends on
+        # is_active()'s pid-liveness + CONCH_LOCK_EXPIRY staleness check --
+        # NEITHER of which the awaiting_human_response mechanism is supposed
+        # to be governed by (design doc §2.1: "exempt from refresh-TTL," and
+        # Theme 9's whole point is the dropped-call/crashed-process case).
+        # Empirically reproduced: a dead holder pid or an elapsed
+        # CONCH_LOCK_EXPIRY made get_holder() return None, silently letting
+        # skip_conch=True bypass a still-live safety confirmation -- exactly
+        # backwards from the intent. Now checks via the dedicated, pid-
+        # liveness-independent Conch.awaiting_human_response_active(), which
+        # mirrors _held_by_other()'s own unconditional semantics exactly.
+        if CONCH_ENABLED and skip_conch:
+            if Conch.awaiting_human_response_active() is not None:
+                skip_conch = False
+
         # Try to acquire conch atomically (no race condition)
         # skip_conch=true bypasses coordination entirely: don't acquire, don't
         # check the holder, don't release. Speak regardless of who else has it.


### PR DESCRIPTION
## Summary

Adds a new Conch lock-file state, `awaiting_human_response`, for the case where a voice-conversation turn is blocked on a pending human confirmation (e.g. an agent asking the user to approve a risky action) rather than an ordinary between-turns hold.

Unlike a normal hold, this state:
- Is a **priority override** in `_held_by_other()`: it blocks all other processes' floor-acquisition attempts unconditionally, even if the original holder's pid has died — cleanup on drop/crash is left to the caller (e.g. an approval-queue's own expiry), not a pid-liveness check here.
- Is **exempt from the normal `CONCH_HOLD_EXPIRY` idle-refresh window**, since a real human decision can take much longer than a between-turns refresh; it carries its own explicit `response_deadline` instead.
- **Exempts the original holder's own process** (verified via pid + process-start-time, not a bare pid comparison, since pid alone is not a reliable identity across process death/reuse) so it can resume the instant the human responds.

New `Conch` classmethods: `mark_awaiting_human_response()` (enter the state), `awaiting_human_response_active()` (the pid-liveness-independent way to check whether the state is currently blocking), and `resolve_awaiting_human_response()` (explicit resume path for an early "yes" rather than waiting out the full deadline).

`_check_and_clear_stale_lock()` gets a matching guard so its existing dead-pid fast-fail path can't silently clear a live `awaiting_human_response` marker out from under this new mechanism. In `converse()`, `skip_conch=True` is now a hard no-op while `awaiting_human_response_active()` is set — it must never be possible to talk over a pending confirmation, no matter what the caller passed.

A payload with no `awaiting_human_response` key at all (every existing lock file today) hits none of the new branches — fully backward compatible with the current two-state (`held` True/False) shape.

**Note on current scope:** `mark_awaiting_human_response()`/`resolve_awaiting_human_response()` have no caller in this repo yet — this PR adds the primitive and its guard-side enforcement (the `converse()` skip_conch check), for a caller (e.g. an external approval/confirmation flow) to invoke going forward. Happy to adjust the framing or narrow this PR if you'd rather see it land alongside an actual call site.

**Cross-platform fix included:** the process-identity check backing the "original holder can resume" exemption was drafted against `/proc/<pid>/stat` (Linux-only) and silently failed closed on every other platform — including Windows, which the rest of this file already supports via `psutil`/`voice_mode.file_lock`. Switched to `psutil.Process(pid).create_time()`, which is portable and matches this module's existing liveness probes.

Verified no overlap with VM-1967 (this branch is on top of it) — the new code touches a different guard than the `ConchQueue` deadlock fix.

## Test plan

- [x] New `tests/test_conch_awaiting_human_response.py` (35 tests) covering: normal hold/acquire regression, the new state's block/exempt/expire semantics, the `converse.py` skip_conch guard (extracted from real source and exercised directly), pid-reuse protection, and the resolve-guard's precondition.
- [x] All existing conch/converse suites still pass alongside it: `test_conch.py`, `test_conch_cli.py`, `test_conch_mcp.py`, `test_conch_notify.py`, `test_conch_queue.py`, `test_converse_conch_queue.py`, `test_converse_skip_conch.py`, `test_vm1967_conch_deadlock_repro.py` — 259/259 total, run locally on native Windows (not just WSL, confirming the cross-platform fix).