### PR TITLE
Fedora Atomic (Silverblue/Bazzite/Bluefin) support, plus installer and whisper fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -127,3 +127,6 @@ voicemode-install-feedback.md
 
 # Local convenience symlink to voice-lab voices dir (per-developer, not shipped)
 /voices
+
+# Local fnox secret store -- never commit (contains encrypted API keys)
+fnox.toml

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,34 @@ dependency step failed and took the rest of the run with it.
 
 ### Fixed
 
+#### CUDA builds no longer fail when the distribution's GCC outpaces nvcc
+
+`-DGGML_CUDA=ON` was passed with an unmodified environment, leaving nvcc to use
+whatever `g++` the distribution defaults to. nvcc rejects a host compiler newer
+than the version its headers were built against, so on any distribution that
+moves faster than CUDA the build aborted at configure time with `#error --
+unsupported GNU version!` — Fedora 44 defaults to GCC 16 while CUDA 13.3 stops
+at 15, and Arch and Fedora Rawhide hit the same wall.
+
+The supported ceiling is now read from CUDA's own `crt/host_config.h` rather
+than hardcoded, and the newest installed compiler at or below it (`g++-15`,
+`g++-14`, …, from Homebrew, Fedora's `gccN-c++` compat packages, or Debian's
+versioned packages) is passed as `CMAKE_CUDA_HOST_COMPILER`, with `CUDAHOSTCXX`
+and `NVCC_CCBIN` set to match so CMake and ggml's own nvcc calls cannot
+disagree. When the default is too new and nothing compatible is installed, the
+build now says so and names the package to install instead of failing with a
+wall of preprocessor output.
+
+#### CUDA guidance on Atomic systems pointed at a container that cannot help
+
+Atomic users missing the toolkit were told to build inside a distrobox
+container. A whisper binary built there links against the container's CUDA
+libraries, but voice-mode runs whisper as a host service, so the suggestion
+produced a binary the host could not run. The guidance now points at NVIDIA's
+runfile with `--toolkit --override`: `/usr/local` is a symlink to
+`/var/usrlocal` on these systems, so it is writable and persists across image
+updates, giving a host-native toolkit without layering or a reboot.
+
 #### Large dependency installs are no longer killed partway through
 
 Homebrew had the shortest install timeout of the three package managers (300s,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,54 @@ dependency step failed and took the rest of the run with it.
 
 ### Fixed
 
+#### Failed installs report the real error instead of crashing the error handler
+
+`whisper_install`'s `except subprocess.CalledProcessError` handler called
+`e.stderr.decode()`, but the configure and build steps run with `text=True`, so
+`e.stderr` is already `str`. The handler therefore raised `AttributeError`
+itself. A sibling `except Exception` cannot catch an exception raised by a
+preceding handler, so it escaped the function entirely and destroyed the cmake
+output at the one moment it was needed — a failed GPU build printed a wall of
+linker noise followed by an unrelated `'str' object has no attribute 'decode'`.
+
+The same line exists verbatim in the Kokoro installer, where it does not crash
+today only because none of its checked calls capture output — so the handler
+silently reports `"stderr": None` for every failure, and would start crashing
+the moment anyone added `capture_output=True`. Both now decode only when handed
+bytes.
+
+Two more handlers that could raise over the top of the error they were meant to
+report:
+
+- `disable_sounddevice_stderr_redirect()` imported `sys` *inside* its `try`,
+  making it a function-local name. When the `sounddevice` import failed — the
+  exact case the handler exists for — `sys` was unbound and the handler raised
+  `UnboundLocalError` instead of logging and continuing. The imports the handler
+  depends on are now bound before the `try`.
+- `Exchange` tailing called `process.terminate()` from its `KeyboardInterrupt`
+  handler; a Ctrl-C during `Popen()` itself left `process` unbound. It is now
+  bound to `None` first and the handler guards on it.
+
+#### The installer no longer reports success after a component fails
+
+A run where Whisper failed and Kokoro succeeded logged
+`"Failed to install whisper packages"` and then, four lines later,
+`"Installation completed" {"success": true}` — and exited 0, so anything
+scripted around `voice-mode-install` saw a clean run. `log_complete` was called
+with the literal `True`; no component result could influence it. Optional
+services are still allowed to fail without aborting the run, but the failures
+are now collected, the final status reflects them, the summary names them with
+the command to retry each, and the process exits 1.
+
+The log also recorded only a success boolean, discarding the exception that was
+live in scope, which is what forced diagnosis back into terminal scrollback.
+`log_install` now accepts the error text and `log_complete` records which
+components failed.
+
+Removed the unreachable `else` branches that reported "may not have completed
+successfully" — those `subprocess.run` calls pass `check=True`, so they can only
+return when the command succeeded.
+
 #### CUDA builds no longer fail when the distribution's GCC outpaces nvcc
 
 `-DGGML_CUDA=ON` was passed with an unmodified environment, leaving nvcc to use

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,50 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+#### Fedora Atomic support — Silverblue, Kinoite, Bazzite, Bluefin
+
+The installer previously ran `sudo dnf install` on anything reporting
+`ID=fedora`. On Atomic variants that can never succeed: `/usr` is read-only,
+and Bazzite ships a `dnf` shim that refuses `install` outright, so the
+dependency step failed and took the rest of the run with it.
+
+- **Atomic systems are now detected** via `/run/ostree-booted`, and reported in
+  the install log as `is_ostree` alongside the detected Homebrew prefix.
+- **Dependencies install through Homebrew** on these systems — no root, no
+  reboot — with a mapping from Fedora RPM names to their homebrew-core
+  formulae. Anything with no Homebrew equivalent now prints the
+  `rpm-ostree install` command plus the required reboot, and the `distrobox`
+  alternative, instead of failing with a bare `dnf` error.
+- **`python3-devel` is skipped** on Atomic: voice-mode installs via
+  `uv tool install`, which builds against uv's managed CPython and ships its
+  own headers.
+
+### Fixed
+
+#### Dependency checks no longer report false negatives
+
+Several checks asked `rpm -q` whether a package was installed, which reports
+missing whenever the dependency was satisfied by anything other than an RPM —
+Homebrew, Nix, or a bundled toolchain. Checks now test for the capability
+rather than the packaging:
+
+- `alsa-lib-devel` → `pkg-config --exists alsa` (the check the whisper section
+  already used).
+- `python3-devel` → probes for `Python.h` under `sysconfig`, so uv-managed
+  interpreters count.
+- `portaudio` → probes for a loadable `libportaudio`, since `sounddevice`
+  dlopens it through cffi rather than linking at build time.
+- `portaudio-devel` → `pkg-config --exists portaudio-2.0`.
+- `pulseaudio` / `pulseaudio-utils` → accept `pactl`, which PipeWire provides
+  on modern Fedora without a `pulseaudio` binary or RPM.
+
+Homebrew's `pkgconfig` directories are now added to `PKG_CONFIG_PATH` when
+running check commands. Homebrew is not on pkg-config's default search path on
+Linux, so `brew install alsa-lib` was previously invisible to `pkg-config`
+even though the compiler would find the headers.
+
 ## [8.12.0] - 2026-07-21
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,22 @@ dependency step failed and took the rest of the run with it.
 
 ### Fixed
 
+#### Large dependency installs are no longer killed partway through
+
+Homebrew had the shortest install timeout of the three package managers (300s,
+against 600s for apt and dnf) despite doing the heaviest work -- it downloads
+large bottles and can build from source. Installing `rust` for Kokoro is a
+~400MB bottle that exceeded 300s on an ordinary connection, so the install was
+killed midway and reported a bare timeout. Raised to 1800s.
+
+#### `voicemode service install whisper` gained `--model` and `--no-gpu`
+
+`whisper_install()` has always accepted `model` and `use_gpu`, but the command
+passed neither. Two consequences: the CUDA error told users to "use --no-gpu"
+when no such flag existed, leaving no way to build CPU-only; and the standalone
+installer's `service install whisper --model <name>` was an unknown option,
+which would have failed for anyone choosing a non-default model.
+
 #### `voicemode service install` reported success after failing
 
 `voicemode service install whisper` printed its error and then exited **0**.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,18 @@ and it printed `✅ Whisper STT service installed` directly beneath
 `❌ Whisper installation failed` — leaving users believing a service was
 installed when it was not. The failure branches now exit non-zero.
 
+#### An auto-detected GPU no longer blocks the Whisper install
+
+`whisper_install()` auto-detects the GPU, then required `nvcc` and refused to
+install without it. Anyone with an NVIDIA card but no CUDA toolkit was blocked
+from installing Whisper at all -- even though whisper.cpp builds and runs fine
+on CPU, and even though nothing had asked for GPU support. On Fedora Atomic
+this was a dead end, since the CUDA toolkit cannot be installed there.
+
+When the GPU was auto-detected, a missing toolkit now warns and falls back to a
+CPU-only build. An explicit `--use-gpu` still errors, so a deliberate request is
+never silently downgraded.
+
 #### Install suggestions no longer point at dnf on Fedora Atomic
 
 The Whisper installer suggested `sudo dnf install cuda-toolkit` (and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,17 @@ dependency step failed and took the rest of the run with it.
 
 ### Fixed
 
+#### Package-manager selection tests no longer depend on the host they run on
+
+`TestPackageManagerSelection` mocked the managers' availability but not the OS
+probes, so it asserted against whatever machine ran it: on macOS the Darwin
+branch returns first, and on a Fedora Atomic host the ostree branch does, so
+`test_get_package_manager_dnf` failed for any Silverblue/Bazzite contributor
+while passing in CI. Both probes are now pinned, and the Atomic branches have
+coverage of their own — including that `DnfManager` is never selected there even
+with `dnf` on PATH, and that RPM→Homebrew translation strips `-devel` and
+collapses `cargo`/`rust` onto the single `rust` formula.
+
 #### Failed installs report the real error instead of crashing the error handler
 
 `whisper_install`'s `except subprocess.CalledProcessError` handler called

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,23 @@ dependency step failed and took the rest of the run with it.
 
 ### Fixed
 
+#### Dependency *installation* on Fedora Atomic and on Fedora + Homebrew
+
+`voicemode service install whisper` fed Homebrew the Fedora RPM names straight
+from `dependencies.yaml`, so it failed with *"No available formula with the
+name portaudio-devel"*. `cargo` was worse — it has no formula at all, because
+cargo ships inside `rust`.
+
+- RPM names are now translated to homebrew-core formulae before install, and
+  de-duplicated (`cargo` + `rust` collapse to a single `rust`). Names with no
+  formula report the `rpm-ostree install` and `distrobox` alternatives instead
+  of a bare brew error.
+- **`get_package_manager()` tried Homebrew first on every platform.** Any
+  Fedora user with Homebrew installed — Atomic or not — got brew selected and
+  handed RPM names it could not resolve. The native manager is now preferred on
+  Linux, with Homebrew as the fallback, and Atomic systems route to Homebrew
+  deliberately rather than by accident.
+
 #### Dependency checks no longer report false negatives
 
 Applies to both dependency paths — the `voicemode deps` CLI

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,21 @@ dependency step failed and took the rest of the run with it.
 
 ### Fixed
 
+#### `voicemode service install` reported success after failing
+
+`voicemode service install whisper` printed its error and then exited **0**.
+The installer runs it with `subprocess.run(..., check=True)`, so nothing raised
+and it printed `✅ Whisper STT service installed` directly beneath
+`❌ Whisper installation failed` — leaving users believing a service was
+installed when it was not. The failure branches now exit non-zero.
+
+#### Install suggestions no longer point at dnf on Fedora Atomic
+
+The Whisper installer suggested `sudo dnf install cuda-toolkit` (and
+`apt-get install build-essential`) on any Linux. On Atomic that command always
+fails. It now suggests `--no-gpu` or a distrobox container for CUDA, and
+Homebrew or `rpm-ostree` for build tools.
+
 #### Dependency *installation* on Fedora Atomic and on Fedora + Homebrew
 
 `voicemode service install whisper` fed Homebrew the Fedora RPM names straight

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,15 +31,24 @@ dependency step failed and took the rest of the run with it.
 
 #### Dependency checks no longer report false negatives
 
+Applies to both dependency paths — the `voicemode deps` CLI
+(`voice_mode/utils/dependencies/`) and the standalone installer
+(`installer/voicemode_install/`), which carry separate copies of
+`dependencies.yaml`.
+
 Several checks asked `rpm -q` whether a package was installed, which reports
 missing whenever the dependency was satisfied by anything other than an RPM —
-Homebrew, Nix, or a bundled toolchain. Checks now test for the capability
+Homebrew, Nix, or a bundled toolchain. On Bazzite this reported 7 of 7 core
+dependencies missing on a working install. Checks now test for the capability
 rather than the packaging:
 
 - `alsa-lib-devel` → `pkg-config --exists alsa` (the check the whisper section
   already used).
-- `python3-devel` → probes for `Python.h` under `sysconfig`, so uv-managed
-  interpreters count.
+- `python3-devel` → probes for `Python.h` under `sysconfig`, using the
+  interpreter that would actually build the extensions (exported as
+  `VOICEMODE_PYTHON`) rather than whatever `python3` resolves to on `PATH`.
+  Under `uv tool install` those differ: uv's managed CPython ships headers
+  while the system `python3` often has none.
 - `portaudio` → probes for a loadable `libportaudio`, since `sounddevice`
   dlopens it through cffi rather than linking at build time.
 - `portaudio-devel` → `pkg-config --exists portaudio-2.0`.

--- a/installer/voicemode_install/checker.py
+++ b/installer/voicemode_install/checker.py
@@ -7,7 +7,26 @@ from typing import List, Optional
 
 import yaml
 
-from .system import PlatformInfo, check_command_exists
+import os
+
+from .system import PlatformInfo, check_command_exists, get_homebrew_prefix
+
+
+# Fedora RPM name -> Homebrew formula, for systems where the dependency was
+# satisfied with Homebrew rather than the distro package manager. Only names
+# that genuinely exist in homebrew-core are listed; anything absent here simply
+# falls through and is reported missing.
+RPM_TO_BREW = {
+    'alsa-lib-devel': 'alsa-lib',
+    'portaudio': 'portaudio',
+    'portaudio-devel': 'portaudio',
+    'SDL2-devel': 'sdl2',
+    'ffmpeg': 'ffmpeg',
+    'cmake': 'cmake',
+    'make': 'make',
+    'rust': 'rust',
+    'cargo': 'rust',
+}
 
 
 @dataclass
@@ -121,6 +140,23 @@ class DependencyChecker:
             # Fallback: check if command exists
             return check_command_exists(package_name)
 
+    def _check_env(self) -> dict:
+        """Environment for check commands, with Homebrew's pkgconfig dir added.
+
+        Homebrew is not on pkg-config's default search path on Linux, so a
+        header installed with ``brew install alsa-lib`` is invisible to a bare
+        ``pkg-config --exists alsa`` even though the compiler would find it.
+        On an immutable OS Homebrew is the main way to get headers at all, so
+        without this every pkg-config check reports a false negative.
+        """
+        env = os.environ.copy()
+        prefix = get_homebrew_prefix()
+        if prefix:
+            existing = env.get('PKG_CONFIG_PATH', '')
+            brew_pc = [str(prefix / 'lib' / 'pkgconfig'), str(prefix / 'share' / 'pkgconfig')]
+            env['PKG_CONFIG_PATH'] = ':'.join([p for p in brew_pc + [existing] if p])
+        return env
+
     def _run_check_command(self, command: str) -> bool:
         """Run a check command and return whether it succeeded."""
         try:
@@ -129,7 +165,8 @@ class DependencyChecker:
                 shell=True,
                 capture_output=True,
                 check=True,
-                timeout=5
+                timeout=5,
+                env=self._check_env()
             )
             return True
         except (subprocess.CalledProcessError, subprocess.TimeoutExpired):
@@ -170,7 +207,12 @@ class DependencyChecker:
             return False
 
     def _check_dnf_package(self, package_name: str) -> bool:
-        """Check if a dnf/yum package is installed."""
+        """Check if a dnf/yum package is installed.
+
+        Falls back to Homebrew: on Fedora Atomic the RPM is often absent
+        because the dependency was satisfied with ``brew install`` instead,
+        which ``rpm -q`` cannot see.
+        """
         try:
             subprocess.run(
                 ['rpm', '-q', package_name],
@@ -179,7 +221,12 @@ class DependencyChecker:
             )
             return True
         except (subprocess.CalledProcessError, FileNotFoundError):
-            return False
+            pass
+
+        brew_formula = RPM_TO_BREW.get(package_name)
+        if brew_formula and get_homebrew_prefix():
+            return self._check_homebrew_package(brew_formula)
+        return False
 
     def get_missing_packages(self, packages: List[PackageInfo]) -> List[PackageInfo]:
         """Filter to only required packages that are not installed."""

--- a/installer/voicemode_install/checker.py
+++ b/installer/voicemode_install/checker.py
@@ -8,6 +8,7 @@ from typing import List, Optional
 import yaml
 
 import os
+import sys
 
 from .system import PlatformInfo, check_command_exists, get_homebrew_prefix
 
@@ -155,6 +156,12 @@ class DependencyChecker:
             existing = env.get('PKG_CONFIG_PATH', '')
             brew_pc = [str(prefix / 'lib' / 'pkgconfig'), str(prefix / 'share' / 'pkgconfig')]
             env['PKG_CONFIG_PATH'] = ':'.join([p for p in brew_pc + [existing] if p])
+
+        # The interpreter that would actually build C extensions -- not whatever
+        # `python3` resolves to on PATH. uv's managed CPython ships its own
+        # headers while the system python3 may have none, so probing PATH's
+        # python3 reports a false missing python3-devel.
+        env['VOICEMODE_PYTHON'] = sys.executable
         return env
 
     def _run_check_command(self, command: str) -> bool:

--- a/installer/voicemode_install/cli.py
+++ b/installer/voicemode_install/cli.py
@@ -237,6 +237,10 @@ def main(dry_run, voice_mode_version, skip_services, non_interactive, model):
 
     # Initialize logger
     logger = InstallLogger()
+    # Optional services are allowed to fail without aborting the run, but the
+    # final status has to reflect it -- previously a failed component was logged
+    # and then forgotten, and the run still reported success and exited 0.
+    failed_components = []
 
     try:
         # Clear screen and show logo
@@ -435,38 +439,36 @@ def main(dry_run, voice_mode_version, skip_services, non_interactive, model):
                     if model != 'base':
                         whisper_cmd.extend(['--model', model])
                     try:
-                        result = subprocess.run(whisper_cmd, check=True)
-                        if result.returncode == 0:
-                            print_success("Whisper STT service installed")
-                            logger.log_install('whisper', ['whisper'], True)
-                        else:
-                            print_warning("Whisper installation may not have completed successfully")
-                            logger.log_install('whisper', ['whisper'], False)
+                        # check=True, so run() only returns on success -- the
+                        # former `else` branch here was unreachable.
+                        subprocess.run(whisper_cmd, check=True)
+                        print_success("Whisper STT service installed")
+                        logger.log_install('whisper', ['whisper'], True)
                     except subprocess.CalledProcessError as e:
                         print_error(f"Whisper installation failed: {e}")
-                        logger.log_install('whisper', ['whisper'], False)
-                    except FileNotFoundError:
+                        logger.log_install('whisper', ['whisper'], False, error=str(e))
+                        failed_components.append('whisper')
+                    except FileNotFoundError as e:
                         print_error("VoiceMode command not found. Cannot install Whisper.")
-                        logger.log_install('whisper', ['whisper'], False)
+                        logger.log_install('whisper', ['whisper'], False, error=str(e))
+                        failed_components.append('whisper')
 
                     # Install Kokoro
                     click.echo()
                     print_step("Installing Kokoro TTS service...")
                     kokoro_cmd = ['voicemode', 'service', 'install', 'kokoro']
                     try:
-                        result = subprocess.run(kokoro_cmd, check=True)
-                        if result.returncode == 0:
-                            print_success("Kokoro TTS service installed")
-                            logger.log_install('kokoro', ['kokoro'], True)
-                        else:
-                            print_warning("Kokoro installation may not have completed successfully")
-                            logger.log_install('kokoro', ['kokoro'], False)
+                        subprocess.run(kokoro_cmd, check=True)
+                        print_success("Kokoro TTS service installed")
+                        logger.log_install('kokoro', ['kokoro'], True)
                     except subprocess.CalledProcessError as e:
                         print_error(f"Kokoro installation failed: {e}")
-                        logger.log_install('kokoro', ['kokoro'], False)
-                    except FileNotFoundError:
+                        logger.log_install('kokoro', ['kokoro'], False, error=str(e))
+                        failed_components.append('kokoro')
+                    except FileNotFoundError as e:
                         print_error("VoiceMode command not found. Cannot install Kokoro.")
-                        logger.log_install('kokoro', ['kokoro'], False)
+                        logger.log_install('kokoro', ['kokoro'], False, error=str(e))
+                        failed_components.append('kokoro')
             else:
                 click.echo("Cloud services recommended for your system configuration.")
                 click.echo("Local services can still be installed if desired:")
@@ -477,11 +479,18 @@ def main(dry_run, voice_mode_version, skip_services, non_interactive, model):
         # Completion summary
         click.echo()
         click.echo("━" * 70)
-        click.echo(click.style("Installation Complete!", fg='green', bold=True))
+        if failed_components:
+            click.echo(click.style("Installation Completed With Failures", fg='red', bold=True))
+        else:
+            click.echo(click.style("Installation Complete!", fg='green', bold=True))
         click.echo("━" * 70)
         click.echo()
 
-        logger.log_complete(success=True, voicemode_installed=True)
+        logger.log_complete(
+            success=not failed_components,
+            voicemode_installed=True,
+            failed_components=failed_components,
+        )
 
         if dry_run:
             click.echo("DRY RUN: No changes were made to your system")
@@ -495,6 +504,16 @@ def main(dry_run, voice_mode_version, skip_services, non_interactive, model):
             click.echo("     claude mcp add --scope user voicemode -- uvx voice-mode")
             click.echo()
             click.echo(f"Installation log: {logger.get_log_path()}")
+
+        if failed_components:
+            click.echo()
+            print_warning(f"Completed with failures: {', '.join(failed_components)}")
+            click.echo("VoiceMode itself is installed; retry the failed components with:")
+            for component in failed_components:
+                click.echo(f"  voicemode service install {component}")
+            # SystemExit derives from BaseException, so the `except Exception`
+            # below does not swallow this.
+            sys.exit(1)
 
     except KeyboardInterrupt:
         click.echo("\n\nInstallation cancelled by user")

--- a/installer/voicemode_install/dependencies.yaml
+++ b/installer/voicemode_install/dependencies.yaml
@@ -143,8 +143,8 @@ voicemode:
         - name: python3-devel
           description: Python development headers (needed for building extensions)
           required: true
-          check_command: rpm -q python3-devel
-          note: Required for compiling webrtcvad (C extension used for silence detection)
+          check_command: python3 -c "import os, sys, sysconfig; sys.exit(0 if os.path.exists(sysconfig.get_path('include') + '/Python.h') else 1)"
+          note: Required for compiling webrtcvad (C extension used for silence detection). Probes for Python.h rather than the RPM, so uv-managed CPython and Fedora Atomic are handled.
 
         - name: gcc
           description: C compiler (needed for building Python extensions)
@@ -161,31 +161,32 @@ voicemode:
         - name: alsa-lib-devel
           description: ALSA development files (audio support)
           required: true
-          check_command: rpm -q alsa-lib-devel
-          note: Required for compiling simpleaudio (C extension used for audio playback)
+          check_command: pkg-config --exists alsa
+          note: Required for compiling simpleaudio (C extension used for audio playback). Matches the check the whisper section already uses, and unlike rpm -q it also sees headers installed with Homebrew.
 
         - name: portaudio
           description: PortAudio library (for sounddevice runtime)
           required: true
-          check_command: rpm -q portaudio
+          check_command: python3 -c "import ctypes.util, sys; sys.exit(0 if ctypes.util.find_library('portaudio') else 1)"
+          note: sounddevice dlopens libportaudio at runtime via cffi, so test for the loadable library rather than the RPM.
 
         - name: portaudio-devel
           description: PortAudio development files
           required: false
-          check_command: rpm -q portaudio-devel
-          note: Optional - only needed for building, not runtime
+          check_command: pkg-config --exists portaudio-2.0
+          note: Optional - only needed for building, not runtime. sounddevice uses cffi ABI mode and needs no PortAudio headers.
 
         - name: pulseaudio
           description: PulseAudio sound server
           required: wsl  # Required for WSL, optional for native Linux
-          check_command: pulseaudio --version
-          note: Essential for WSL2 audio. Usually pre-installed on native Linux desktops.
+          check_command: pulseaudio --version || pactl --version
+          note: Essential for WSL2 audio. Usually pre-installed on native Linux desktops. Modern Fedora ships PipeWire, which provides the PulseAudio interface without the pulseaudio binary, so accept pactl too.
 
         - name: pulseaudio-utils
           description: PulseAudio utilities
           required: wsl  # Required for WSL, optional for native Linux
-          check_command: rpm -q pulseaudio-utils
-          note: Essential for WSL2 audio. Usually pre-installed on native Linux desktops.
+          check_command: pactl --version
+          note: Essential for WSL2 audio. Usually pre-installed on native Linux desktops. Tests for the pactl binary, which PipeWire also provides (pipewire-pulseaudio), rather than the RPM.
 
         - name: ffmpeg
           description: Audio/video processing

--- a/installer/voicemode_install/dependencies.yaml
+++ b/installer/voicemode_install/dependencies.yaml
@@ -143,7 +143,7 @@ voicemode:
         - name: python3-devel
           description: Python development headers (needed for building extensions)
           required: true
-          check_command: python3 -c "import os, sys, sysconfig; sys.exit(0 if os.path.exists(sysconfig.get_path('include') + '/Python.h') else 1)"
+          check_command: ${VOICEMODE_PYTHON:-python3} -c "import os, sys, sysconfig; sys.exit(0 if os.path.exists(sysconfig.get_path('include') + '/Python.h') else 1)"
           note: Required for compiling webrtcvad (C extension used for silence detection). Probes for Python.h rather than the RPM, so uv-managed CPython and Fedora Atomic are handled.
 
         - name: gcc

--- a/installer/voicemode_install/installer.py
+++ b/installer/voicemode_install/installer.py
@@ -3,8 +3,16 @@
 import subprocess
 from typing import List, Optional
 
-from .checker import PackageInfo
-from .system import PlatformInfo, get_package_manager
+from .checker import PackageInfo, RPM_TO_BREW
+from .system import PlatformInfo, get_package_manager, get_homebrew_prefix
+
+# Packages that need no action on Fedora Atomic, with the reason shown to the
+# user. python3-devel only ever supplies build headers, and voice-mode is
+# installed with `uv tool install`, which builds against uv's own managed
+# CPython -- that ships its headers with it.
+OSTREE_SATISFIED = {
+    'python3-devel': 'uv-managed CPython provides the Python headers',
+}
 
 
 class PackageInstaller:
@@ -14,7 +22,9 @@ class PackageInstaller:
         self.platform = platform_info
         self.dry_run = dry_run
         self.non_interactive = non_interactive
-        self.package_manager = get_package_manager(platform_info.distribution)
+        self.package_manager = get_package_manager(
+            platform_info.distribution, platform_info.is_ostree
+        )
 
     def install_packages(self, packages: List[PackageInfo]) -> bool:
         """
@@ -36,6 +46,10 @@ class PackageInstaller:
                 return self._install_homebrew(package_names)
             elif self.platform.distribution == 'debian':
                 return self._install_apt(package_names)
+            elif self.platform.is_ostree:
+                # Must precede the plain 'fedora' branch: Atomic variants report
+                # ID=fedora but dnf install cannot work there.
+                return self._install_ostree(package_names)
             elif self.platform.distribution == 'fedora':
                 return self._install_dnf(package_names)
             else:
@@ -92,6 +106,68 @@ class PackageInstaller:
         except FileNotFoundError:
             print("Error: apt not found")
             return False
+
+    def _install_ostree(self, packages: List[str]) -> bool:
+        """Install packages on Fedora Atomic (Silverblue, Kinoite, Bazzite, Bluefin).
+
+        ``dnf install`` does not work on these images -- the root filesystem is
+        read-only, and Bazzite ships a dnf shim that refuses install outright.
+        The two real options are Homebrew (no root, no reboot) and
+        ``rpm-ostree install`` (layers the package, requires a reboot).
+
+        Homebrew is strongly preferred: every dependency here is a build-time
+        header or a CLI tool, so nothing needs to come from the base image, and
+        layering would cost the user a reboot for no benefit.
+        """
+        remaining = []
+        for pkg in packages:
+            reason = OSTREE_SATISFIED.get(pkg)
+            if reason:
+                print(f"  Skipping {pkg}: {reason}")
+            else:
+                remaining.append(pkg)
+
+        if not remaining:
+            return True
+
+        brew_pkgs, unmapped = [], []
+        for pkg in remaining:
+            formula = RPM_TO_BREW.get(pkg)
+            if formula:
+                if formula not in brew_pkgs:
+                    brew_pkgs.append(formula)
+            else:
+                unmapped.append(pkg)
+
+        ok = True
+        if brew_pkgs:
+            if get_homebrew_prefix():
+                print(f"Detected Fedora Atomic -- installing via Homebrew: {', '.join(brew_pkgs)}")
+                ok = self._install_homebrew(brew_pkgs)
+            else:
+                unmapped.extend(remaining)
+                print(
+                    "Homebrew is not installed. It is the recommended way to add "
+                    "development headers on an immutable OS:\n"
+                    '  /bin/bash -c "$(curl -fsSL '
+                    'https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"'
+                )
+                ok = False
+
+        if unmapped:
+            print(
+                "\nThese packages have no Homebrew equivalent and must be layered "
+                "onto the image:\n"
+                f"  sudo rpm-ostree install {' '.join(sorted(set(unmapped)))}\n"
+                "  systemctl reboot\n"
+                "Layering takes effect only after a reboot. Alternatively, do the "
+                "build inside a distrobox container, where dnf works normally:\n"
+                "  distrobox create --name dev --image fedora:latest\n"
+                "  distrobox enter dev"
+            )
+            ok = False
+
+        return ok
 
     def _install_dnf(self, packages: List[str]) -> bool:
         """Install packages using dnf."""

--- a/installer/voicemode_install/installer.py
+++ b/installer/voicemode_install/installer.py
@@ -37,7 +37,11 @@ class PackageInstaller:
 
         package_names = [pkg.name for pkg in packages]
 
-        if self.dry_run:
+        # On Atomic the interesting part of a dry run is *how* each package
+        # would be obtained -- brew, rpm-ostree, or skipped entirely -- so let
+        # _install_ostree report that itself rather than printing a flat list
+        # that hides the routing.
+        if self.dry_run and not self.platform.is_ostree:
             print(f"[DRY RUN] Would install: {', '.join(package_names)}")
             return True
 
@@ -142,8 +146,11 @@ class PackageInstaller:
         ok = True
         if brew_pkgs:
             if get_homebrew_prefix():
-                print(f"Detected Fedora Atomic -- installing via Homebrew: {', '.join(brew_pkgs)}")
-                ok = self._install_homebrew(brew_pkgs)
+                if self.dry_run:
+                    print(f"[DRY RUN] Would run: brew install {' '.join(brew_pkgs)}")
+                else:
+                    print(f"Detected Fedora Atomic -- installing via Homebrew: {', '.join(brew_pkgs)}")
+                    ok = self._install_homebrew(brew_pkgs)
             else:
                 unmapped.extend(remaining)
                 print(

--- a/installer/voicemode_install/logger.py
+++ b/installer/voicemode_install/logger.py
@@ -53,16 +53,23 @@ class InstallLogger:
             }
         )
 
-    def log_install(self, package_type: str, packages: list, success: bool):
+    def log_install(self, package_type: str, packages: list, success: bool,
+                    error: str = None):
         """Log package installation."""
+        details = {
+            'package_type': package_type,
+            'packages': packages,
+            'success': success
+        }
+        # Without this the log recorded only that something failed, never why,
+        # so diagnosing a failed run meant scrolling back through the terminal.
+        if error:
+            details['error'] = error
+
         self.log_event(
             'install',
             f'{"Successfully installed" if success else "Failed to install"} {package_type} packages',
-            {
-                'package_type': package_type,
-                'packages': packages,
-                'success': success
-            }
+            details
         )
 
     def log_error(self, message: str, error: Exception = None):
@@ -74,15 +81,20 @@ class InstallLogger:
 
         self.log_event('error', message, details)
 
-    def log_complete(self, success: bool, voicemode_installed: bool):
+    def log_complete(self, success: bool, voicemode_installed: bool,
+                     failed_components: list = None):
         """Log installation completion."""
+        details = {
+            'success': success,
+            'voicemode_installed': voicemode_installed
+        }
+        if failed_components:
+            details['failed_components'] = failed_components
+
         self.log_event(
             'complete',
-            'Installation completed' if success else 'Installation failed',
-            {
-                'success': success,
-                'voicemode_installed': voicemode_installed
-            }
+            'Installation completed' if success else 'Installation completed with failures',
+            details
         )
 
     def get_log_path(self) -> str:

--- a/installer/voicemode_install/system.py
+++ b/installer/voicemode_install/system.py
@@ -17,6 +17,42 @@ class PlatformInfo:
     distribution: str  # debian, fedora, darwin, etc. (for yaml lookup)
     architecture: str  # arm64, x86_64
     is_wsl: bool = False
+    is_ostree: bool = False  # Fedora Atomic: Silverblue, Kinoite, Bazzite, Bluefin...
+
+
+def is_ostree_system() -> bool:
+    """Detect an rpm-ostree / Fedora Atomic system (Silverblue, Bazzite, Bluefin...).
+
+    These report ID=fedora in /etc/os-release but have a read-only /usr and no
+    working ``dnf install`` -- Bazzite ships a dnf shim that refuses install
+    outright. Packages are layered with ``rpm-ostree install`` (requires a
+    reboot) or, preferably, installed with Homebrew or in a distrobox.
+
+    /run/ostree-booted is created by ostree at boot and is the canonical marker.
+    """
+    return Path('/run/ostree-booted').exists() or Path('/sysroot/ostree').is_dir()
+
+
+def get_homebrew_prefix() -> Optional[Path]:
+    """Return the Homebrew prefix if Homebrew is installed, else None.
+
+    Homebrew on Linux is a first-class way to get development headers on an
+    immutable OS, since it installs under $HOME or /home/linuxbrew and needs
+    neither root nor a reboot.
+    """
+    brew = shutil.which('brew')
+    if not brew:
+        for candidate in (Path('/home/linuxbrew/.linuxbrew'), Path.home() / '.linuxbrew'):
+            if (candidate / 'bin' / 'brew').exists():
+                return candidate
+        return None
+    try:
+        result = subprocess.run(
+            [brew, '--prefix'], capture_output=True, text=True, check=True, timeout=10
+        )
+        return Path(result.stdout.strip())
+    except (subprocess.CalledProcessError, subprocess.TimeoutExpired, OSError):
+        return None
 
 
 def detect_platform() -> PlatformInfo:
@@ -55,7 +91,8 @@ def detect_platform() -> PlatformInfo:
             os_name=distro_info['name'],
             distribution=distro_info['family'],
             architecture=architecture,
-            is_wsl=is_wsl
+            is_wsl=is_wsl,
+            is_ostree=is_ostree_system()
         )
     else:
         raise RuntimeError(f"Unsupported operating system: {os_type}")
@@ -103,8 +140,15 @@ def _detect_linux_distro() -> dict:
     raise RuntimeError("Unable to detect Linux distribution")
 
 
-def get_package_manager(distribution: str) -> str:
-    """Get the package manager command for the distribution."""
+def get_package_manager(distribution: str, is_ostree: bool = False) -> str:
+    """Get the package manager command for the distribution.
+
+    On Fedora Atomic (ostree) the answer is never ``dnf`` -- prefer Homebrew,
+    which needs no root and no reboot, and fall back to ``rpm-ostree``.
+    """
+    if distribution == 'fedora' and is_ostree:
+        return 'brew' if get_homebrew_prefix() else 'rpm-ostree'
+
     if distribution == 'darwin':
         return 'brew'
     elif distribution == 'debian':
@@ -141,6 +185,8 @@ def get_system_info() -> dict:
         'distribution': platform_info.distribution,
         'architecture': platform_info.architecture,
         'is_wsl': platform_info.is_wsl,
+        'is_ostree': platform_info.is_ostree,
+        'homebrew_prefix': str(get_homebrew_prefix() or ''),
         'python_version': platform.python_version(),
         'platform': platform.platform(),
     }

--- a/tests/test_dependencies.py
+++ b/tests/test_dependencies.py
@@ -8,7 +8,10 @@ from voice_mode.utils.dependencies.package_managers import (
     BrewManager,
     AptManager,
     DnfManager,
-    get_package_manager
+    OstreeBrewManager,
+    RpmOstreeManager,
+    get_package_manager,
+    translate_to_brew,
 )
 
 
@@ -148,19 +151,31 @@ class TestPackageManagers:
         assert manager.check_package("ffmpeg") is True
 
 
+@patch('voice_mode.utils.dependencies.package_managers.platform.system', return_value='Linux')
+@patch('voice_mode.utils.dependencies.package_managers.is_ostree_system', return_value=False)
 class TestPackageManagerSelection:
-    """Test automatic package manager selection."""
+    """Test automatic package manager selection on a traditional Linux distro.
+
+    Both the OS and the ostree probe are pinned so these assert the intended
+    branch on any host. Without that, they read the machine they run on: on a
+    Fedora Atomic host the ostree branch returns before the dnf/apt/brew list is
+    ever consulted, and on macOS the Darwin branch does.
+    """
 
     @patch('voice_mode.utils.dependencies.package_managers.BrewManager.check_available')
-    def test_get_package_manager_brew(self, mock_brew):
-        """Test getting Brew manager when available."""
+    @patch('voice_mode.utils.dependencies.package_managers.DnfManager.check_available')
+    @patch('voice_mode.utils.dependencies.package_managers.AptManager.check_available')
+    def test_get_package_manager_brew(self, mock_apt, mock_dnf, mock_brew, _ostree, _sys):
+        """Brew is the fallback when no native package manager is present."""
         mock_brew.return_value = True
+        mock_dnf.return_value = False
+        mock_apt.return_value = False
         manager = get_package_manager()
         assert isinstance(manager, BrewManager)
 
     @patch('voice_mode.utils.dependencies.package_managers.BrewManager.check_available')
     @patch('voice_mode.utils.dependencies.package_managers.DnfManager.check_available')
-    def test_get_package_manager_dnf(self, mock_dnf, mock_brew):
+    def test_get_package_manager_dnf(self, mock_dnf, mock_brew, _ostree, _sys):
         """Test getting DNF manager when Brew not available."""
         mock_brew.return_value = False
         mock_dnf.return_value = True
@@ -169,8 +184,20 @@ class TestPackageManagerSelection:
 
     @patch('voice_mode.utils.dependencies.package_managers.BrewManager.check_available')
     @patch('voice_mode.utils.dependencies.package_managers.DnfManager.check_available')
+    def test_dnf_preferred_over_brew(self, mock_dnf, mock_brew, _ostree, _sys):
+        """The native manager wins when both are installed.
+
+        dependencies.yaml supplies distro package names, so preferring Homebrew
+        would hand it names it cannot resolve on a machine that has both.
+        """
+        mock_brew.return_value = True
+        mock_dnf.return_value = True
+        assert isinstance(get_package_manager(), DnfManager)
+
+    @patch('voice_mode.utils.dependencies.package_managers.BrewManager.check_available')
+    @patch('voice_mode.utils.dependencies.package_managers.DnfManager.check_available')
     @patch('voice_mode.utils.dependencies.package_managers.AptManager.check_available')
-    def test_get_package_manager_apt(self, mock_apt, mock_dnf, mock_brew):
+    def test_get_package_manager_apt(self, mock_apt, mock_dnf, mock_brew, _ostree, _sys):
         """Test getting APT manager when others not available."""
         mock_brew.return_value = False
         mock_dnf.return_value = False
@@ -181,7 +208,7 @@ class TestPackageManagerSelection:
     @patch('voice_mode.utils.dependencies.package_managers.BrewManager.check_available')
     @patch('voice_mode.utils.dependencies.package_managers.DnfManager.check_available')
     @patch('voice_mode.utils.dependencies.package_managers.AptManager.check_available')
-    def test_get_package_manager_none_available(self, mock_apt, mock_dnf, mock_brew):
+    def test_get_package_manager_none_available(self, mock_apt, mock_dnf, mock_brew, _ostree, _sys):
         """Test error when no package manager is available."""
         mock_brew.return_value = False
         mock_dnf.return_value = False
@@ -189,3 +216,55 @@ class TestPackageManagerSelection:
 
         with pytest.raises(RuntimeError, match="No supported package manager found"):
             get_package_manager()
+
+
+@patch('voice_mode.utils.dependencies.package_managers.platform.system', return_value='Linux')
+@patch('voice_mode.utils.dependencies.package_managers.is_ostree_system', return_value=True)
+class TestPackageManagerSelectionOstree:
+    """Selection on Fedora Atomic (Silverblue, Kinoite, Bazzite, Bluefin).
+
+    `dnf install` can never succeed there -- /usr is read-only and Bazzite ships
+    a dnf shim that refuses it -- so DnfManager must never be selected even
+    though `dnf` is on PATH.
+    """
+
+    @patch('voice_mode.utils.dependencies.package_managers.get_homebrew_prefix')
+    def test_ostree_with_homebrew(self, mock_prefix, _ostree, _sys):
+        """Homebrew is the install path when present: no root, no reboot."""
+        mock_prefix.return_value = '/home/linuxbrew/.linuxbrew'
+        assert isinstance(get_package_manager(), OstreeBrewManager)
+
+    @patch('voice_mode.utils.dependencies.package_managers.get_homebrew_prefix')
+    def test_ostree_without_homebrew(self, mock_prefix, _ostree, _sys):
+        """Without Homebrew, fall back to the manager that explains the options."""
+        mock_prefix.return_value = None
+        assert isinstance(get_package_manager(), RpmOstreeManager)
+
+    @patch('voice_mode.utils.dependencies.package_managers.get_homebrew_prefix')
+    @patch('voice_mode.utils.dependencies.package_managers.DnfManager.check_available',
+           return_value=True)
+    def test_ostree_never_selects_dnf(self, _dnf, mock_prefix, _ostree, _sys):
+        """dnf on PATH must not win on Atomic -- installing with it cannot work."""
+        mock_prefix.return_value = None
+        assert not isinstance(get_package_manager(), DnfManager)
+
+
+class TestBrewNameTranslation:
+    """dependencies.yaml uses Fedora RPM names; Homebrew formulae differ."""
+
+    def test_devel_suffix_is_stripped(self):
+        """`brew install portaudio-devel` fails -- the formula is `portaudio`."""
+        formulae, unmappable = translate_to_brew(['portaudio-devel', 'alsa-lib-devel'])
+        assert formulae == ['portaudio', 'alsa-lib']
+        assert unmappable == []
+
+    def test_cargo_and_rust_collapse_to_one_formula(self):
+        """cargo has no formula of its own; it ships inside rust."""
+        formulae, unmappable = translate_to_brew(['cargo', 'rust'])
+        assert formulae == ['rust']
+        assert unmappable == []
+
+    def test_unmappable_names_are_reported_not_guessed(self):
+        formulae, unmappable = translate_to_brew(['portaudio', 'no-such-package'])
+        assert formulae == ['portaudio']
+        assert unmappable == ['no-such-package']

--- a/voice_mode/cli.py
+++ b/voice_mode/cli.py
@@ -607,8 +607,12 @@ def _echo_missing_dependencies(result):
 @service.command('install')
 @click.argument('service_name', type=click.Choice(VALID_SERVICES, case_sensitive=False), metavar='SERVICE')
 @click.option('--force', '-f', is_flag=True, help='Force reinstall even if already installed')
+@click.option('--model', default=None, help='Whisper model to download (whisper only)')
+@click.option('--use-gpu/--no-gpu', default=None,
+              help='Enable or disable GPU support (whisper only). --no-gpu builds CPU-only '
+                   'and needs no CUDA toolkit.')
 @click.help_option('-h', '--help')
-def service_install(service_name, force):
+def service_install(service_name, force, model, use_gpu):
     """Install a voice service.
 
     \b
@@ -626,7 +630,16 @@ def service_install(service_name, force):
     """
     if service_name == 'whisper':
         from voice_mode.tools.whisper.install import whisper_install
-        result = asyncio.run(getattr(whisper_install, 'fn', whisper_install)(force_reinstall=force))
+        # whisper_install accepts model and use_gpu, but this command previously
+        # passed neither -- so --no-gpu, which the CUDA error message tells the
+        # user to run, did not exist, and the standalone installer's
+        # `service install whisper --model X` was an unknown option.
+        kwargs = {'force_reinstall': force}
+        if model is not None:
+            kwargs['model'] = model
+        if use_gpu is not None:
+            kwargs['use_gpu'] = use_gpu
+        result = asyncio.run(getattr(whisper_install, 'fn', whisper_install)(**kwargs))
         # Handle dict result from tool
         if isinstance(result, dict):
             if result.get("success"):

--- a/voice_mode/cli.py
+++ b/voice_mode/cli.py
@@ -558,6 +558,7 @@ def service_health(service_name):
         display_name = 'Kokoro'
     else:
         click.echo(f"❌ Unknown service: {service_name}")
+        sys.exit(1)
         return
 
     import subprocess
@@ -635,6 +636,7 @@ def service_install(service_name, force):
             else:
                 click.echo(f"❌ Whisper installation failed: {result.get('error', 'Unknown error')}")
                 _echo_missing_dependencies(result)
+                sys.exit(1)
         else:
             click.echo(result)
     elif service_name == 'kokoro':
@@ -648,6 +650,7 @@ def service_install(service_name, force):
             else:
                 click.echo(f"❌ Kokoro installation failed: {result.get('error', 'Unknown error')}")
                 _echo_missing_dependencies(result)
+                sys.exit(1)
         else:
             click.echo(result)
     elif service_name == 'voicemode':
@@ -660,6 +663,7 @@ def service_install(service_name, force):
         else:
             click.echo(f"❌ VoiceMode installation failed: {result.get('error', 'Unknown error')}")
             _echo_missing_dependencies(result)
+            sys.exit(1)
     elif service_name == 'mlx-audio':
         from voice_mode.tools.mlx_audio.install import mlx_audio_install
         result = asyncio.run(mlx_audio_install(force_reinstall=force))
@@ -679,10 +683,12 @@ def service_install(service_name, force):
             else:
                 click.echo(f"❌ mlx-audio installation failed: {result.get('error', 'Unknown error')}")
                 _echo_missing_dependencies(result)
+                sys.exit(1)
         else:
             click.echo(result)
     else:
         click.echo(f"❌ Unknown service: {service_name}")
+        sys.exit(1)
 
 
 # ============================================================================

--- a/voice_mode/config.py
+++ b/voice_mode/config.py
@@ -1428,11 +1428,16 @@ def disable_sounddevice_stderr_redirect():
     This prevents sounddevice from redirecting stderr to /dev/null
     which can interfere with audio playback in MCP server context.
     """
+    # Imported before the try because the handler below writes to sys.stderr.
+    # Importing sys inside the try made it a function-local name, so the
+    # ImportError this handler exists to absorb left sys unbound and the handler
+    # raised UnboundLocalError over the top of it.
+    import sys
+    import atexit
+
     try:
         import sounddevice as sd
-        import sys
-        import atexit
-        
+
         # Method 1: Override _ignore_stderr in various locations
         if hasattr(sd, '_sounddevice'):
             if hasattr(sd._sounddevice, '_ignore_stderr'):

--- a/voice_mode/dependencies.yaml
+++ b/voice_mode/dependencies.yaml
@@ -124,7 +124,7 @@ voicemode:
         - name: pulseaudio
           description: PulseAudio sound server
           required: wsl  # Required for WSL, optional for native Linux
-          check_command: pulseaudio --version
+          check_command: pulseaudio --version || pactl --version
           note: Essential for WSL2 audio. Usually pre-installed on native Linux desktops.
 
         - name: pulseaudio-utils
@@ -143,7 +143,7 @@ voicemode:
         - name: python3-devel
           description: Python development headers (needed for building extensions)
           required: true
-          check_command: rpm -q python3-devel
+          check_command: ${VOICEMODE_PYTHON:-python3} -c "import os, sys, sysconfig; sys.exit(0 if os.path.exists(sysconfig.get_path('include') + '/Python.h') else 1)"
           note: Required for compiling webrtcvad (C extension used for silence detection)
 
         - name: gcc
@@ -161,30 +161,30 @@ voicemode:
         - name: alsa-lib-devel
           description: ALSA development files (audio support)
           required: true
-          check_command: rpm -q alsa-lib-devel
+          check_command: pkg-config --exists alsa
           note: Required for compiling simpleaudio (C extension used for audio playback)
 
         - name: portaudio
           description: PortAudio library (for sounddevice runtime)
           required: true
-          check_command: rpm -q portaudio
+          check_command: python3 -c "import ctypes.util, sys; sys.exit(0 if ctypes.util.find_library('portaudio') else 1)"
 
         - name: portaudio-devel
           description: PortAudio development files
           required: false
-          check_command: rpm -q portaudio-devel
+          check_command: pkg-config --exists portaudio-2.0
           note: Optional - only needed for building, not runtime
 
         - name: pulseaudio
           description: PulseAudio sound server
           required: wsl  # Required for WSL, optional for native Linux
-          check_command: pulseaudio --version
+          check_command: pulseaudio --version || pactl --version
           note: Essential for WSL2 audio. Usually pre-installed on native Linux desktops.
 
         - name: pulseaudio-utils
           description: PulseAudio utilities
           required: wsl  # Required for WSL, optional for native Linux
-          check_command: rpm -q pulseaudio-utils
+          check_command: pactl --version
           note: Essential for WSL2 audio. Usually pre-installed on native Linux desktops.
 
         - name: ffmpeg

--- a/voice_mode/exchanges/reader.py
+++ b/voice_mode/exchanges/reader.py
@@ -116,6 +116,10 @@ class ExchangeReader:
             # Use tail -f for real-time following
             cmd = ["tail", "-n", str(lines) if lines > 0 else "+1", "-f", str(today_file)]
             
+            # Bound before the try: a Ctrl-C delivered during Popen() itself
+            # would otherwise leave the KeyboardInterrupt handler below reaching
+            # for an unbound name and raising UnboundLocalError instead.
+            process = None
             try:
                 process = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True)
                 
@@ -130,8 +134,9 @@ class ExchangeReader:
                             logger.error(f"Error processing line: {e}")
             
             except KeyboardInterrupt:
-                process.terminate()
-                process.wait()
+                if process is not None:
+                    process.terminate()
+                    process.wait()
             except Exception as e:
                 logger.error(f"Error tailing file: {e}")
         else:

--- a/voice_mode/tools/kokoro/install.py
+++ b/voice_mode/tools/kokoro/install.py
@@ -435,7 +435,14 @@ async def kokoro_install(
         return {
             "success": False,
             "error": f"Command failed: {e.cmd}",
-            "stderr": e.stderr.decode() if e.stderr else None
+            # Byte-for-byte the same trap as the whisper installer had: this only
+            # avoids raising today because none of the checked calls above
+            # capture output, so e.stderr is always None.
+            "stderr": (
+                e.stderr.decode(errors="replace")
+                if isinstance(e.stderr, bytes)
+                else e.stderr
+            ),
         }
     except Exception as e:
         return {

--- a/voice_mode/tools/whisper/install.py
+++ b/voice_mode/tools/whisper/install.py
@@ -1,6 +1,7 @@
 """Installation tool for whisper.cpp"""
 
 import os
+import re
 import sys
 import platform
 import subprocess
@@ -8,7 +9,7 @@ import shutil
 import json
 import logging
 from pathlib import Path
-from typing import Dict, Any, Optional, Union
+from typing import Dict, Any, Optional, Tuple, Union
 import asyncio
 try:
     from importlib.resources import files
@@ -27,6 +28,79 @@ from voice_mode.utils.migration_helpers import auto_migrate_if_needed
 from voice_mode.utils.gpu_detection import detect_gpu
 
 logger = logging.getLogger("voicemode")
+
+
+def _nvcc_max_gcc_major() -> Optional[int]:
+    """Highest GCC major version the installed nvcc will accept, if knowable.
+
+    CUDA records its ceiling in crt/host_config.h rather than exposing it via a
+    flag, so read that instead of hardcoding a table that goes stale with every
+    CUDA release.
+    """
+    nvcc = shutil.which("nvcc")
+    if not nvcc:
+        return None
+    header = Path(nvcc).resolve().parent.parent / "include" / "crt" / "host_config.h"
+    try:
+        text = header.read_text(errors="ignore")
+    except OSError:
+        return None
+    match = re.search(r"gcc versions later than (\d+)", text)
+    return int(match.group(1)) if match else None
+
+
+def _gxx_major(compiler: str) -> Optional[int]:
+    """Major version of a g++ binary, or None if it cannot be determined."""
+    try:
+        result = subprocess.run(
+            [compiler, "-dumpversion"], capture_output=True, text=True, timeout=10
+        )
+    except (subprocess.SubprocessError, OSError):
+        return None
+    if result.returncode != 0:
+        return None
+    try:
+        return int(result.stdout.strip().split(".")[0])
+    except (ValueError, IndexError):
+        return None
+
+
+def cuda_host_compiler_override() -> Tuple[Optional[str], Optional[str]]:
+    """Pick a C++ compiler that nvcc will accept for the CUDA build.
+
+    Distributions routinely ship a GCC newer than the current CUDA release
+    supports -- Fedora 44 defaults to GCC 16 while CUDA 13.3 stops at 15 -- and
+    nvcc then aborts with "unsupported GNU version", so ``-DGGML_CUDA=ON`` fails
+    at configure time on an otherwise correct setup.
+
+    Returns ``(compiler, problem)``. ``compiler`` is a path to hand to CMake, or
+    None when the default is already supported. ``problem`` is a warning for the
+    case where the default is too new and nothing compatible is installed.
+    """
+    ceiling = _nvcc_max_gcc_major()
+    if ceiling is None:
+        return None, None
+
+    default = shutil.which("g++") or shutil.which("c++")
+    default_major = _gxx_major(default) if default else None
+    if default_major is not None and default_major <= ceiling:
+        return None, None
+
+    # Fedora's compat packages install as g++-14, Homebrew's gcc@15 as g++-15,
+    # Debian's as g++-13. Walk down from the ceiling so the newest usable
+    # compiler wins.
+    for major in range(ceiling, 7, -1):
+        for name in (f"g++-{major}", f"g++{major}"):
+            found = shutil.which(name)
+            if found and _gxx_major(found) == major:
+                return found, None
+
+    return None, (
+        f"The default C++ compiler is GCC {default_major}, but nvcc supports at "
+        f"most GCC {ceiling}. Install a compatible compiler (e.g. "
+        f"`brew install gcc@{ceiling}` or `sudo dnf install gcc{ceiling}-c++`) "
+        f"and reinstall, or use --no-gpu to build CPU-only."
+    )
 
 
 async def update_whisper_service_files(
@@ -564,12 +638,21 @@ async def whisper_install(
             if use_gpu and not shutil.which("nvcc"):
                 # Suggest distro-appropriate install command, or --no-gpu as alternative
                 if on_ostree:
-                    # No Homebrew formula for the CUDA toolkit, and layering it is
-                    # heavy, so lead with the option that needs neither.
+                    # Layering the toolkit is unreliable (rpm-ostree struggles
+                    # with packages this large) and a container would leave the
+                    # binary linked against libraries the host does not have.
+                    # NVIDIA's runfile is the way in: /usr/local is a symlink to
+                    # /var/usrlocal, so it is writable and survives image
+                    # updates without layering anything.
                     cuda_install = (
-                        "use --no-gpu for CPU-only, or run the build inside a "
-                        "distrobox container where dnf works: "
-                        "distrobox create --name cuda --image fedora:latest"
+                        "download NVIDIA's runfile from "
+                        "https://developer.nvidia.com/cuda-downloads and install "
+                        "the toolkit only -- /usr/local is a symlink to "
+                        "/var/usrlocal, so it is writable and persists across "
+                        "image updates: "
+                        "sudo sh cuda_<version>_linux.run --silent --toolkit --override. "
+                        "Then add /usr/local/cuda/bin to PATH. "
+                        "Or use --no-gpu for CPU-only"
                     )
                     missing_deps.append(f"CUDA toolkit ({cuda_install})")
                 else:
@@ -651,6 +734,18 @@ async def whisper_install(
                 logger.info("Enabling Core ML support with fallback for Apple Silicon")
         elif is_linux and use_gpu:
             cmake_flags.append("-DGGML_CUDA=ON")
+            host_cxx, host_cxx_problem = cuda_host_compiler_override()
+            if host_cxx:
+                # CMake uses CMAKE_CUDA_HOST_COMPILER for its own compile tests;
+                # NVCC_CCBIN covers nvcc invocations ggml makes outside CMake's
+                # CUDA language support. Set both so they cannot disagree.
+                logger.info(f"Using {host_cxx} as the CUDA host compiler")
+                cmake_flags.append(f"-DCMAKE_CUDA_HOST_COMPILER={host_cxx}")
+                build_env["CUDAHOSTCXX"] = host_cxx
+                build_env["NVCC_CCBIN"] = host_cxx
+            elif host_cxx_problem:
+                logger.warning(host_cxx_problem)
+                print(f"⚠️  {host_cxx_problem}")
         
         # Get number of CPU cores for parallel build
         cpu_count = os.cpu_count() or 4

--- a/voice_mode/tools/whisper/install.py
+++ b/voice_mode/tools/whisper/install.py
@@ -477,7 +477,11 @@ async def whisper_install(
                 "error": f"Unsupported operating system: {system}"
             }
         
-        # Auto-detect GPU if not specified
+        # Auto-detect GPU if not specified. Track whether this was a choice the
+        # user made explicitly: an auto-detected GPU should degrade to a CPU
+        # build when the CUDA toolkit is missing, but an explicit --use-gpu
+        # should still be an error rather than silently ignored.
+        gpu_auto_detected = use_gpu is None
         if use_gpu is None:
             use_gpu, gpu_type = detect_gpu()
             logger.info(f"Auto-detected GPU: {gpu_type} (enabled: {use_gpu})")
@@ -538,6 +542,24 @@ async def whisper_install(
                     missing_deps.append("build-essential (run: sudo apt-get install build-essential)")
                 else:
                     missing_deps.append("gcc/make (install your distribution's build tools)")
+
+            if use_gpu and not shutil.which("nvcc") and gpu_auto_detected:
+                # The GPU was auto-detected, not asked for. A missing CUDA
+                # toolkit is not a reason to refuse to install -- whisper.cpp
+                # builds and runs fine on CPU. Failing here strands anyone with
+                # an NVIDIA card and no toolkit, and on Fedora Atomic the
+                # toolkit cannot be installed at all.
+                logger.warning(
+                    "GPU detected but the CUDA toolkit (nvcc) is not installed -- "
+                    "building CPU-only. Install the CUDA toolkit and reinstall with "
+                    "--use-gpu for GPU acceleration."
+                )
+                print(
+                    "⚠️  GPU detected but CUDA toolkit (nvcc) not found - building CPU-only.\n"
+                    "   Reinstall with --use-gpu after installing the CUDA toolkit to enable it."
+                )
+                use_gpu = False
+                gpu_type = "cpu"
 
             if use_gpu and not shutil.which("nvcc"):
                 # Suggest distro-appropriate install command, or --no-gpu as alternative

--- a/voice_mode/tools/whisper/install.py
+++ b/voice_mode/tools/whisper/install.py
@@ -520,21 +520,46 @@ async def whisper_install(
                     missing_deps.append("cmake (run: brew install cmake)")
         
         elif is_linux:
+            from voice_mode.utils.dependencies.package_managers import is_ostree_system
+
+            # Fedora Atomic (Silverblue, Bazzite, Bluefin) reports ID=fedora and
+            # ships dnf, but `dnf install` cannot work there -- suggesting it
+            # sends the user down a path that always fails.
+            on_ostree = is_ostree_system()
+
             # Check for build essentials
             if not shutil.which("gcc") or not shutil.which("make"):
-                missing_deps.append("build-essential (run: sudo apt-get install build-essential)")
-            
+                if on_ostree:
+                    missing_deps.append(
+                        "gcc/make (run: brew install gcc make, "
+                        "or sudo rpm-ostree install gcc make && systemctl reboot)"
+                    )
+                elif shutil.which("apt-get"):
+                    missing_deps.append("build-essential (run: sudo apt-get install build-essential)")
+                else:
+                    missing_deps.append("gcc/make (install your distribution's build tools)")
+
             if use_gpu and not shutil.which("nvcc"):
                 # Suggest distro-appropriate install command, or --no-gpu as alternative
-                if shutil.which("apt-get"):
-                    cuda_install = "sudo apt-get install nvidia-cuda-toolkit"
-                elif shutil.which("dnf"):
-                    cuda_install = "sudo dnf install cuda-toolkit"
+                if on_ostree:
+                    # No Homebrew formula for the CUDA toolkit, and layering it is
+                    # heavy, so lead with the option that needs neither.
+                    cuda_install = (
+                        "use --no-gpu for CPU-only, or run the build inside a "
+                        "distrobox container where dnf works: "
+                        "distrobox create --name cuda --image fedora:latest"
+                    )
+                    missing_deps.append(f"CUDA toolkit ({cuda_install})")
                 else:
-                    cuda_install = "your distribution's CUDA toolkit package"
-                missing_deps.append(
-                    f"CUDA toolkit (run: {cuda_install}, or use --no-gpu for CPU-only)"
-                )
+                    if shutil.which("apt-get"):
+                        cuda_install = "sudo apt-get install nvidia-cuda-toolkit"
+                    elif shutil.which("dnf"):
+                        cuda_install = "sudo dnf install cuda-toolkit"
+                    else:
+                        cuda_install = "your distribution's CUDA toolkit package"
+                    missing_deps.append(
+                        f"CUDA toolkit (run: {cuda_install}, or use --no-gpu for CPU-only)"
+                    )
         
         if missing_deps:
             return {

--- a/voice_mode/tools/whisper/install.py
+++ b/voice_mode/tools/whisper/install.py
@@ -934,7 +934,15 @@ async def whisper_install(
         return {
             "success": False,
             "error": f"Command failed: {e.cmd}",
-            "stderr": e.stderr.decode() if e.stderr else None
+            # The build and configure steps run with text=True, so e.stderr is
+            # already str -- .decode() raised AttributeError *inside* this
+            # handler, which the sibling `except Exception` cannot catch, so the
+            # real cmake failure was destroyed at the moment it mattered most.
+            "stderr": (
+                e.stderr.decode(errors="replace")
+                if isinstance(e.stderr, bytes)
+                else e.stderr
+            ),
         }
     except Exception as e:
         if 'original_dir' in locals():

--- a/voice_mode/utils/dependencies/checker.py
+++ b/voice_mode/utils/dependencies/checker.py
@@ -49,6 +49,66 @@ def load_dependencies() -> dict:
             raise FileNotFoundError("Could not find dependencies.yaml")
 
 
+def is_ostree_system() -> bool:
+    """Detect an rpm-ostree / Fedora Atomic system (Silverblue, Bazzite, Bluefin).
+
+    These have /etc/fedora-release but a read-only /usr and no working
+    ``dnf install``, so dependencies are normally satisfied with Homebrew or
+    layered with ``rpm-ostree``.
+    """
+    return os.path.exists("/run/ostree-booted") or os.path.isdir("/sysroot/ostree")
+
+
+def get_homebrew_prefix() -> Optional[str]:
+    """Return the Homebrew prefix if present, else None."""
+    import shutil as _shutil
+
+    brew = _shutil.which("brew")
+    if brew:
+        try:
+            result = subprocess.run(
+                [brew, "--prefix"], capture_output=True, text=True, timeout=10
+            )
+            if result.returncode == 0:
+                return result.stdout.strip()
+        except (subprocess.SubprocessError, OSError):
+            pass
+    for candidate in ("/home/linuxbrew/.linuxbrew", os.path.expanduser("~/.linuxbrew")):
+        if os.path.exists(os.path.join(candidate, "bin", "brew")):
+            return candidate
+    return None
+
+
+def _check_env() -> dict:
+    """Environment for check commands, with Homebrew's pkgconfig dirs added.
+
+    Homebrew is not on pkg-config's default search path on Linux, so headers
+    installed with ``brew install alsa-lib`` are invisible to a bare
+    ``pkg-config --exists alsa`` even though the compiler finds them. On an
+    immutable OS Homebrew is often the only way to get headers, so without this
+    every pkg-config check is a false negative.
+    """
+    env = os.environ.copy()
+    prefix = get_homebrew_prefix()
+    if prefix:
+        parts = [
+            os.path.join(prefix, "lib", "pkgconfig"),
+            os.path.join(prefix, "share", "pkgconfig"),
+        ]
+        existing = env.get("PKG_CONFIG_PATH", "")
+        if existing:
+            parts.append(existing)
+        env["PKG_CONFIG_PATH"] = ":".join(parts)
+
+    # The interpreter that would actually build C extensions for voice-mode --
+    # not whatever `python3` resolves to on PATH. Under `uv tool install` these
+    # differ: uv's managed CPython ships its own headers while the system
+    # python3 may have none, so probing PATH's python3 reports a false missing
+    # python3-devel.
+    env["VOICEMODE_PYTHON"] = sys.executable
+    return env
+
+
 def detect_platform() -> str:
     """Detect OS/distribution.
 
@@ -107,12 +167,17 @@ def check_dependency(package: dict, platform_key: str) -> bool:
     # Use check_command if provided
     if "check_command" in package:
         try:
-            cmd = package["check_command"].split()
+            # shell=True (matching the standalone installer's checker) so a
+            # check can use quoting or a fallback such as `a --version || b
+            # --version`. The previous .split() broke both. Commands come from
+            # the bundled dependencies.yaml, not from user input.
             result = subprocess.run(
-                cmd,
+                package["check_command"],
+                shell=True,
                 capture_output=True,
                 timeout=5,
-                text=True
+                text=True,
+                env=_check_env()
             )
             installed = result.returncode == 0
             logger.debug(f"Check command for {package_name}: {installed}")

--- a/voice_mode/utils/dependencies/checker.py
+++ b/voice_mode/utils/dependencies/checker.py
@@ -11,7 +11,7 @@ import time
 from typing import List, Dict, Optional, Tuple
 from pathlib import Path
 
-from .package_managers import get_package_manager
+from .package_managers import get_package_manager, get_homebrew_prefix, is_ostree_system
 from .cache import get_cache
 
 logger = logging.getLogger(__name__)
@@ -47,36 +47,6 @@ def load_dependencies() -> dict:
                 with yaml_file.open() as f:
                     return yaml.safe_load(f)
             raise FileNotFoundError("Could not find dependencies.yaml")
-
-
-def is_ostree_system() -> bool:
-    """Detect an rpm-ostree / Fedora Atomic system (Silverblue, Bazzite, Bluefin).
-
-    These have /etc/fedora-release but a read-only /usr and no working
-    ``dnf install``, so dependencies are normally satisfied with Homebrew or
-    layered with ``rpm-ostree``.
-    """
-    return os.path.exists("/run/ostree-booted") or os.path.isdir("/sysroot/ostree")
-
-
-def get_homebrew_prefix() -> Optional[str]:
-    """Return the Homebrew prefix if present, else None."""
-    import shutil as _shutil
-
-    brew = _shutil.which("brew")
-    if brew:
-        try:
-            result = subprocess.run(
-                [brew, "--prefix"], capture_output=True, text=True, timeout=10
-            )
-            if result.returncode == 0:
-                return result.stdout.strip()
-        except (subprocess.SubprocessError, OSError):
-            pass
-    for candidate in ("/home/linuxbrew/.linuxbrew", os.path.expanduser("~/.linuxbrew")):
-        if os.path.exists(os.path.join(candidate, "bin", "brew")):
-            return candidate
-    return None
 
 
 def _check_env() -> dict:

--- a/voice_mode/utils/dependencies/package_managers.py
+++ b/voice_mode/utils/dependencies/package_managers.py
@@ -1,12 +1,78 @@
 """Package manager abstraction for cross-platform dependency installation."""
 
 from abc import ABC, abstractmethod
-from typing import List, Tuple
+from typing import List, Optional, Tuple
+import os
+import platform
 import subprocess
 import shutil
 import logging
 
 logger = logging.getLogger(__name__)
+
+
+# dependencies.yaml lists Fedora RPM names. Homebrew formula names differ, so
+# they must be translated before being handed to brew -- `brew install
+# portaudio-devel` fails with "No available formula". Only names that exist in
+# homebrew-core are listed; anything else is reported as unmappable.
+RPM_TO_BREW = {
+    'alsa-lib-devel': 'alsa-lib',
+    'portaudio': 'portaudio',
+    'portaudio-devel': 'portaudio',
+    'SDL2-devel': 'sdl2',
+    'ffmpeg': 'ffmpeg',
+    'cmake': 'cmake',
+    'make': 'make',
+    'rust': 'rust',
+    'cargo': 'rust',          # cargo ships inside the rust formula
+    'gcc': 'gcc',
+    'gcc-c++': 'gcc',
+    'git': 'git',
+}
+
+
+def is_ostree_system() -> bool:
+    """Detect an rpm-ostree / Fedora Atomic system (Silverblue, Bazzite, Bluefin).
+
+    These have /etc/fedora-release but a read-only /usr and no working
+    ``dnf install`` -- Bazzite ships a dnf shim that refuses install outright.
+    """
+    return os.path.exists("/run/ostree-booted") or os.path.isdir("/sysroot/ostree")
+
+
+def get_homebrew_prefix() -> Optional[str]:
+    """Return the Homebrew prefix if present, else None."""
+    brew = shutil.which("brew")
+    if brew:
+        try:
+            result = subprocess.run(
+                [brew, "--prefix"], capture_output=True, text=True, timeout=10
+            )
+            if result.returncode == 0:
+                return result.stdout.strip()
+        except (subprocess.SubprocessError, OSError):
+            pass
+    for candidate in ("/home/linuxbrew/.linuxbrew", os.path.expanduser("~/.linuxbrew")):
+        if os.path.exists(os.path.join(candidate, "bin", "brew")):
+            return candidate
+    return None
+
+
+def translate_to_brew(package_names: List[str]) -> Tuple[List[str], List[str]]:
+    """Map Fedora RPM names to Homebrew formulae.
+
+    Returns (formulae, unmappable). Formulae are de-duplicated because several
+    RPMs collapse onto one formula (cargo and rust both -> rust).
+    """
+    formulae: List[str] = []
+    unmappable: List[str] = []
+    for name in package_names:
+        formula = RPM_TO_BREW.get(name)
+        if formula is None:
+            unmappable.append(name)
+        elif formula not in formulae:
+            formulae.append(formula)
+    return formulae, unmappable
 
 
 class PackageManager(ABC):
@@ -126,6 +192,69 @@ class DnfManager(PackageManager):
             return False, str(e)
 
 
+class OstreeBrewManager(BrewManager):
+    """Homebrew on Fedora Atomic, translating RPM names to formulae.
+
+    dependencies.yaml supplies Fedora RPM names, which are not Homebrew formula
+    names -- `brew install portaudio-devel` fails outright, and `cargo` has no
+    formula at all because it ships inside `rust`.
+    """
+
+    def check_package(self, package_name: str) -> bool:
+        formula = RPM_TO_BREW.get(package_name)
+        return super().check_package(formula) if formula else False
+
+    def install_packages(self, package_names: List[str], verbose: bool = False) -> Tuple[bool, str]:
+        formulae, unmappable = translate_to_brew(package_names)
+
+        if unmappable:
+            msg = (
+                f"No Homebrew formula for: {', '.join(unmappable)}.\n"
+                f"Layer them onto the image instead:\n"
+                f"  sudo rpm-ostree install {' '.join(unmappable)}\n"
+                f"  systemctl reboot\n"
+                f"Or build inside a container where dnf works:\n"
+                f"  distrobox create --name dev --image fedora:latest && distrobox enter dev"
+            )
+            if not formulae:
+                return False, msg
+            logger.warning(msg)
+
+        ok, output = super().install_packages(formulae, verbose=verbose)
+        if unmappable:
+            output = f"{output}\n{msg}"
+            ok = False
+        return ok, output
+
+
+class RpmOstreeManager(PackageManager):
+    """Fallback for Fedora Atomic with no Homebrew: explain, never run dnf."""
+
+    def check_available(self) -> bool:
+        return shutil.which("rpm-ostree") is not None
+
+    def check_package(self, package_name: str) -> bool:
+        try:
+            result = subprocess.run(
+                ["rpm", "-q", package_name], capture_output=True, text=True, timeout=5
+            )
+            return result.returncode == 0
+        except (subprocess.SubprocessError, OSError):
+            return False
+
+    def install_packages(self, package_names: List[str], verbose: bool = False) -> Tuple[bool, str]:
+        return False, (
+            "This is a Fedora Atomic system, where packages cannot be installed "
+            "into the running root filesystem.\n"
+            "Install Homebrew (no root, no reboot) -- recommended:\n"
+            '  /bin/bash -c "$(curl -fsSL '
+            'https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"\n'
+            "Or layer them, which requires a reboot:\n"
+            f"  sudo rpm-ostree install {' '.join(package_names)}\n"
+            "  systemctl reboot"
+        )
+
+
 def get_package_manager() -> PackageManager:
     """Detect and return appropriate package manager for current platform.
 
@@ -135,11 +264,25 @@ def get_package_manager() -> PackageManager:
     Raises:
         RuntimeError: If no supported package manager is found
     """
-    managers = [BrewManager(), DnfManager(), AptManager()]
+    if platform.system() == "Darwin":
+        return BrewManager()
+
+    # Fedora Atomic: dnf install cannot work, so never select DnfManager here.
+    if is_ostree_system():
+        if get_homebrew_prefix():
+            logger.debug("Detected package manager: OstreeBrewManager")
+            return OstreeBrewManager()
+        logger.debug("Detected package manager: RpmOstreeManager")
+        return RpmOstreeManager()
+
+    # Native package manager first. Homebrew is only a fallback: it is often
+    # installed alongside dnf/apt, and dependencies.yaml gives distro package
+    # names, so preferring brew would feed it names it cannot resolve.
+    managers = [DnfManager(), AptManager(), BrewManager()]
 
     for manager in managers:
         if manager.check_available():
             logger.debug(f"Detected package manager: {manager.__class__.__name__}")
             return manager
 
-    raise RuntimeError("No supported package manager found (tried brew, dnf, apt-get)")
+    raise RuntimeError("No supported package manager found (tried dnf, apt-get, brew)")

--- a/voice_mode/utils/dependencies/package_managers.py
+++ b/voice_mode/utils/dependencies/package_managers.py
@@ -31,6 +31,13 @@ RPM_TO_BREW = {
 }
 
 
+# Homebrew had the shortest install timeout (300s) despite doing the heaviest
+# work -- it downloads large bottles and falls back to building from source.
+# The rust bottle alone is ~400MB, which exceeded 300s on an ordinary
+# connection and killed the install partway through with no useful error.
+BREW_INSTALL_TIMEOUT = 1800
+
+
 def is_ostree_system() -> bool:
     """Detect an rpm-ostree / Fedora Atomic system (Silverblue, Bazzite, Bluefin).
 
@@ -117,10 +124,10 @@ class BrewManager(PackageManager):
         cmd = ["brew", "install"] + package_names
         try:
             if verbose:
-                result = subprocess.run(cmd, text=True, timeout=300)
+                result = subprocess.run(cmd, text=True, timeout=BREW_INSTALL_TIMEOUT)
                 return result.returncode == 0, ""
             else:
-                result = subprocess.run(cmd, capture_output=True, text=True, timeout=300)
+                result = subprocess.run(cmd, capture_output=True, text=True, timeout=BREW_INSTALL_TIMEOUT)
                 return result.returncode == 0, result.stderr or result.stdout
         except (subprocess.SubprocessError, OSError) as e:
             return False, str(e)


### PR DESCRIPTION
Adds Fedora Atomic (Silverblue, Kinoite, Bazzite, Bluefin) support to the
installer, plus several fixes that are not Atomic-specific.

## Why

The installer ran `sudo dnf install` for anything reporting `ID=fedora`. On
Atomic variants that can never succeed — `/usr` is read-only and Bazzite ships a
`dnf` shim that refuses `install` outright — so the dependency step failed and
took the rest of the run with it. The dependency *checks* used `rpm -q`, so a
fully working install reported 7 of 7 core deps missing.

## Fixes that apply to everyone, not just Atomic

- **`get_package_manager()` tried Homebrew first on every platform.** Any
  Fedora/Debian user with Homebrew installed got brew handed distro package
  names it cannot resolve. Native manager now wins.
- **`voicemode service install` exited 0 on failure**, so the installer's
  `subprocess.run(..., check=True)` never raised — it printed
  `Whisper installation failed` and `Whisper STT service installed` back to back.
- **The error handler crashed instead of reporting.** `e.stderr.decode()` on a
  `text=True` subprocess raises `AttributeError` *inside* the handler; a sibling
  `except Exception` cannot catch that, so it escaped and destroyed the cmake
  output at the one moment it mattered. Two more handlers could raise over their
  own error (`sys` imported inside the `try` that needed it; `process` unbound on
  Ctrl-C during `Popen`).
- **CUDA builds failed wherever the distro's GCC outpaces nvcc** — Fedora 44
  ships GCC 16, CUDA 13.3 accepts ≤15, so `-DGGML_CUDA=ON` aborted at configure
  with `unsupported GNU version`. The ceiling is now read from CUDA's own
  `crt/host_config.h` and a compatible `g++` is selected.
- **Homebrew had the shortest install timeout** (300s vs 600s) despite the
  heaviest work; the `rust` bottle exceeded it and was killed mid-download.
- **`--model` and `--no-gpu` did not exist** on `service install`, though the
  installer shells out with `--model` and the CUDA error told users to pass
  `--no-gpu`.
- **A whisper GPU build hard-failed when the GPU was only auto-detected**,
  stranding anyone with an NVIDIA card and no toolkit. Now falls back to CPU.
- **Selection tests were host-dependent** — they mocked manager availability but
  not the OS probes, so `test_get_package_manager_dnf` failed for any
  Silverblue/Bazzite contributor while passing in CI.

## Atomic support

Detects `/run/ostree-booted`, routes installs through Homebrew (no root, no
reboot) with an RPM→formula map, and replaces `rpm -q` with capability probes
(`pkg-config`, loadable-library, `Python.h`). `python3-devel` is skipped because
`uv tool install` builds against uv's managed CPython, which ships its own
headers. Anything with no Homebrew equivalent prints the `rpm-ostree install`
command and reboot rather than failing with a bare `dnf` error.

## Testing

`pytest`: **1925 passed, 56 skipped, 0 failed.**

Verified end to end on Bazzite 44 (Fedora Atomic, GNOME/Wayland, RTX 4070 Ti):
`voice-mode-install` goes from 7 missing core deps to 0, installs `cmake`,
`portaudio-devel`, `cargo` and `rust` itself, builds whisper.cpp with CUDA
(`ARCHS = 890`), and a full Kokoro→whisper round trip transcribes correctly.
