### PR TITLE
fix: decouple microphone recording rate from TTS sample rate

### DIFF
--- a/docs/.archive/troubleshooting/wsl2-microphone-access.md
+++ b/docs/.archive/troubleshooting/wsl2-microphone-access.md
@@ -221,8 +221,8 @@ export VOICEMODE_INPUT_DEVICE=0
 # Increase audio buffer size
 export VOICEMODE_AUDIO_BUFFER_SIZE=4096
 
-# Use different sample rate
-export VOICEMODE_SAMPLE_RATE=16000
+# Use different microphone recording rate (decoupled from TTS playback)
+export VOICEMODE_RECORDING_SAMPLE_RATE=16000
 
 # Enable verbose audio debugging
 export VOICEMODE_DEBUG=true

--- a/docs/guides/configuration.md
+++ b/docs/guides/configuration.md
@@ -140,7 +140,11 @@ VOICEMODE_STT_AUDIO_FORMAT=mp3      # STT-specific
 VOICEMODE_OPUS_BITRATE=32000        # Opus bitrate (bps)
 VOICEMODE_MP3_BITRATE=64k           # MP3 bitrate
 VOICEMODE_AAC_BITRATE=64k           # AAC bitrate
-VOICEMODE_SAMPLE_RATE=24000         # Sample rate (Hz)
+
+# Microphone recording rate (independent of TTS, which is fixed at 24kHz).
+# Set this to your mic's native rate (e.g. 44100 or 48000) if recordings
+# sound wrong -- see https://github.com/mbailey/voicemode/issues/491
+VOICEMODE_RECORDING_SAMPLE_RATE=24000
 ```
 
 ### Audio Feedback

--- a/docs/reference/environment.md
+++ b/docs/reference/environment.md
@@ -120,10 +120,19 @@ Supported formats: `pcm`, `opus`, `mp3`, `wav`, `flac`, `aac`
 
 | Variable | Description | Default | Example |
 |----------|-------------|---------|---------|
-| `VOICEMODE_SAMPLE_RATE` | Sample rate in Hz | `24000` | `48000` |
+| `VOICEMODE_RECORDING_SAMPLE_RATE` | Microphone capture rate in Hz | `24000` | `48000` |
 | `VOICEMODE_OPUS_BITRATE` | Opus bitrate in bps | `32000` | `64000` |
 | `VOICEMODE_MP3_BITRATE` | MP3 bitrate | `64k` | `128k` |
 | `VOICEMODE_AAC_BITRATE` | AAC bitrate | `64k` | `96k` |
+
+`VOICEMODE_RECORDING_SAMPLE_RATE` controls only microphone recording, decoupled from
+TTS/playback (fixed at 24kHz). If recordings sound corrupted, sped up, or slowed down,
+set this to your microphone's native sample rate (commonly `44100` or `48000` for USB
+mics) rather than leaving it at the TTS default. See
+[issue #491](https://github.com/mbailey/voicemode/issues/491).
+
+There is no `VOICEMODE_SAMPLE_RATE` variable — TTS playback rate is fixed and not
+independently configurable.
 
 ### Audio Feedback
 

--- a/tests/test_recording_sample_rate_config.py
+++ b/tests/test_recording_sample_rate_config.py
@@ -1,0 +1,44 @@
+#!/usr/bin/env python
+"""
+Test that microphone recording rate is decoupled from TTS playback rate.
+
+See https://github.com/mbailey/voicemode/issues/491 -- SAMPLE_RATE (24000, tuned for
+TTS/playback) was also used as the *microphone capture* rate everywhere, with no way to
+override it independently. On hardware whose native rate differs (e.g. many USB mics are
+44.1kHz/48kHz-native, never 24kHz), some audio backends resample transparently and some do
+not, producing corrupted/aliased recordings. RECORDING_SAMPLE_RATE defaults to SAMPLE_RATE
+(no behavior change) but can be overridden independently via VOICEMODE_RECORDING_SAMPLE_RATE.
+"""
+
+import importlib
+
+
+class TestRecordingSampleRateConfig:
+    def test_recording_sample_rate_defaults_to_sample_rate(self):
+        """With no override, RECORDING_SAMPLE_RATE must equal SAMPLE_RATE -- zero behavior change."""
+        import voice_mode.config as config
+        importlib.reload(config)
+
+        assert config.RECORDING_SAMPLE_RATE == config.SAMPLE_RATE
+        assert config.SAMPLE_RATE == 24000
+
+    def test_recording_sample_rate_override_is_decoupled_from_tts_rate(self, monkeypatch):
+        """Overriding VOICEMODE_RECORDING_SAMPLE_RATE must NOT change the TTS SAMPLE_RATE."""
+        monkeypatch.setenv("VOICEMODE_RECORDING_SAMPLE_RATE", "48000")
+
+        import voice_mode.config as config
+        importlib.reload(config)
+
+        try:
+            assert config.RECORDING_SAMPLE_RATE == 48000
+            assert config.SAMPLE_RATE == 24000, "TTS sample rate must be unaffected by the override"
+        finally:
+            monkeypatch.delenv("VOICEMODE_RECORDING_SAMPLE_RATE", raising=False)
+            importlib.reload(config)
+
+    def test_module_reload_restores_default_after_override_cleared(self):
+        """Sanity check on the reload-based test pattern itself: after clearing the env var and
+        reloading again, we're back to the unchanged-default state (no test pollution)."""
+        import voice_mode.config as config
+        importlib.reload(config)
+        assert config.RECORDING_SAMPLE_RATE == config.SAMPLE_RATE

--- a/tests/test_recording_sample_rate_prepare_audio.py
+++ b/tests/test_recording_sample_rate_prepare_audio.py
@@ -1,0 +1,96 @@
+#!/usr/bin/env python
+"""
+Test that prepare_audio_for_stt() and record_audio() honor RECORDING_SAMPLE_RATE
+(not the TTS SAMPLE_RATE) -- see tests/test_recording_sample_rate_config.py for
+background on why this is decoupled (issue #491).
+"""
+
+import io
+import wave
+from unittest.mock import patch
+
+import numpy as np
+import pytest
+
+from voice_mode.tools import converse as converse_module
+from voice_mode.tools.converse import prepare_audio_for_stt, record_audio
+
+
+class TestPrepareAudioForSttHonorsRecordingRate:
+    def test_wav_export_uses_overridden_recording_rate_not_tts_rate(self, monkeypatch):
+        """The WAV bytes prepare_audio_for_stt produces must reflect whatever rate the audio
+        was ACTUALLY captured at (RECORDING_SAMPLE_RATE), not the unrelated TTS SAMPLE_RATE --
+        a mismatch here silently pitch/speed-shifts the audio Whisper receives."""
+        overridden_rate = 48000
+        monkeypatch.setattr(converse_module, "RECORDING_SAMPLE_RATE", overridden_rate)
+
+        one_second_of_silence = np.zeros(overridden_rate, dtype=np.int16)
+        wav_bytes = prepare_audio_for_stt(one_second_of_silence, output_format="wav")
+
+        with wave.open(io.BytesIO(wav_bytes), "rb") as wav_file:
+            # prepare_audio_for_stt downsamples to Whisper's native 16kHz regardless of
+            # capture rate -- the exported file's rate should be 16000, and (critically)
+            # the audio's actual DURATION should still be ~1 second. If the frame_rate used
+            # to build the AudioSegment were wrong (e.g. still hardcoded to 24000 while the
+            # real capture was 48000), the duration would come out wrong instead.
+            assert wav_file.getframerate() == 16000
+            duration_s = wav_file.getnframes() / wav_file.getframerate()
+            assert duration_s == pytest.approx(1.0, abs=0.01)
+
+    def test_wav_export_at_default_rate_matches_prior_behavior(self, monkeypatch):
+        """With no override, behavior is unchanged from before this fix."""
+        from voice_mode.config import SAMPLE_RATE
+        monkeypatch.setattr(converse_module, "RECORDING_SAMPLE_RATE", SAMPLE_RATE)
+
+        one_second_of_silence = np.zeros(SAMPLE_RATE, dtype=np.int16)
+        wav_bytes = prepare_audio_for_stt(one_second_of_silence, output_format="wav")
+
+        with wave.open(io.BytesIO(wav_bytes), "rb") as wav_file:
+            assert wav_file.getframerate() == 16000
+            duration_s = wav_file.getnframes() / wav_file.getframerate()
+            assert duration_s == pytest.approx(1.0, abs=0.01)
+
+
+class TestRecordAudioUsesRecordingRate:
+    def test_record_audio_requests_overridden_recording_rate_from_sounddevice(self, monkeypatch):
+        """record_audio() must open the input device at RECORDING_SAMPLE_RATE, not SAMPLE_RATE."""
+        overridden_rate = 48000
+        monkeypatch.setattr(converse_module, "RECORDING_SAMPLE_RATE", overridden_rate)
+
+        fake_recording = np.zeros((overridden_rate, 1), dtype=np.int16)
+        with (
+            patch.object(converse_module.sd, "rec", return_value=fake_recording) as mock_rec,
+            patch.object(converse_module.sd, "wait"),
+        ):
+            record_audio(1.0)
+
+        assert mock_rec.call_args.kwargs["samplerate"] == overridden_rate
+        assert mock_rec.call_args.args[0] == overridden_rate  # samples_to_record == 1s worth
+
+
+class TestVadResamplingMathAtOverriddenRates:
+    """record_audio_with_silence_detection() resamples each 30ms capture chunk down to
+    WebRTC VAD's fixed 16kHz frame size. WebRTC VAD requires an EXACT 10/20/30ms frame at
+    8k/16k/32kHz -- if the resample math doesn't land on exactly 480 samples (30ms @ 16kHz)
+    for a given RECORDING_SAMPLE_RATE, vad.is_speech() raises (caught non-fatally, but it
+    silently disables silence detection for that call). This replicates the exact formula
+    from converse.py's record_audio_with_silence_detection() to guard the invariant
+    independently of the full threaded/queue-based recording path, which isn't practical
+    to unit test directly.
+    """
+
+    @pytest.mark.parametrize("recording_rate", [8000, 16000, 24000, 32000, 44100, 48000])
+    def test_resampled_chunk_matches_exact_vad_frame_size(self, recording_rate):
+        from voice_mode.config import VAD_CHUNK_DURATION_MS
+
+        vad_sample_rate = 16000
+        vad_chunk_samples = int(vad_sample_rate * VAD_CHUNK_DURATION_MS / 1000)
+        assert vad_chunk_samples == 480  # WebRTC VAD's fixed 30ms/16kHz frame size
+
+        chunk_samples = int(recording_rate * VAD_CHUNK_DURATION_MS / 1000)
+        resampled_length = int(chunk_samples * vad_sample_rate / recording_rate)
+
+        assert resampled_length == vad_chunk_samples, (
+            f"at RECORDING_SAMPLE_RATE={recording_rate}, resampled_length={resampled_length} "
+            f"!= the exact {vad_chunk_samples}-sample VAD frame size WebRTC VAD requires"
+        )

--- a/voice_mode/config.py
+++ b/voice_mode/config.py
@@ -938,6 +938,15 @@ SOUNDFONTS_ENABLED = env_bool("VOICEMODE_SOUNDFONTS_ENABLED", True)
 SAMPLE_RATE = 24000  # Standard TTS sample rate for both OpenAI and Kokoro
 CHANNELS = 1
 
+# Microphone capture rate, decoupled from SAMPLE_RATE (TTS/playback).
+# Requesting a rate the input device doesn't natively support is not
+# universally safe: some backends resample transparently, others reject the
+# rate outright or silently produce corrupted/aliased samples (see
+# https://github.com/mbailey/voicemode/issues/491 -- reported against a
+# 48kHz-native mic). Defaults to SAMPLE_RATE so behavior is unchanged unless
+# a user on affected hardware opts in.
+RECORDING_SAMPLE_RATE = int(os.getenv("VOICEMODE_RECORDING_SAMPLE_RATE", str(SAMPLE_RATE)))
+
 # ==================== SILENCE DETECTION CONFIGURATION ====================
 
 # Disable silence detection (useful for noisy environments)

--- a/voice_mode/resources/configuration.py
+++ b/voice_mode/resources/configuration.py
@@ -24,7 +24,7 @@ from ..config import (
     # Audio settings
     AUDIO_FORMAT, TTS_AUDIO_FORMAT, STT_AUDIO_FORMAT,
     TTS_TRAILING_SILENCE,
-    SAMPLE_RATE, CHANNELS,
+    SAMPLE_RATE, RECORDING_SAMPLE_RATE, CHANNELS,
     # Silence detection
     DISABLE_SILENCE_DETECTION, VAD_AGGRESSIVENESS, SILENCE_THRESHOLD_MS,
     MIN_RECORDING_DURATION, INITIAL_SILENCE_GRACE_PERIOD, DEFAULT_LISTEN_DURATION,
@@ -92,7 +92,8 @@ async def all_configuration() -> str:
     lines.append(f"  Format: {AUDIO_FORMAT}")
     lines.append(f"  TTS Format: {TTS_AUDIO_FORMAT}")
     lines.append(f"  STT Format: {STT_AUDIO_FORMAT}")
-    lines.append(f"  Sample Rate: {SAMPLE_RATE} Hz")
+    lines.append(f"  TTS Sample Rate: {SAMPLE_RATE} Hz")
+    lines.append(f"  Recording Sample Rate: {RECORDING_SAMPLE_RATE} Hz")
     lines.append(f"  Channels: {CHANNELS}")
     lines.append("")
     

--- a/voice_mode/tools/converse.py
+++ b/voice_mode/tools/converse.py
@@ -36,7 +36,7 @@ from voice_mode.conversation_logger import get_conversation_logger
 from voice_mode.config import (
     audio_operation_lock,
     BASE_DIR,
-    SAMPLE_RATE,
+    RECORDING_SAMPLE_RATE,
     CHANNELS,
     DEBUG,
     DEBUG_DIR,
@@ -974,10 +974,10 @@ def prepare_audio_for_stt(audio_data: np.ndarray, output_format: str = "mp3") ->
     import io
 
     # Create AudioSegment from raw data
-    # Audio is recorded at SAMPLE_RATE (24kHz), 16-bit mono
+    # Audio is recorded at RECORDING_SAMPLE_RATE, 16-bit mono
     audio = AudioSegment(
         audio_data.tobytes(),
-        frame_rate=SAMPLE_RATE,
+        frame_rate=RECORDING_SAMPLE_RATE,
         sample_width=2,  # 16-bit = 2 bytes
         channels=CHANNELS
     )
@@ -988,7 +988,7 @@ def prepare_audio_for_stt(audio_data: np.ndarray, output_format: str = "mp3") ->
     # Downsample to 16kHz (Whisper's native rate) for better compression
     # This also reduces size by ~33% even before compression
     whisper_sample_rate = 16000
-    if SAMPLE_RATE != whisper_sample_rate:
+    if RECORDING_SAMPLE_RATE != whisper_sample_rate:
         audio = audio.set_frame_rate(whisper_sample_rate)
 
     # Export to target format
@@ -1109,7 +1109,7 @@ async def speech_to_text(
 
         if STT_SAVE_FORMAT == "wav":
             # Save as uncompressed WAV for full quality archival
-            write(str(save_file_path), SAMPLE_RATE, audio_data)
+            write(str(save_file_path), RECORDING_SAMPLE_RATE, audio_data)
         else:
             # Save in configured compressed format
             saved_audio = prepare_audio_for_stt(audio_data, STT_SAVE_FORMAT)
@@ -1227,7 +1227,7 @@ def record_audio(duration: float) -> np.ndarray:
             devices = sd.query_devices()
             default_input = sd.default.device[0]
             logger.debug(f"Default input device: {default_input} - {devices[default_input]['name'] if default_input is not None else 'None'}")
-            logger.debug(f"Recording config - Sample rate: {SAMPLE_RATE}Hz, Channels: {CHANNELS}, dtype: int16")
+            logger.debug(f"Recording config - Sample rate: {RECORDING_SAMPLE_RATE}Hz, Channels: {CHANNELS}, dtype: int16")
         except Exception as dev_e:
             logger.error(f"Error querying audio devices: {dev_e}")
     
@@ -1238,12 +1238,12 @@ def record_audio(duration: float) -> np.ndarray:
     original_stderr = sys.stderr
     
     try:
-        samples_to_record = int(duration * SAMPLE_RATE)
+        samples_to_record = int(duration * RECORDING_SAMPLE_RATE)
         logger.debug(f"Recording {samples_to_record} samples...")
-        
+
         recording = sd.rec(
             samples_to_record,
-            samplerate=SAMPLE_RATE,
+            samplerate=RECORDING_SAMPLE_RATE,
             channels=CHANNELS,
             dtype=np.int16
         )
@@ -1262,7 +1262,7 @@ def record_audio(duration: float) -> np.ndarray:
         
     except Exception as e:
         logger.error(f"Recording failed: {e}")
-        logger.error(f"Audio config when error occurred - Sample rate: {SAMPLE_RATE}, Channels: {CHANNELS}")
+        logger.error(f"Audio config when error occurred - Sample rate: {RECORDING_SAMPLE_RATE}, Channels: {CHANNELS}")
         
         # Check if this is a device error that might be recoverable
         error_str = str(e).lower()
@@ -1372,11 +1372,11 @@ def record_audio_with_silence_detection(max_duration: float, disable_silence_det
         vad = webrtcvad.Vad(effective_vad_aggressiveness)
         
         # Calculate chunk size (must be 10, 20, or 30ms worth of samples)
-        chunk_samples = int(SAMPLE_RATE * VAD_CHUNK_DURATION_MS / 1000)
+        chunk_samples = int(RECORDING_SAMPLE_RATE * VAD_CHUNK_DURATION_MS / 1000)
         chunk_duration_s = VAD_CHUNK_DURATION_MS / 1000
-        
+
         # WebRTC VAD only supports 8000, 16000, or 32000 Hz
-        # We'll tell VAD we're using 16kHz even though we're recording at 24kHz
+        # We'll tell VAD we're using 16kHz even though we're recording at RECORDING_SAMPLE_RATE
         # This requires adjusting our chunk size to match what VAD expects
         vad_sample_rate = 16000
         vad_chunk_samples = int(vad_sample_rate * VAD_CHUNK_DURATION_MS / 1000)
@@ -1410,7 +1410,7 @@ def record_audio_with_silence_detection(max_duration: float, disable_silence_det
             logger.info(f"[VAD_DEBUG]   effective_min_duration: {max(MIN_RECORDING_DURATION, min_duration)}s")
             logger.info(f"[VAD_DEBUG]   VAD aggressiveness: {effective_vad_aggressiveness}")
             logger.info(f"[VAD_DEBUG]   Silence threshold: {SILENCE_THRESHOLD_MS}ms")
-            logger.info(f"[VAD_DEBUG]   Sample rate: {SAMPLE_RATE}Hz (VAD using {vad_sample_rate}Hz)")
+            logger.info(f"[VAD_DEBUG]   Sample rate: {RECORDING_SAMPLE_RATE}Hz (VAD using {vad_sample_rate}Hz)")
             logger.info(f"[VAD_DEBUG]   Chunk duration: {VAD_CHUNK_DURATION_MS}ms")
         
         def audio_callback(indata, frames, time, status):
@@ -1430,7 +1430,7 @@ def record_audio_with_silence_detection(max_duration: float, disable_silence_det
         
         try:
             # Create continuous input stream
-            with sd.InputStream(samplerate=SAMPLE_RATE,
+            with sd.InputStream(samplerate=RECORDING_SAMPLE_RATE,
                                channels=CHANNELS,
                                dtype=np.int16,
                                callback=audio_callback,
@@ -1500,11 +1500,11 @@ def record_audio_with_silence_detection(max_duration: float, disable_silence_det
                         chunk_flat = chunk.flatten()
                         chunks.append(chunk_flat)
                         
-                        # For VAD, we need to downsample from 24kHz to 16kHz
+                        # For VAD, we need to downsample from RECORDING_SAMPLE_RATE to 16kHz
                         # Use scipy's resample for proper downsampling
                         from scipy import signal
                         # Calculate the number of samples we need after resampling
-                        resampled_length = int(len(chunk_flat) * vad_sample_rate / SAMPLE_RATE)
+                        resampled_length = int(len(chunk_flat) * vad_sample_rate / RECORDING_SAMPLE_RATE)
                         vad_chunk = signal.resample(chunk_flat, resampled_length)
                         # Take exactly the number of samples VAD expects
                         vad_chunk = vad_chunk[:vad_chunk_samples].astype(np.int16)
@@ -2016,7 +2016,7 @@ async def listen_and_transcribe(
         if SAVE_AUDIO and AUDIO_DIR and len(audio_data) > 0:
             timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
             audio_path = os.path.join(AUDIO_DIR, f"no_speech_{timestamp}.wav")
-            write(audio_path, SAMPLE_RATE, audio_data)
+            write(audio_path, RECORDING_SAMPLE_RATE, audio_data)
             logger.debug(f"Saved no-speech audio to: {audio_path}")
     else:
         stt_classified = True
@@ -3996,8 +3996,8 @@ consult the MCP resources listed above.
                             "request_time_ms": stt_metrics.get('request_time_ms', 0),
                             "is_local": stt_metrics.get('is_local', False),
                             "format": "wav",
-                            "sample_rate_hz": SAMPLE_RATE,
-                            "bitrate_kbps": (SAMPLE_RATE * 16 * CHANNELS) // 1000
+                            "sample_rate_hz": RECORDING_SAMPLE_RATE,
+                            "bitrate_kbps": (RECORDING_SAMPLE_RATE * 16 * CHANNELS) // 1000
                         }
                     if response_text:
                         event_logger.log_event(event_logger.STT_COMPLETE, stt_event_data)


### PR DESCRIPTION
Fixes #491.

## Summary

`SAMPLE_RATE` (`voice_mode/config.py`, `24000`) was a single hardcoded constant used for **both** TTS playback and microphone recording. 24kHz is correct for TTS (it's what the providers emit), but wrong as a hardcoded mic capture rate — a microphone's native rate is whatever the hardware is, commonly 44.1kHz or 48kHz for USB mics, never 24kHz. Requesting a rate the device doesn't natively support isn't universally safe: some audio backends resample transparently, some don't, producing corrupted/aliased recordings on affected hardware/OS/driver combinations — exactly what #491 reports with a 48kHz-native mic.

## The fix

Added `RECORDING_SAMPLE_RATE = int(os.getenv("VOICEMODE_RECORDING_SAMPLE_RATE", str(SAMPLE_RATE)))` — a new, independent config constant. **Defaults to `SAMPLE_RATE`, so behavior is unchanged unless a user explicitly opts in.**

Switched every recording-side usage in `voice_mode/tools/converse.py` to the new constant:
- `prepare_audio_for_stt()`'s `AudioSegment` construction + the Whisper-downsample comparison
- The full-quality WAV archival write, and the no-speech WAV dump
- `record_audio()`'s `sd.rec()` call, sample-count math, and debug/error logging
- `record_audio_with_silence_detection()`'s VAD chunk-size math, `sd.InputStream()` call, and the VAD-downsampling resample-length math
- The STT stats/telemetry dict (`sample_rate_hz`, `bitrate_kbps`)

All TTS/playback-side usage (all of `streaming.py`, `core.py`'s chime-playback functions) is untouched — verified by checking every remaining `SAMPLE_RATE` reference in the repo is genuinely playback-side, not a missed recording site.

**Docs fix, found while verifying this:** `docs/reference/environment.md` and `docs/guides/configuration.md` already documented a `VOICEMODE_SAMPLE_RATE` variable — including recommending it as a fix for exactly this kind of mic-rate mismatch — but the code never actually reads that variable anywhere (confirmed via a repo-wide grep). It was a documented no-op that would have silently done nothing for anyone following the docs. Updated those entries (and one in `docs/.archive/troubleshooting/wsl2-microphone-access.md`) to point at the new, working `VOICEMODE_RECORDING_SAMPLE_RATE` instead.

## Test plan

- [x] `tests/test_recording_sample_rate_config.py` — new, 3 tests: default equals `SAMPLE_RATE` (24000, unchanged behavior), override is decoupled from TTS rate, no cross-test pollution
- [x] `tests/test_recording_sample_rate_prepare_audio.py` — new, 5 tests:
  - `prepare_audio_for_stt()` produces WAV bytes whose actual *duration* is correct at an overridden rate (a real check via `wave` module on real exported bytes — this would fail if `frame_rate` weren't threaded correctly, unlike a mocked-call-args check)
  - Same at the default rate (regression guard)
  - `record_audio()` requests the overridden rate from `sounddevice`
  - VAD resample math lands on an exact 480-sample (30ms/16kHz) frame across every standard rate (8k/16k/24k/32k/44.1k/48kHz) — WebRTC VAD requires an exact frame size or raises, so this guards the most delicate part of the change
- [x] Full existing suite (`tests/test_stt_audio_saving.py`, `test_stt_local_compression_skip.py`, `test_silence_detection.py`, `test_vad_aggressiveness.py`, `test_history_buffer.py`, `test_audio_format_config.py`): 61 passed, 2 failed (confirmed pre-existing on unmodified `master` too — missing `ffmpeg` in my environment, unrelated to this change), 5 skipped (pre-existing, unrelated)