### PR TITLE
fix: release playback waiter when the audio stream dies (#522)

### DIFF
--- a/voice_mode/audio_player.py
+++ b/voice_mode/audio_player.py
@@ -134,7 +134,8 @@ class NonBlockingAudioPlayer:
                 channels=channels,
                 callback=self._audio_callback,
                 blocksize=self.buffer_size,
-                dtype=np.float32
+                dtype=np.float32,
+                finished_callback=self.playback_complete.set,
             )
             self.stream.start()
 


### PR DESCRIPTION
Full analysis, reproduction and evidence in #522.

playback_complete was only ever set from inside _audio_callback. When a stream dies abnormally - e.g. a concurrent client invalidating it (PaErrorCode -9988) - the callback stops being invoked, nothing sets the event, and _wait_for_player_with_control() awaits forever. converse() never returns, its finally never runs, and the conch is held indefinitely.

finished_callback fires whenever PortAudio tears the stream down for any reason, so the waiter is always released.

Tested on 8.12.0 (WSL2/WSLg): normal playback unaffected on both the local CLI and streamable-HTTP paths.