### PR TITLE
test: fix three pre-existing failures on Python 3.10 and fastmcp 3.4.3

### DIFF
--- a/tests/test_mcp_shutdown_patch.py
+++ b/tests/test_mcp_shutdown_patch.py
@@ -11,9 +11,17 @@ handler (e.g. VM-2015's orphaned recording thread).
 """
 
 import asyncio
+import sys
 
 import anyio
 import pytest
+
+if sys.version_info < (3, 11):
+    # ExceptionGroup only became a builtin in 3.11. anyio pulls the backport in
+    # on older interpreters (it is already locked for python < 3.11), so import
+    # it rather than leaving the name undefined -- without this the assertions
+    # below raise NameError on 3.10 instead of testing anything.
+    from exceptiongroup import ExceptionGroup
 
 from voice_mode.mcp_shutdown_patch import (
     TESTED_FASTMCP_VERSION,

--- a/tests/test_turns_discoverability.py
+++ b/tests/test_turns_discoverability.py
@@ -39,6 +39,25 @@ def _collapse_whitespace(text: str) -> str:
     return re.sub(r"\s+", " ", text)
 
 
+def _schema_description(schema: dict) -> str | None:
+    """Find a property's description wherever the schema generator put it.
+
+    An Optional parameter is emitted as an ``anyOf`` union, and which level
+    carries the ``description`` depends on the fastmcp/pydantic version: it sits
+    on the property itself in some, and on a nested ``anyOf`` member in others
+    (fastmcp 3.4.3 wraps it one level deeper). Reading only the top level makes
+    the assertion a version check rather than a description check, so search
+    recursively instead.
+    """
+    if "description" in schema:
+        return schema["description"]
+    for member in schema.get("anyOf", []):
+        found = _schema_description(member)
+        if found is not None:
+            return found
+    return None
+
+
 # Golden copy of README.md's "LITERAL SCHEMA-DESCRIPTION TEXT" for `turns`
 # (## Design section). Kept as a literal duplicate here (same convention as
 # the impl-003 golden tests for the survey JSON worked examples) so a change
@@ -98,7 +117,7 @@ async def test_turns_schema_property_carries_the_description():
     i.e. it's reachable via Annotated/Field, not just docstring prose."""
     tool = await mcp.get_tool("converse")
     turns_schema = tool.parameters["properties"]["turns"]
-    assert turns_schema["description"] == _TURNS_PARAM_DESCRIPTION
+    assert _schema_description(turns_schema) == _TURNS_PARAM_DESCRIPTION
 
 
 @pytest.mark.asyncio
@@ -106,7 +125,7 @@ async def test_turns_schema_description_covers_key_contract_points():
     """Spot-check the substance survives (verbs, controls, return shape) --
     guards against a future edit accidentally truncating the text."""
     tool = await mcp.get_tool("converse")
-    desc = tool.parameters["properties"]["turns"]["description"]
+    desc = _schema_description(tool.parameters["properties"]["turns"])
     for expected in (
         '"say": str',
         '"ask": str',


### PR DESCRIPTION
Three tests fail on `master` today. The `Test Voice Mode MCP` workflow is
`pull_request`-triggered, so `master` never runs it — the breakage only shows up
on contributors' PRs, where it reads as "your branch broke CI".

Reproduced on a clean `master` checkout with no other changes present:

```
$ git checkout 5c1b3e4
$ uv run --python 3.10 -m pytest \
    tests/test_mcp_shutdown_patch.py::TestDispatchUntilClosed::test_cancels_on_iteration_error \
    tests/test_turns_discoverability.py

FAILED ...test_cancels_on_iteration_error - NameError: name 'ExceptionGroup' is not defined
FAILED ...test_turns_schema_property_carries_the_description - KeyError: 'description'
FAILED ...test_turns_schema_description_covers_key_contract_points - KeyError: 'description'
3 failed, 4 passed
```

## `ExceptionGroup` on Python 3.10

`ExceptionGroup` only became a builtin in 3.11, so on 3.10 the name is undefined
and the assertion raises `NameError` instead of testing anything. `exceptiongroup`
is already locked as a dependency for `python_full_version < '3.11'` (uv.lock),
so this imports the backport there rather than adding anything new.

## `turns` schema description on fastmcp 3.4.3

The tests read `tool.parameters["properties"]["turns"]["description"]`. fastmcp
3.4.3 emits an optional parameter as an `anyOf` union and carries the
description on a nested member, so the key is absent at the top level:

```json
"turns": {"anyOf": [{"anyOf": [...], "description": "Ordered list of utterances..."}], "default": null}
```

The description is still present and still byte-for-byte correct — only its
position moved. Rather than hardcode the new shape (which just swaps one version
assumption for another), the lookup now walks `anyOf` members recursively, so it
passes on both the old and new layouts.

`test_turns_param_description_constant_matches_readme_literal_text` is untouched
and still enforces the golden README text, so the drift guard this file exists
for is unaffected.

## Verification

| | before | after |
|---|---|---|
| these two files, py3.10 | 3 failed, 4 passed | **16 passed** |
| these two files, py3.12 | 16 passed | **16 passed** |
| full suite, py3.10 | 3 failed | **1918 passed, 56 skipped, 0 failed** |

Test-only; no runtime code touched, so no CHANGELOG entry.

Split out from #517 so the CI fix can land independently of that PR.
